### PR TITLE
fix args for doxygen

### DIFF
--- a/docs/api/real/rfftn.rst
+++ b/docs/api/real/rfftn.rst
@@ -5,4 +5,4 @@
 KokkosFFT::rfftn
 ----------------
 
-.. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM1> axes, KokkosFFT::Normalization, shape_type<DIM2> s)
+.. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)

--- a/docs/api/standard/ifft2.rst
+++ b/docs/api/standard/ifft2.rst
@@ -5,4 +5,4 @@
 KokkosFFT::ifft2
 ----------------
 
-.. doxygenfunction:: KokkosFFT::ifft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<DIM> s)
+.. doxygenfunction:: KokkosFFT::ifft2(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)


### PR DESCRIPTION
This PR fixes the bugs for documentation in `ifft2` and `rfftn`.