### PR TITLE
Simplify plan reuse api

### DIFF
--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -6,4 +6,3 @@ KokkosFFT::hfft
 ---------------
 
 .. doxygenfunction:: KokkosFFT::hfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::hfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)

--- a/docs/api/hermitian/ihfft.rst
+++ b/docs/api/hermitian/ihfft.rst
@@ -6,4 +6,3 @@ KokkosFFT::ihfft
 ----------------
 
 .. doxygenfunction:: KokkosFFT::ihfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::ihfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)

--- a/docs/api/real/irfft.rst
+++ b/docs/api/real/irfft.rst
@@ -6,4 +6,3 @@ KokkosFFT::irfft
 ----------------
 
 .. doxygenfunction:: KokkosFFT::irfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::irfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)

--- a/docs/api/real/irfft2.rst
+++ b/docs/api/real/irfft2.rst
@@ -4,5 +4,4 @@
 
 KokkosFFT::irfft2
 -----------------
-.. doxygenfunction:: KokkosFFT::irfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::irfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization norm, axis_type<2> axes, shape_type<DIM> s)
+.. doxygenfunction:: KokkosFFT::irfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)

--- a/docs/api/real/irfftn.rst
+++ b/docs/api/real/irfftn.rst
@@ -4,7 +4,6 @@
 
 KokkosFFT::irfftn
 -----------------
-.. doxygenfunction:: KokkosFFT::irfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::irfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM1> axes, KokkosFFT::Normalization, shape_type<DIM2> s)
-.. doxygenfunction:: KokkosFFT::irfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, axis_type<DIM1> axes, KokkosFFT::Normalization norm, shape_type<DIM2> s)
+
+.. doxygenfunction:: KokkosFFT::irfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)
    

--- a/docs/api/real/rfft.rst
+++ b/docs/api/real/rfft.rst
@@ -6,4 +6,3 @@ KokkosFFT::rfft
 ---------------
 
 .. doxygenfunction:: KokkosFFT::rfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::rfft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)

--- a/docs/api/real/rfft2.rst
+++ b/docs/api/real/rfft2.rst
@@ -5,5 +5,4 @@
 KokkosFFT::rfft2
 ----------------
 
-.. doxygenfunction:: KokkosFFT::rfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::rfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization norm, axis_type<2> axes, shape_type<DIM> s)
+.. doxygenfunction:: KokkosFFT::rfft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)

--- a/docs/api/real/rfftn.rst
+++ b/docs/api/real/rfftn.rst
@@ -4,6 +4,5 @@
 
 KokkosFFT::rfftn
 ----------------
-.. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, shape_type<DIM> s)
+
 .. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM1> axes, KokkosFFT::Normalization, shape_type<DIM2> s)
-.. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, axis_type<DIM1> axes, KokkosFFT::Normalization norm, shape_type<DIM2> s)

--- a/docs/api/standard/fft.rst
+++ b/docs/api/standard/fft.rst
@@ -6,4 +6,3 @@ KokkosFFT::fft
 --------------
 
 .. doxygenfunction:: KokkosFFT::fft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::fft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization norm, int axis, std::optional<std::size_t> n)

--- a/docs/api/standard/fft2.rst
+++ b/docs/api/standard/fft2.rst
@@ -5,5 +5,4 @@
 KokkosFFT::fft2
 ---------------
 
-.. doxygenfunction:: KokkosFFT::fft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::fft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization norm, axis_type<2> axes, shape_type<DIM> s)
+.. doxygenfunction:: KokkosFFT::fft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)

--- a/docs/api/standard/fftn.rst
+++ b/docs/api/standard/fftn.rst
@@ -5,6 +5,4 @@
 KokkosFFT::fftn
 ---------------
 
-.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM1> axes, KokkosFFT::Normalization, shape_type<DIM2> s)
-.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, axis_type<DIM1> axes, KokkosFFT::Normalization norm, shape_type<DIM2> s)
+.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)

--- a/docs/api/standard/ifft.rst
+++ b/docs/api/standard/ifft.rst
@@ -6,4 +6,3 @@ KokkosFFT::ifft
 ---------------
 
 .. doxygenfunction:: KokkosFFT::ifft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
-.. doxygenfunction:: KokkosFFT::ifft(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)

--- a/docs/api/standard/ifft2.rst
+++ b/docs/api/standard/ifft2.rst
@@ -6,4 +6,3 @@ KokkosFFT::ifft2
 ----------------
 
 .. doxygenfunction:: KokkosFFT::ifft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::ifft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, KokkosFFT::Normalization norm, axis_type<2> axes, shape_type<DIM> s)

--- a/docs/api/standard/ifftn.rst
+++ b/docs/api/standard/ifftn.rst
@@ -5,6 +5,4 @@
 KokkosFFT::ifftn
 ----------------
 
-.. doxygenfunction:: KokkosFFT::ifftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, shape_type<DIM> s)
-.. doxygenfunction:: KokkosFFT::ifftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM1> axes, KokkosFFT::Normalization, shape_type<DIM2> s)
-.. doxygenfunction:: KokkosFFT::ifftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, const PlanType& plan, axis_type<DIM1> axes, KokkosFFT::Normalization norm, shape_type<DIM2> s)
+.. doxygenfunction:: KokkosFFT::ifftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -30,12 +30,14 @@ int main(int argc, char* argv[]) {
     int axis = -1;
     KokkosFFT::Impl::Plan fft_plan(exec, xc2c, xc2c_hat,
                                    KokkosFFT::Direction::forward, axis);
-    KokkosFFT::fft(exec, xc2c, xc2c_hat, fft_plan);
+    // KokkosFFT::fft(exec, xc2c, xc2c_hat, fft_plan);
+    KokkosFFT::Impl::fft_exec_impl(fft_plan, xc2c, xc2c_hat);
     exec.fence();
 
     KokkosFFT::Impl::Plan ifft_plan(exec, xc2c_hat, xc2c_inv,
                                     KokkosFFT::Direction::backward, axis);
-    KokkosFFT::ifft(exec, xc2c_hat, xc2c_inv, ifft_plan);
+    // KokkosFFT::ifft(exec, xc2c_hat, xc2c_inv, ifft_plan);
+    KokkosFFT::Impl::fft_exec_impl(ifft_plan, xc2c_hat, xc2c_inv);
     exec.fence();
 
     // 1D R2C FFT
@@ -46,7 +48,8 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Impl::Plan rfft_plan(exec, xr2c, xr2c_hat,
                                     KokkosFFT::Direction::forward, axis);
-    KokkosFFT::rfft(exec, xr2c, xr2c_hat, rfft_plan);
+    // KokkosFFT::rfft(exec, xr2c, xr2c_hat, rfft_plan);
+    KokkosFFT::Impl::fft_exec_impl(rfft_plan, xr2c, xr2c_hat);
     exec.fence();
 
     // 1D C2R FFT
@@ -57,7 +60,8 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Impl::Plan irfft_plan(exec, xc2r, xc2r_hat,
                                      KokkosFFT::Direction::backward, axis);
-    KokkosFFT::irfft(exec, xc2r, xc2r_hat, irfft_plan);
+    // KokkosFFT::irfft(exec, xc2r, xc2r_hat, irfft_plan);
+    KokkosFFT::Impl::fft_exec_impl(irfft_plan, xc2r, xc2r_hat);
     exec.fence();
   }
   Kokkos::finalize();

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -30,13 +30,11 @@ int main(int argc, char* argv[]) {
     int axis = -1;
     KokkosFFT::Impl::Plan fft_plan(exec, xc2c, xc2c_hat,
                                    KokkosFFT::Direction::forward, axis);
-    // KokkosFFT::fft(exec, xc2c, xc2c_hat, fft_plan);
     KokkosFFT::Impl::fft_exec_impl(fft_plan, xc2c, xc2c_hat);
     exec.fence();
 
     KokkosFFT::Impl::Plan ifft_plan(exec, xc2c_hat, xc2c_inv,
                                     KokkosFFT::Direction::backward, axis);
-    // KokkosFFT::ifft(exec, xc2c_hat, xc2c_inv, ifft_plan);
     KokkosFFT::Impl::fft_exec_impl(ifft_plan, xc2c_hat, xc2c_inv);
     exec.fence();
 
@@ -48,7 +46,6 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Impl::Plan rfft_plan(exec, xr2c, xr2c_hat,
                                     KokkosFFT::Direction::forward, axis);
-    // KokkosFFT::rfft(exec, xr2c, xr2c_hat, rfft_plan);
     KokkosFFT::Impl::fft_exec_impl(rfft_plan, xr2c, xr2c_hat);
     exec.fence();
 
@@ -60,7 +57,6 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Impl::Plan irfft_plan(exec, xc2r, xc2r_hat,
                                      KokkosFFT::Direction::backward, axis);
-    // KokkosFFT::irfft(exec, xc2r, xc2r_hat, irfft_plan);
     KokkosFFT::Impl::fft_exec_impl(irfft_plan, xc2r, xc2r_hat);
     exec.fence();
   }

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -43,35 +43,39 @@
 // General Transform Interface
 namespace KokkosFFT {
 namespace Impl {
+
 template <typename PlanType, typename InViewType, typename OutViewType>
-void _fft(const PlanType& plan, const InViewType& in, OutViewType& out,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
+void exec_impl(
+    const PlanType& plan, const InViewType& in, OutViewType& out,
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "_fft: InViewType is not a Kokkos::View.");
+                "exec_impl: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<OutViewType>::value,
-                "_fft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "_fft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "_fft: OutViewType must be either LayoutLeft or LayoutRight.");
+                "exec_impl: OutViewType is not a Kokkos::View.");
+  static_assert(
+      KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
+      "exec_impl: InViewType must be either LayoutLeft or LayoutRight.");
+  static_assert(
+      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
+      "exec_impl: OutViewType must be either LayoutLeft or LayoutRight.");
 
   static_assert(InViewType::rank() == OutViewType::rank(),
-                "_fft: InViewType and OutViewType must have "
+                "exec_impl: InViewType and OutViewType must have "
                 "the same rank.");
   static_assert(std::is_same_v<typename InViewType::array_layout,
                                typename OutViewType::array_layout>,
-                "_fft: InViewType and OutViewType must have "
+                "exec_impl: InViewType and OutViewType must have "
                 "the same Layout.");
 
   using ExecutionSpace = typename PlanType::execSpace;
   static_assert(
       Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename InViewType::memory_space>::accessible,
-      "_fft: execution_space cannot access data in InViewType");
+      "exec_impl: execution_space cannot access data in InViewType");
   static_assert(
       Kokkos::SpaceAccessibility<
           ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "_fft: execution_space cannot access data in OutViewType");
+      "exec_impl: execution_space cannot access data in OutViewType");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -81,11 +85,72 @@ void _fft(const PlanType& plan, const InViewType& in, OutViewType& out,
   auto* odata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
       ExecutionSpace, out_value_type>::type*>(out.data());
 
-  auto const exec_space    = plan.exec_space();
-  auto const fft_direction = direction_type<ExecutionSpace>(plan.direction());
-  KokkosFFT::Impl::_exec(plan.plan(), idata, odata, fft_direction, plan.info());
+  auto const exec_space = plan.exec_space();
+  auto const direction  = direction_type<ExecutionSpace>(plan.direction());
+  KokkosFFT::Impl::_exec(plan.plan(), idata, odata, direction, plan.info());
   KokkosFFT::Impl::normalize(exec_space, out, plan.direction(), norm,
                              plan.fft_size());
+}
+
+template <typename PlanType, typename InViewType, typename OutViewType>
+void fft_exec_impl(
+    const PlanType& plan, const InViewType& in, OutViewType& out,
+    // KokkosFFT::Direction direction,
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
+  static_assert(Kokkos::is_view<InViewType>::value,
+                "fft_exec_impl: InViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<OutViewType>::value,
+                "fft_exec_impl: OutViewType is not a Kokkos::View.");
+  static_assert(
+      KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
+      "fft_exec_impl: InViewType must be either LayoutLeft or LayoutRight.");
+  static_assert(
+      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
+      "fft_exec_impl: OutViewType must be either LayoutLeft or LayoutRight.");
+
+  static_assert(InViewType::rank() == OutViewType::rank(),
+                "fft_exec_impl: InViewType and OutViewType must have "
+                "the same rank.");
+  static_assert(std::is_same_v<typename InViewType::array_layout,
+                               typename OutViewType::array_layout>,
+                "fft_exec_impl: InViewType and OutViewType must have "
+                "the same Layout.");
+
+  using ExecutionSpace = typename PlanType::execSpace;
+  static_assert(
+      Kokkos::SpaceAccessibility<ExecutionSpace,
+                                 typename InViewType::memory_space>::accessible,
+      "fft_exec_impl: execution_space cannot access data in InViewType");
+  static_assert(
+      Kokkos::SpaceAccessibility<
+          ExecutionSpace, typename OutViewType::memory_space>::accessible,
+      "fft_exec_impl: execution_space cannot access data in OutViewType");
+
+  plan.template good<InViewType, OutViewType>(in, out);
+
+  const auto exec_space = plan.exec_space();
+  InViewType _in;
+  if (plan.is_crop_or_pad_needed()) {
+    auto new_shape = plan.shape();
+    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
+  } else {
+    _in = in;
+  }
+
+  if (plan.is_transpose_needed()) {
+    InViewType in_T;
+    OutViewType out_T;
+
+    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
+    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
+
+    KokkosFFT::Impl::exec_impl(plan, in_T, out_T, norm);
+
+    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
+
+  } else {
+    KokkosFFT::Impl::exec_impl(plan, _in, out, norm);
+  }
 }
 
 }  // namespace Impl
@@ -132,95 +197,7 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axis, n);
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief One dimensional FFT in forward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for forward fft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void fft(const ExecutionSpace& exec_space, const InViewType& in,
-         OutViewType& out, const PlanType& plan,
-         KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-         int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fft: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::forward, axis_type<1>{axis});
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief One dimensional FFT in backward direction
@@ -263,96 +240,7 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axis, n);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief One dimensional FFT in backward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for backward fft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void ifft(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, const PlanType& plan,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifft: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::backward, axis_type<1>{axis});
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief One dimensional FFT for real input
@@ -404,57 +292,6 @@ void rfft(const ExecutionSpace& exec_space, const InViewType& in,
   fft(exec_space, in, out, norm, axis, n);
 }
 
-/// \brief One dimensional FFT for real input with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for forward fft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void rfft(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, const PlanType& plan,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfft: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(std::is_floating_point<in_value_type>::value,
-                "rfft: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
-                "rfft: OutViewType must be complex");
-
-  fft(exec_space, in, out, plan, norm, axis, n);
-}
-
 /// \brief Inverse of rfft
 ///
 /// \param exec_space [in] Kokkos execution space
@@ -501,53 +338,6 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(std::is_floating_point<out_value_type>::value,
                 "irfft: OutViewType must be real");
   ifft(exec_space, in, out, norm, axis, n);
-}
-
-/// \brief Inverse of rfft with a given
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (real)
-/// \param plan [in] KokkosFFT Plan for irfft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void irfft(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfft: OutViewType is not a Kokkos::View.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfft: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
-                "irfft: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
-                "irfft: OutViewType must be real");
-
-  ifft(exec_space, in, out, plan, norm, axis, n);
 }
 
 /// \brief One dimensional FFT of a signal that has Hermitian symmetry
@@ -606,65 +396,6 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
   irfft(exec_space, in_conj, out, new_norm, axis, n);
 }
 
-/// \brief One dimensional FFT of a signal that has Hermitian symmetry with a
-/// given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (real)
-/// \param plan [in] KokkosFFT Plan for hfft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void hfft(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, const PlanType& plan,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "hfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "hfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "hfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "hfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "hfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "hfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "hfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "hfft: execution_space cannot access data in OutViewType");
-
-  // [TO DO]
-  // allow real type as input, need to obtain complex view type from in view
-  // type
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
-                "hfft: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
-                "hfft: OutViewType must be real");
-  auto new_norm = KokkosFFT::Impl::swap_direction(norm);
-  // using ComplexViewType = typename
-  // KokkosFFT::Impl::complex_view_type<ExecutionSpace, InViewType>::type;
-  // ComplexViewType in_conj;
-  InViewType in_conj;
-  KokkosFFT::Impl::conjugate(exec_space, in, in_conj);
-  irfft(exec_space, in_conj, out, plan, new_norm, axis, n);
-}
-
 /// \brief Inverse of hfft
 ///
 /// \param exec_space [in] Kokkos execution space
@@ -717,60 +448,6 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
   out = out_conj;
 }
 
-/// \brief Inverse of hfft with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for ihfft
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axis [in] Axis over which FFT is performed (optional)
-/// \param n [in] Length of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ihfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ihfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ihfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ihfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ihfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ihfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ihfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ihfft: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(std::is_floating_point<in_value_type>::value,
-                "ihfft: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
-                "ihfft: OutViewType must be complex");
-
-  auto new_norm = KokkosFFT::Impl::swap_direction(norm);
-  OutViewType out_conj;
-  rfft(exec_space, in, out, plan, new_norm, axis, n);
-  KokkosFFT::Impl::conjugate(exec_space, out, out_conj);
-  out = out_conj;
-}
-
 // 2D FFT
 
 /// \brief Two dimensional FFT in forward direction
@@ -813,94 +490,7 @@ void fft2(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief Two dimensional FFT in forward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for fft2
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axes [in] Axes over which FFT is performed (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void fft2(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, const PlanType& plan,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fft2: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::forward, axes);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief Two dimensional FFT in backward direction
@@ -943,94 +533,7 @@ void ifft2(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief Two dimensional FFT in backward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for ifft2
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axes [in] Axes over which FFT is performed (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void ifft2(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifft2: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::backward, axes);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief Two dimensional FFT for real input
@@ -1080,57 +583,6 @@ void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
                 "rfft2: OutViewType must be complex");
 
   fft2(exec_space, in, out, norm, axes, s);
-}
-
-/// \brief Two dimensional FFT for real input with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for ifft2
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axes [in] Axes over which FFT is performed (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfft2: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(std::is_floating_point<in_value_type>::value,
-                "rfft2: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
-                "rfft2: OutViewType must be complex");
-
-  fft2(exec_space, in, out, plan, norm, axes, s);
 }
 
 /// \brief Inverse of rfft2 with a given plan
@@ -1183,132 +635,7 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
   ifft2(exec_space, in, out, norm, axes, s);
 }
 
-/// \brief Inverse of rfft2 with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (real)
-/// \param plan [in] KokkosFFT Plan for irfft2
-/// \param norm [in] How the normalization is applied (optional)
-/// \param axes [in] Axes over which FFT is performed (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType>
-void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
-            OutViewType& out, const PlanType& plan,
-            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-            axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "irfft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfft2: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
-                "irfft2: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
-                "irfft2: OutViewType must be real");
-
-  ifft2(exec_space, in, out, plan, norm, axes, s);
-}
-
 // ND FFT
-
-/// \brief N-dimensional FFT in forward direction
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void fftn(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in OutViewType");
-
-  // Create a default sequence of axes {-rank, -(rank-1), ..., -1}
-  constexpr std::size_t rank = InViewType::rank();
-  constexpr int start        = -static_cast<int>(rank);
-  axis_type<rank> axes       = KokkosFFT::Impl::index_sequence<rank>(start);
-
-  InViewType _in;
-  shape_type<DIM> zeros = {0};  // default shape means no crop or pad
-  if (s != zeros) {
-    auto modified_shape = KokkosFFT::Impl::get_modified_shape(in, s, axes);
-    if (KokkosFFT::Impl::is_crop_or_pad_needed(in, modified_shape)) {
-      KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
-    } else {
-      _in = in;
-    }
-  } else {
-    _in = in;
-  }
-
-  KokkosFFT::Impl::Plan plan(exec_space, _in, out,
-                             KokkosFFT::Direction::forward, axes);
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
 
 /// \brief N-dimensional FFT in forward direction with a given plan
 ///
@@ -1351,166 +678,7 @@ void fftn(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief N-dimensional FFT in forward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for fftn
-/// \param axes [in] Axes over which FFT is performed
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType, std::size_t DIM = 1>
-void fftn(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, const PlanType& plan, axis_type<DIM> axes,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::forward, axes);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief N-dimensional FFT in backward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in OutViewType");
-
-  // Create a default sequence of axes {-rank, -(rank-1), ..., -1}
-  constexpr std::size_t rank = InViewType::rank();
-  constexpr int start        = -static_cast<int>(rank);
-  axis_type<rank> axes       = KokkosFFT::Impl::index_sequence<rank>(start);
-
-  InViewType _in;
-  shape_type<DIM> zeros = {0};  // default shape means no crop or pad
-  if (s != zeros) {
-    auto modified_shape = KokkosFFT::Impl::get_modified_shape(in, s, axes);
-    if (KokkosFFT::Impl::is_crop_or_pad_needed(in, modified_shape)) {
-      KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, modified_shape);
-    } else {
-      _in = in;
-    }
-  } else {
-    _in = in;
-  }
-
-  KokkosFFT::Impl::Plan plan(exec_space, _in, out,
-                             KokkosFFT::Direction::backward, axes);
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief N-dimensional FFT in backward direction with a given plan
@@ -1554,194 +722,7 @@ void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief N-dimensional FFT in backward direction with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for ifftn
-/// \param axes [in] Axes over which FFT is performed
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType, std::size_t DIM = 1>
-void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan, axis_type<DIM> axes,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in OutViewType");
-
-  plan.template good<ExecutionSpace, InViewType, OutViewType>(
-      in, out, KokkosFFT::Direction::backward, axes);
-
-  InViewType _in;
-  if (plan.is_crop_or_pad_needed()) {
-    auto new_shape = plan.shape();
-    KokkosFFT::Impl::crop_or_pad(exec_space, in, _in, new_shape);
-  } else {
-    _in = in;
-  }
-
-  if (plan.is_transpose_needed()) {
-    InViewType in_T;
-    OutViewType out_T;
-
-    KokkosFFT::Impl::transpose(exec_space, _in, in_T, plan.map());
-    KokkosFFT::Impl::transpose(exec_space, out, out_T, plan.map());
-
-    KokkosFFT::Impl::_fft(plan, in_T, out_T, norm);
-
-    KokkosFFT::Impl::transpose(exec_space, out_T, out, plan.map_inv());
-  } else {
-    KokkosFFT::Impl::_fft(plan, _in, out, norm);
-  }
-}
-
-/// \brief N-dimensional FFT for real input with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real)
-/// \param out [out] Ouput data (complex)
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(std::is_floating_point<in_value_type>::value,
-                "rfftn: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
-                "rfftn: OutViewType must be complex");
-
-  fftn(exec_space, in, out, norm, s);
-}
-
-/// \brief N-dimensional FFT for real input with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real)
-/// \param out [out] Ouput data (complex)
-/// \param plan [in] KokkosFFT Plan for rfftn
-/// \param axes [in] Axes over which FFT is performed
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType, std::size_t DIM = 1>
-void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, const PlanType& plan, axis_type<DIM> axes,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(std::is_floating_point<in_value_type>::value,
-                "rfftn: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
-                "rfftn: OutViewType must be complex");
-
-  fftn(exec_space, in, out, plan, axes, norm, s);
+  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
 }
 
 /// \brief N-dimensional FFT for real input
@@ -1792,56 +773,6 @@ void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
                 "rfftn: OutViewType must be complex");
 
   fftn(exec_space, in, out, axes, norm, s);
-}
-
-/// \brief Inverse of rfftn with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (real)
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
-            OutViewType& out,
-            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-            shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "irfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfftn: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
-                "irfftn: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
-                "irfftn: OutViewType must be real");
-
-  ifftn(exec_space, in, out, norm, s);
 }
 
 /// \brief Inverse of rfftn
@@ -1895,57 +826,6 @@ void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
   ifftn(exec_space, in, out, axes, norm, s);
 }
 
-/// \brief Inverse of rfftn with a given plan
-///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
-/// \param out [out] Ouput data (real)
-/// \param plan [in] KokkosFFT Plan for irfftn
-/// \param axes [in] Axes over which FFT is performed
-/// \param norm [in] How the normalization is applied (optional)
-/// \param s [in] Shape of the transformed axis of the output (optional)
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          typename PlanType, std::size_t DIM = 1>
-void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
-            OutViewType& out, const PlanType& plan, axis_type<DIM> axes,
-            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-            shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "irfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in OutViewType");
-
-  using in_value_type  = typename InViewType::non_const_value_type;
-  using out_value_type = typename OutViewType::non_const_value_type;
-
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
-                "irfftn: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
-                "irfftn: OutViewType must be real");
-
-  ifftn(exec_space, in, out, plan, axes, norm, s);
-}
 }  // namespace KokkosFFT
 
 #endif


### PR DESCRIPTION
This PR aims at removing the older APIs to reuse FFT plans.
We now have a single API to reuse FFT plan: `KokkosFFT::Impl::fft_exec_impl`.
Contrary to the previous implementation, Plan includes all the information related to FFT. In the new interface, we can only change the input and output views (keeping the same extents, but can be different data) and normalization direction. Once the plan is fixed, we can no longer change axis, data shape, and FFT direction, and thus these arguments must be suppressed.

Following modifications are made:
1. Remove older version of FFT APIs with a plan argument
2. Remove an overload of `fftn` without axes argument
3. Tests and examples are updated accordingly

This is a big change, so reviews are appreciated