### PR TITLE
Remove wait after onemkl dft calls

### DIFF
--- a/examples/01_1DFFT/01_1DFFT.cpp
+++ b/examples/01_1DFFT/01_1DFFT.cpp
@@ -24,23 +24,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifft(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
     View1D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xr2c_hat", n0 / 2 + 1);
     View1D<double> xc2r_hat("xc2r", n0);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/examples/02_2DFFT/02_2DFFT.cpp
+++ b/examples/02_2DFFT/02_2DFFT.cpp
@@ -24,23 +24,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft2(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifft2(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 2D R2C FFT
     View2D<double> xr2c("xr2c", n0, n1);
     View2D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0, n1 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft2(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 2D C2R FFT
     View2D<Kokkos::complex<double> > xc2r("xr2c_hat", n0, n1 / 2 + 1);
     View2D<double> xc2r_hat("xc2r", n0, n1);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft2(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/examples/03_NDFFT/03_NDFFT.cpp
+++ b/examples/03_NDFFT/03_NDFFT.cpp
@@ -24,23 +24,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fftn(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifftn(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 3D R2C FFT
     View3D<double> xr2c("xr2c", n0, n1, n2);
     View3D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0, n1, n2 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfftn(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 3D C2R FFT
     View3D<Kokkos::complex<double> > xc2r("xr2c_hat", n0, n1, n2 / 2 + 1);
     View3D<double> xc2r_hat("xc2r", n0, n1, n2);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfftn(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/examples/04_batchedFFT/04_batchedFFT.cpp
+++ b/examples/04_batchedFFT/04_batchedFFT.cpp
@@ -24,27 +24,33 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft(execution_space(), xc2c, xc2c_hat,
                    KokkosFFT::Normalization::backward, /*axis=*/-1);
     KokkosFFT::ifft(execution_space(), xc2c_hat, xc2c_inv,
                     KokkosFFT::Normalization::backward, /*axis=*/-1);
+    Kokkos::fence();
 
     // 1D batched R2C FFT
     View3D<double> xr2c("xr2c", n0, n1, n2);
     View3D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0, n1, n2 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft(execution_space(), xr2c, xr2c_hat,
                     KokkosFFT::Normalization::backward, /*axis=*/-1);
+    Kokkos::fence();
 
     // 1D batched C2R FFT
     View3D<Kokkos::complex<double> > xc2r("xr2c_hat", n0, n1, n2 / 2 + 1);
     View3D<double> xc2r_hat("xc2r", n0, n1, n2);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft(execution_space(), xc2r, xc2r_hat,
                      KokkosFFT::Normalization::backward, /*axis=*/-1);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/examples/05_1DFFT_HOST_DEVICE/05_1DFFT_HOST_DEVICE.cpp
+++ b/examples/05_1DFFT_HOST_DEVICE/05_1DFFT_HOST_DEVICE.cpp
@@ -27,23 +27,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifft(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
     View1D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xr2c_hat", n0 / 2 + 1);
     View1D<double> xc2r_hat("xc2r", n0);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
 
 #ifdef ENABLE_HOST_AND_DEVICE
     // FFTs on Host
@@ -56,6 +62,7 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::fft(host_execution_space(), h_xc2c, h_xc2c_hat);
     KokkosFFT::ifft(host_execution_space(), h_xc2c_hat, h_xc2c_inv);
+    Kokkos::fence();
 
     // 1D R2C FFT
     HostView1D<double> h_xr2c("h_xr2c", n0);
@@ -63,6 +70,7 @@ int main(int argc, char* argv[]) {
 
     Kokkos::deep_copy(h_xr2c, xr2c);
     KokkosFFT::rfft(host_execution_space(), h_xr2c, h_xr2c_hat);
+    Kokkos::fence();
 
     // 1D C2R FFT
     HostView1D<Kokkos::complex<double> > h_xc2r("h_xr2c_hat", n0 / 2 + 1);
@@ -70,6 +78,7 @@ int main(int argc, char* argv[]) {
 
     Kokkos::deep_copy(h_xc2r, xc2r);
     KokkosFFT::irfft(host_execution_space(), h_xc2r, h_xc2r_hat);
+    Kokkos::fence();
 #endif
   }
   Kokkos::finalize();

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -24,33 +24,40 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     int axis = -1;
     KokkosFFT::Impl::Plan fft_plan(execution_space(), xc2c, xc2c_hat,
                                    KokkosFFT::Direction::forward, axis);
     KokkosFFT::fft(execution_space(), xc2c, xc2c_hat, fft_plan);
+    Kokkos::fence();
 
     KokkosFFT::Impl::Plan ifft_plan(execution_space(), xc2c_hat, xc2c_inv,
                                     KokkosFFT::Direction::backward, axis);
     KokkosFFT::ifft(execution_space(), xc2c_hat, xc2c_inv, ifft_plan);
+    Kokkos::fence();
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
     View1D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::Impl::Plan rfft_plan(execution_space(), xr2c, xr2c_hat,
                                     KokkosFFT::Direction::forward, axis);
     KokkosFFT::rfft(execution_space(), xr2c, xr2c_hat, rfft_plan);
+    Kokkos::fence();
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xc2r_hat", n0 / 2 + 1);
     View1D<double> xc2r_hat("xc2r", n0);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::Impl::Plan irfft_plan(execution_space(), xc2r, xc2r_hat,
                                      KokkosFFT::Direction::backward, axis);
     KokkosFFT::irfft(execution_space(), xc2r, xc2r_hat, irfft_plan);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/fft/src/KokkosFFT_SYCL_transform.hpp
+++ b/fft/src/KokkosFFT_SYCL_transform.hpp
@@ -13,8 +13,8 @@ namespace Impl {
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, float* idata, std::complex<float>* odata,
            [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
-  [[maybe_unused]] auto r2c = oneapi::mkl::dft::compute_forward(plan, idata,
-                                               reinterpret_cast<float*>(odata));
+  [[maybe_unused]] auto r2c = oneapi::mkl::dft::compute_forward(
+      plan, idata, reinterpret_cast<float*>(odata));
 }
 
 template <typename PlanType, typename... Args>
@@ -43,9 +43,11 @@ void _exec(PlanType& plan, std::complex<float>* idata,
            std::complex<float>* odata, [[maybe_unused]] int direction,
            [[maybe_unused]] Args... args) {
   if (direction == 1) {
-    [[maybe_unused]] auto c2c = oneapi::mkl::dft::compute_forward(plan, idata, odata);
+    [[maybe_unused]] auto c2c =
+        oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {
-    [[maybe_unused]] auto c2c = oneapi::mkl::dft::compute_backward(plan, idata, odata);
+    [[maybe_unused]] auto c2c =
+        oneapi::mkl::dft::compute_backward(plan, idata, odata);
   }
 }
 
@@ -54,9 +56,11 @@ void _exec(PlanType& plan, std::complex<double>* idata,
            std::complex<double>* odata, [[maybe_unused]] int direction,
            [[maybe_unused]] Args... args) {
   if (direction == 1) {
-    [[maybe_unused]] auto z2z = oneapi::mkl::dft::compute_forward(plan, idata, odata);
+    [[maybe_unused]] auto z2z =
+        oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {
-    [[maybe_unused]] auto z2z = oneapi::mkl::dft::compute_backward(plan, idata, odata);
+    [[maybe_unused]] auto z2z =
+        oneapi::mkl::dft::compute_backward(plan, idata, odata);
   }
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_SYCL_transform.hpp
+++ b/fft/src/KokkosFFT_SYCL_transform.hpp
@@ -13,33 +13,29 @@ namespace Impl {
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, float* idata, std::complex<float>* odata,
            [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
-  auto r2c = oneapi::mkl::dft::compute_forward(plan, idata,
+  [[maybe_unused]] auto r2c = oneapi::mkl::dft::compute_forward(plan, idata,
                                                reinterpret_cast<float*>(odata));
-  r2c.wait();
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, double* idata, std::complex<double>* odata,
            [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
-  auto d2z = oneapi::mkl::dft::compute_forward(
+  [[maybe_unused]] auto d2z = oneapi::mkl::dft::compute_forward(
       plan, idata, reinterpret_cast<double*>(odata));
-  d2z.wait();
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, std::complex<float>* idata, float* odata,
            [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
-  auto c2r = oneapi::mkl::dft::compute_backward(
+  [[maybe_unused]] auto c2r = oneapi::mkl::dft::compute_backward(
       plan, reinterpret_cast<float*>(idata), odata);
-  c2r.wait();
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, std::complex<double>* idata, double* odata,
            [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
-  auto z2d = oneapi::mkl::dft::compute_backward(
+  [[maybe_unused]] auto z2d = oneapi::mkl::dft::compute_backward(
       plan, reinterpret_cast<double*>(idata), odata);
-  z2d.wait();
 }
 
 template <typename PlanType, typename... Args>
@@ -47,11 +43,9 @@ void _exec(PlanType& plan, std::complex<float>* idata,
            std::complex<float>* odata, [[maybe_unused]] int direction,
            [[maybe_unused]] Args... args) {
   if (direction == 1) {
-    auto c2c = oneapi::mkl::dft::compute_forward(plan, idata, odata);
-    c2c.wait();
+    [[maybe_unused]] auto c2c = oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {
-    auto c2c = oneapi::mkl::dft::compute_backward(plan, idata, odata);
-    c2c.wait();
+    [[maybe_unused]] auto c2c = oneapi::mkl::dft::compute_backward(plan, idata, odata);
   }
 }
 
@@ -60,11 +54,9 @@ void _exec(PlanType& plan, std::complex<double>* idata,
            std::complex<double>* odata, [[maybe_unused]] int direction,
            [[maybe_unused]] Args... args) {
   if (direction == 1) {
-    auto z2z = oneapi::mkl::dft::compute_forward(plan, idata, odata);
-    z2z.wait();
+    [[maybe_unused]] auto z2z = oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {
-    auto z2z = oneapi::mkl::dft::compute_backward(plan, idata, odata);
-    z2z.wait();
+    [[maybe_unused]] auto z2z = oneapi::mkl::dft::compute_backward(plan, idata, odata);
   }
 }
 }  // namespace Impl

--- a/install_test/as_library/hello.cpp
+++ b/install_test/as_library/hello.cpp
@@ -24,23 +24,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifft(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
     View1D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xr2c_hat", n0 / 2 + 1);
     View1D<double> xc2r_hat("xc2r", n0);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 

--- a/install_test/as_subdirectory/hello.cpp
+++ b/install_test/as_subdirectory/hello.cpp
@@ -24,23 +24,29 @@ int main(int argc, char* argv[]) {
 
     Kokkos::Random_XorShift64_Pool<> random_pool(12345);
     Kokkos::fill_random(xc2c, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::fft2(execution_space(), xc2c, xc2c_hat);
     KokkosFFT::ifft2(execution_space(), xc2c_hat, xc2c_inv);
+    Kokkos::fence();
 
     // 2D R2C FFT
     View2D<double> xr2c("xr2c", n0, n1);
     View2D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0, n1 / 2 + 1);
     Kokkos::fill_random(xr2c, random_pool, 1);
+    Kokkos::fence();
 
     KokkosFFT::rfft2(execution_space(), xr2c, xr2c_hat);
+    Kokkos::fence();
 
     // 2D C2R FFT
     View2D<Kokkos::complex<double> > xc2r("xr2c_hat", n0, n1 / 2 + 1);
     View2D<double> xc2r_hat("xc2r", n0, n1);
     Kokkos::fill_random(xc2r, random_pool, I);
+    Kokkos::fence();
 
     KokkosFFT::irfft2(execution_space(), xc2r, xc2r_hat);
+    Kokkos::fence();
   }
   Kokkos::finalize();
 


### PR DESCRIPTION
In this PR, we have 
1. removed the `.wait() ` after oneMKL calls to make KokkosFFT APIs asynchronous
2. `Kokkos::fence()` added after KokkosFFT API calls
3. unit tests passed after modifications on Intel PVC