### PR TITLE
Create plan with shape arg

### DIFF
--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -22,6 +22,11 @@ auto get_modified_shape(const ViewType& view, shape_type<DIM> shape,
                 "larger than or equal to 1");
   constexpr int rank = static_cast<int>(ViewType::rank());
 
+  shape_type<DIM> zeros = {0};  // default shape means no crop or pad
+  if (shape == zeros) {
+    return KokkosFFT::Impl::extract_extents(view);
+  }
+
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> positive_axes;
   for (std::size_t i = 0; i < DIM; i++) {

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -21,7 +21,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes) {
+             [[maybe_unused]] Direction direction, axis_type<1> axes, shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -39,7 +39,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -59,7 +59,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<2> axes) {
+             [[maybe_unused]] Direction direction, axis_type<2> axes, shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -77,7 +77,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -97,7 +97,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<3> axes) {
+             [[maybe_unused]] Direction direction, axis_type<3> axes, shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -115,7 +115,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -137,7 +137,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes) {
+             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -153,7 +154,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                               std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -21,7 +21,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes, shape_type<1> s) {
+             [[maybe_unused]] Direction direction, axis_type<1> axes,
+             shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -59,7 +60,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<2> axes, shape_type<2> s) {
+             [[maybe_unused]] Direction direction, axis_type<2> axes,
+             shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -97,7 +99,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<3> axes, shape_type<3> s) {
+             [[maybe_unused]] Direction direction, axis_type<3> axes,
+             shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -21,7 +21,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes, shape_type<1> s) {
+             [[maybe_unused]] Direction direction, axis_type<1> axes,
+             shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -21,7 +21,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes) {
+             [[maybe_unused]] Direction direction, axis_type<1> axes, shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -40,7 +40,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -61,7 +61,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<2> axes) {
+             [[maybe_unused]] Direction direction, axis_type<2> axes,
+             shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -80,7 +81,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -101,7 +102,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<3> axes) {
+             [[maybe_unused]] Direction direction, axis_type<3> axes,
+             shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -120,7 +122,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -143,7 +145,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes) {
+             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -159,7 +162,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                               std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_OpenMP_plans.hpp
+++ b/fft/src/KokkosFFT_OpenMP_plans.hpp
@@ -37,7 +37,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes) {
+             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -57,7 +58,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                               std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -88,7 +88,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              BufferViewType& buffer, InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes) {
+             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -105,7 +106,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                               std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -52,7 +52,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              [[maybe_unused]] BufferViewType& buffer,
              [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes) {
+             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
@@ -69,7 +70,7 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes);
+      KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                               std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,


### PR DESCRIPTION
This PR is to cleanup internal behavior regarding the shape argument (`n` or `s`). 
Plan is constructed based on this shape argument. 
This allows us to simplify the internal behavior when crop or pad is needed.