### PR TITLE
Cleanup plan class

### DIFF
--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -97,9 +97,6 @@ class Plan {
   //! The type of extents of input/output views
   using extents_type = shape_type<InViewType::rank()>;
 
-  //! Execution space
-  execSpace m_exec_space;
-
   //! Dynamically allocatable fft plan.
   std::unique_ptr<fft_plan_type> m_plan;
 
@@ -151,8 +148,7 @@ class Plan {
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
                 OutViewType& out, KokkosFFT::Direction direction, int axis,
                 std::optional<std::size_t> n = std::nullopt)
-      : m_exec_space(exec_space),
-        m_fft_size(1),
+      : m_fft_size(1),
         m_is_transpose_needed(false),
         m_direction(direction),
         m_axes({axis}) {
@@ -204,8 +200,7 @@ class Plan {
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
                 OutViewType& out, KokkosFFT::Direction direction,
                 axis_type<DIM> axes, shape_type<DIM> s = {0})
-      : m_exec_space(exec_space),
-        m_fft_size(1),
+      : m_fft_size(1),
         m_is_transpose_needed(false),
         m_direction(direction),
         m_axes(axes) {
@@ -315,9 +310,6 @@ class Plan {
           "not identical.");
     }
   }
-
-  /// \brief Return the internal execution space
-  execSpace const& exec_space() const noexcept { return m_exec_space; }
 
   /// \brief Return the FFT plan
   fft_plan_type& plan() const { return *m_plan; }

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -97,6 +97,9 @@ class Plan {
   //! The type of extents of input/output views
   using extents_type = shape_type<InViewType::rank()>;
 
+  //! Execution space
+  execSpace m_exec_space;
+
   //! Dynamically allocatable fft plan.
   std::unique_ptr<fft_plan_type> m_plan;
 
@@ -114,6 +117,9 @@ class Plan {
 
   //! axes for fft
   axis_type<DIM> m_axes;
+
+  //! Shape of the transformed axis of the output
+  shape_type<DIM> m_shape;
 
   //! directions of fft
   KokkosFFT::Direction m_direction;
@@ -140,10 +146,16 @@ class Plan {
   /// \param out [in] Ouput data
   /// \param direction [in] Direction of FFT (forward/backward)
   /// \param axis [in] Axis over which FFT is performed
+  /// \param n [in] Length of the transformed axis of the output (optional)
   //
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
-                OutViewType& out, KokkosFFT::Direction direction, int axis)
-      : m_fft_size(1), m_is_transpose_needed(false), m_direction(direction) {
+                OutViewType& out, KokkosFFT::Direction direction, int axis,
+                std::optional<std::size_t> n = std::nullopt)
+      : m_exec_space(exec_space),
+        m_fft_size(1),
+        m_is_transpose_needed(false),
+        m_direction(direction),
+        m_axes({axis}) {
     static_assert(Kokkos::is_view<InViewType>::value,
                   "Plan::Plan: InViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<OutViewType>::value,
@@ -172,7 +184,6 @@ class Plan {
             ExecutionSpace, typename OutViewType::memory_space>::accessible,
         "Plan::Plan: execution_space cannot access data in OutViewType");
 
-    m_axes                     = {axis};
     m_in_extents               = KokkosFFT::Impl::extract_extents(in);
     m_out_extents              = KokkosFFT::Impl::extract_extents(out);
     std::tie(m_map, m_map_inv) = KokkosFFT::Impl::get_map_axes(in, axis);
@@ -188,11 +199,13 @@ class Plan {
   /// \param out [in] Ouput data
   /// \param direction [in] Direction of FFT (forward/backward)
   /// \param axes [in] Axes over which FFT is performed
+  /// \param s [in] Shape of the transformed axis of the output (optional)
   //
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
                 OutViewType& out, KokkosFFT::Direction direction,
-                axis_type<DIM> axes)
-      : m_fft_size(1),
+                axis_type<DIM> axes, shape_type<DIM> s = {0})
+      : m_exec_space(exec_space),
+        m_fft_size(1),
         m_is_transpose_needed(false),
         m_direction(direction),
         m_axes(axes) {
@@ -237,6 +250,11 @@ class Plan {
     _destroy_info<ExecutionSpace, fft_info_type>(m_info);
     _destroy_plan<ExecutionSpace, fft_plan_type>(m_plan);
   }
+
+  Plan(const Plan&) = delete;
+  Plan& operator=(const Plan&) = delete;
+  Plan& operator=(Plan&&) = delete;
+  Plan(Plan&&)            = delete;
 
   /// \brief Sanity check of the plan used to call FFT interface with
   ///        pre-defined FFT plan. This raises an error if there is an
@@ -297,6 +315,9 @@ class Plan {
           "not identical.");
     }
   }
+
+  /// \brief Return the internal execution space
+  execSpace const& exec_space() const noexcept { return m_exec_space; }
 
   /// \brief Return the FFT plan
   fft_plan_type& plan() const { return *m_plan; }

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -335,7 +335,6 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
   } else {
     _in = in;
   }
-  std::cout << "_in.extent(0): " << _in.extent(0) << std::endl;
 
   KokkosFFT::Impl::Plan plan(exec_space, _in, out,
                              KokkosFFT::Direction::backward, axis);

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -319,20 +319,23 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
       "ifft: execution_space cannot access data in OutViewType");
 
   InViewType _in;
-  // [TO DO] Modify crop_or_pad to perform the following lines
-  // KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, n);
   if (n) {
     std::size_t _n = n.value();
     auto modified_shape =
         KokkosFFT::Impl::get_modified_shape(in, shape_type<1>({_n}));
+
+    /* [FIX THIS] Shallow copy should be sufficient
     if (KokkosFFT::Impl::is_crop_or_pad_needed(in, modified_shape)) {
       KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
     } else {
       _in = in;
     }
+    */
+    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
   } else {
     _in = in;
   }
+  std::cout << "_in.extent(0): " << _in.extent(0) << std::endl;
 
   KokkosFFT::Impl::Plan plan(exec_space, _in, out,
                              KokkosFFT::Direction::backward, axis);
@@ -393,17 +396,18 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
       "ifft: execution_space cannot access data in OutViewType");
 
   InViewType _in;
-  // [TO DO] Modify crop_or_pad to perform the following lines
-  // KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, n);
   if (n) {
     std::size_t _n = n.value();
     auto modified_shape =
         KokkosFFT::Impl::get_modified_shape(in, shape_type<1>({_n}));
+    /* [FIX THIS] Shallow copy should be sufficient
     if (KokkosFFT::Impl::is_crop_or_pad_needed(in, modified_shape)) {
       KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
     } else {
       _in = in;
     }
+    */
+    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
   } else {
     _in = in;
   }


### PR DESCRIPTION
Resolves #90 

In this PR, we
1. disabled the non-default constructors of `Plan` class
2. added some tests for reshaping parameter `s`