### PR TITLE
Disallow invalid plan

### DIFF
--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -190,6 +190,20 @@ class Plan {
             ExecutionSpace, typename OutViewType::memory_space>::accessible,
         "Plan::Plan: execution_space cannot access data in OutViewType");
 
+    if (std::is_floating_point<in_value_type>::value &&
+        m_direction != KokkosFFT::Direction::forward) {
+      throw std::runtime_error(
+          "Plan::Plan: real to complex transform is constrcuted with backward "
+          "direction.");
+    }
+
+    if (std::is_floating_point<out_value_type>::value &&
+        m_direction != KokkosFFT::Direction::backward) {
+      throw std::runtime_error(
+          "Plan::Plan: complex to real transform is constrcuted with forward "
+          "direction.");
+    }
+
     shape_type<1> s = {0};
     if (n) {
       std::size_t _n = n.value();
@@ -256,6 +270,20 @@ class Plan {
             ExecutionSpace, typename OutViewType::memory_space>::accessible,
         "Plan::Plan: execution_space cannot access data in OutViewType");
 
+    if (std::is_floating_point<in_value_type>::value &&
+        m_direction != KokkosFFT::Direction::forward) {
+      throw std::runtime_error(
+          "Plan::Plan: real to complex transform is constrcuted with backward "
+          "direction.");
+    }
+
+    if (std::is_floating_point<out_value_type>::value &&
+        m_direction != KokkosFFT::Direction::backward) {
+      throw std::runtime_error(
+          "Plan::Plan: complex to real transform is constrcuted with forward "
+          "direction.");
+    }
+
     bool is_C2R = is_complex<in_value_type>::value &&
                   std::is_floating_point<out_value_type>::value;
 
@@ -305,23 +333,6 @@ class Plan {
     static_assert(std::is_same_v<nonConstOutViewType2, nonConstOutViewType>,
                   "Plan::good: OutViewType for plan and "
                   "execution are not identical.");
-
-    using in_value_type  = typename InViewType2::non_const_value_type;
-    using out_value_type = typename OutViewType2::non_const_value_type;
-
-    if (std::is_floating_point<in_value_type>::value &&
-        m_direction != KokkosFFT::Direction::forward) {
-      throw std::runtime_error(
-          "Plan::good: real to complex transform is constrcuted with backward "
-          "direction.");
-    }
-
-    if (std::is_floating_point<out_value_type>::value &&
-        m_direction != KokkosFFT::Direction::backward) {
-      throw std::runtime_error(
-          "Plan::good: complex to real transform is constrcuted with forward "
-          "direction.");
-    }
 
     auto in_extents  = KokkosFFT::Impl::extract_extents(in);
     auto out_extents = KokkosFFT::Impl::extract_extents(out);

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -72,6 +72,39 @@ void test_plan_1dfft_1dview() {
   KokkosFFT::Impl::Plan plan_c2c_f_axes0(execution_space(), x_cin, x_cout,
                                          KokkosFFT::Direction::backward,
                                          /*axes=*/axes_type<1>({0}));
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis0(
+            execution_space(), x, x_c, KokkosFFT::Direction::backward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes0(
+            execution_space(), x, x_c, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<1>({0}));
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis0(
+            execution_space(), x_c, x, KokkosFFT::Direction::forward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes0(
+            execution_space(), x_c, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<1>({0}));
+      },
+      std::runtime_error);
 }
 
 template <typename T, typename LayoutType>
@@ -114,6 +147,53 @@ void test_plan_1dfft_2dview() {
   KokkosFFT::Impl::Plan plan_c2c_f_axis_1(execution_space(), x_cin, x_cout,
                                           KokkosFFT::Direction::forward,
                                           /*axis=*/1);
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axis=*/1);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_minus1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axis=*/-1);
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axis=*/1);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_minus1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axis=*/-1);
+      },
+      std::runtime_error);
 }
 
 template <typename T, typename LayoutType>
@@ -170,6 +250,55 @@ void test_plan_1dfft_3dview() {
   KokkosFFT::Impl::Plan plan_c2c_b_axis_2(execution_space(), x_cin, x_cout,
                                           KokkosFFT::Direction::backward,
                                           /*axis=*/2);
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axis=*/1);
+      },
+      std::runtime_error);
+
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_2(
+            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
+            /*axis=*/2);
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axis=*/0);
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axis=*/1);
+      },
+      std::runtime_error);
+
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_2(
+            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
+            /*axis=*/2);
+      },
+      std::runtime_error);
 }
 
 // Tests for 1D FFT plan on 1D View
@@ -231,6 +360,39 @@ void test_plan_2dfft_2dview() {
   KokkosFFT::Impl::Plan plan_c2c_f_axes_1_0(execution_space(), x_cin, x_cout,
                                             KokkosFFT::Direction::forward,
                                             /*axes=*/axes_type<2>({1, 0}));
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({1, 0}));
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({1, 0}));
+      },
+      std::runtime_error);
 }
 
 template <typename T, typename LayoutType>
@@ -305,6 +467,95 @@ void test_plan_2dfft_3dview() {
   KokkosFFT::Impl::Plan plan_c2c_f_axes_2_1(execution_space(), x_cin, x_cout,
                                             KokkosFFT::Direction::forward,
                                             /*axes=*/axes_type<2>({2, 1}));
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_2(
+            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({0, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({1, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_2(
+            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({1, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({2, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<2>({2, 1}));
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_2(
+            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({0, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({1, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_2(
+            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({1, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({2, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<2>({2, 1}));
+      },
+      std::runtime_error);
 }
 
 // Tests for 2D FFT plan on 2D View
@@ -396,6 +647,95 @@ void test_plan_3dfft_3dview() {
   KokkosFFT::Impl::Plan plan_c2c_f_axes_2_1_0(execution_space(), x_cin, x_cout,
                                               KokkosFFT::Direction::forward,
                                               /*axes=*/axes_type<3>({2, 1, 0}));
+
+  // Check if errors are correctly raised aginst wrong dirction
+  // Input Real, Output Complex -> must be forward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1_2(
+            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({0, 1, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_2_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({0, 2, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0_2(
+            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({1, 0, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_2_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({1, 2, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_0_1(
+            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({2, 0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_1_0(
+            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
+            /*axes=*/axes_type<3>({2, 1, 0}));
+      },
+      std::runtime_error);
+
+  // Input Complex, Output Real -> must be backward plan
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1_2(
+            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({0, 1, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_2_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({0, 2, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0_2(
+            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({1, 0, 2}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_2_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({1, 2, 0}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_0_1(
+            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({2, 0, 1}));
+      },
+      std::runtime_error);
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_1_0(
+            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
+            /*axes=*/axes_type<3>({2, 1, 0}));
+      },
+      std::runtime_error);
 }
 
 // Tests for 3D FFT plan on 3D View

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -223,19 +223,6 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
   KokkosFFT::Impl::Plan irfft_plan(execution_space(), outr, _ar,
                                    KokkosFFT::Direction::backward, axis);
 
-  // Check if errors are correctly raised aginst wrong dirction
-  KokkosFFT::Direction wrong_fft_direction  = KokkosFFT::Direction::backward;
-  KokkosFFT::Direction wrong_ifft_direction = KokkosFFT::Direction::forward;
-  KokkosFFT::Impl::Plan wrong_rfft_plan(execution_space(), ar, outr,
-                                        wrong_fft_direction, axis);
-  KokkosFFT::Impl::Plan wrong_irfft_plan(execution_space(), outr, _ar,
-                                         wrong_ifft_direction, axis);
-
-  EXPECT_THROW(KokkosFFT::Impl::fft_exec_impl(wrong_rfft_plan, ar, outr),
-               std::runtime_error);
-  EXPECT_THROW(KokkosFFT::Impl::fft_exec_impl(wrong_irfft_plan, outr, _ar),
-               std::runtime_error);
-
   // Check if errors are correctly raised aginst wrong extents
   const int maxlen_wrong = 32 * 2;
   ComplexView1DType a_wrong("a", maxlen_wrong), _a_wrong("_a", maxlen_wrong);


### PR DESCRIPTION
This PR aims to disallow the construction of invalid plans.
If the input is real and output is complex, the FFT direction must be forward, and vice versa. 
If these conditions are violated (e.g., input real, output complex, and backward fft direction), 
`Plan` constructor throws a runtime error.

Following modifications are made:
1.  Runtime errors are raised for invalid Plans in `Plan` constructors.
2. Tests if runtime errors are thrown for invalid Plans