### PR TITLE
For padding capability, use the output type to compute the modified extents

### DIFF
--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -43,12 +43,8 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   auto [map, map_inv] = KokkosFFT::Impl::get_map_axes(in, axes);
 
   // Get new shape based on shape parameter
-  // [TO DO] get_modified shape should take out as well and check is_C2R
-  // internally
-  bool is_C2R = is_complex<in_value_type>::value &&
-                std::is_floating_point<out_value_type>::value;
   auto modified_in_shape =
-      KokkosFFT::Impl::get_modified_shape(in, shape, axes, is_C2R);
+      KokkosFFT::Impl::get_modified_shape(in, out, shape, axes);
 
   // Get extents for the inner most axes in LayoutRight
   // If we allow the FFT on the layoutLeft, this part should be modified

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -11,9 +11,21 @@
 
 namespace KokkosFFT {
 namespace Impl {
+
+/// \brief Return a new shape of the input view based on the
+/// specified input shape and axes.
+///
+/// \tparam InViewType The input view type
+/// \tparam OutViewType The output view type
+/// \tparam DIM         The dimensionality of the shape and axes
+///
+/// \param in [in] Input view from which to derive the new shape
+/// \param out [in] Ouput view (unused but necessary for type deduction)
+/// \param shape [in] THe new shape of the input view. If the shape is zero,
+/// no modifications are made.
+/// \param axis [in] Axis over which the shape modification is applied.
 template <typename InViewType, typename OutViewType, std::size_t DIM>
-auto get_modified_shape(const InViewType& in,
-                        [[maybe_unused]] const OutViewType& out,
+auto get_modified_shape(const InViewType in, const OutViewType /* out */,
                         shape_type<DIM> shape, axis_type<DIM> axes) {
   static_assert(InViewType::rank() >= DIM,
                 "get_modified_shape: Rank of Input View must be larger "
@@ -59,7 +71,7 @@ auto get_modified_shape(const InViewType& in,
   using out_value_type = typename OutViewType::non_const_value_type;
 
   bool is_C2R = is_complex<in_value_type>::value &&
-                std::is_floating_point<out_value_type>::value;
+                std::is_floating_point_v<out_value_type>;
 
   if (is_C2R) {
     int reshaped_axis                = positive_axes.back();

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -20,10 +20,10 @@ namespace Impl {
 /// \tparam DIM         The dimensionality of the shape and axes
 ///
 /// \param in [in] Input view from which to derive the new shape
-/// \param out [in] Ouput view (unused but necessary for type deduction)
-/// \param shape [in] THe new shape of the input view. If the shape is zero,
+/// \param out [in] Output view (unused but necessary for type deduction)
+/// \param shape [in] The new shape of the input view. If the shape is zero,
 /// no modifications are made.
-/// \param axis [in] Axis over which the shape modification is applied.
+/// \param axes [in] Axes over which the shape modification is applied.
 template <typename InViewType, typename OutViewType, std::size_t DIM>
 auto get_modified_shape(const InViewType in, const OutViewType /* out */,
                         shape_type<DIM> shape, axis_type<DIM> axes) {

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -81,8 +81,8 @@ void test_reshape1D_2DView() {
     View2D<Kokkos::complex<double>> x_in("x_in", _n0, _n1);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<2> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -108,8 +108,8 @@ void test_reshape1D_3DView() {
     View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<3> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -134,8 +134,8 @@ void test_reshape1D_4DView() {
     View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<4> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -161,8 +161,8 @@ void test_reshape1D_5DView() {
     View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<5> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -187,8 +187,8 @@ void test_reshape1D_6DView() {
     View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<6> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -214,8 +214,8 @@ void test_reshape1D_7DView() {
                                          _n6);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<7> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -241,8 +241,8 @@ void test_reshape1D_8DView() {
                                          _n6, _n7);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<8> ref_shape = default_shape;
-      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
-      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
+      auto n_new              = x_in.extent(axis0) + i0;
+      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
           x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
@@ -311,12 +311,10 @@ void test_reshape2D_2DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<2> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -348,12 +346,10 @@ void test_reshape2D_3DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<3> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -385,12 +381,10 @@ void test_reshape2D_4DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<4> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -422,12 +416,10 @@ void test_reshape2D_5DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<5> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -460,12 +452,10 @@ void test_reshape2D_6DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<6> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -498,12 +488,10 @@ void test_reshape2D_7DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<7> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -536,12 +524,10 @@ void test_reshape2D_8DView() {
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<8> ref_shape = default_shape;
-          std::size_t n0_new =
-              static_cast<std::size_t>(x_in.extent(axis0) + i0);
-          std::size_t n1_new =
-              static_cast<std::size_t>(x_in.extent(axis1) + i1);
-          ref_shape.at(axis0) = n0_new;
-          ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
+          auto n0_new             = x_in.extent(axis0) + i0;
+          auto n1_new             = x_in.extent(axis1) + i1;
+          ref_shape.at(axis0)     = n0_new;
+          ref_shape.at(axis1)     = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
@@ -561,7 +547,7 @@ TYPED_TEST(GetModifiedShape2D, 2DView) {
 
 TYPED_TEST(GetModifiedShape2D, 3DView) {
   using float_type = typename TestFixture::float_type;
-  test_reshape2D_2DView<float_type>();
+  test_reshape2D_3DView<float_type>();
 }
 
 TYPED_TEST(GetModifiedShape2D, 4DView) {
@@ -611,12 +597,9 @@ void test_reshape3D_3DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<3> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -624,7 +607,7 @@ void test_reshape3D_3DView() {
 
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
               auto modified_shape     = KokkosFFT::Impl::get_modified_shape(
-                  x_in, x_out, new_shape, axes);
+                      x_in, x_out, new_shape, axes);
 
               EXPECT_TRUE(modified_shape == ref_shape);
             }
@@ -657,12 +640,9 @@ void test_reshape3D_4DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<4> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -702,12 +682,9 @@ void test_reshape3D_5DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<5> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -748,12 +725,9 @@ void test_reshape3D_6DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<6> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -794,12 +768,9 @@ void test_reshape3D_7DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<7> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -839,12 +810,9 @@ void test_reshape3D_8DView() {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<8> ref_shape = default_shape;
-              std::size_t n0_new =
-                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
-              std::size_t n1_new =
-                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
-              std::size_t n2_new =
-                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
+              auto n0_new             = x_in.extent(axis0) + i0;
+              auto n1_new             = x_in.extent(axis1) + i1;
+              auto n2_new             = x_in.extent(axis2) + i2;
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -607,7 +607,7 @@ void test_reshape3D_3DView() {
 
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
               auto modified_shape     = KokkosFFT::Impl::get_modified_shape(
-                      x_in, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
 
               EXPECT_TRUE(modified_shape == ref_shape);
             }

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -607,7 +607,7 @@ void test_reshape3D_3DView() {
 
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
               auto modified_shape     = KokkosFFT::Impl::get_modified_shape(
-                      x, x_out, new_shape, axes);
+                  x, x_out, new_shape, axes);
 
               EXPECT_TRUE(modified_shape == ref_shape);
             }

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -624,7 +624,7 @@ void test_reshape3D_3DView() {
 
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
               auto modified_shape     = KokkosFFT::Impl::get_modified_shape(
-                      x_in, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
 
               EXPECT_TRUE(modified_shape == ref_shape);
             }

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -47,14 +47,14 @@ void test_reshape1D_1DView() {
   bool is_C2R = !KokkosFFT::Impl::is_complex<T>::value;
 
   View1D<T> x_out("x_out", len);
-  View1D<Kokkos::complex<double>> x("x", get_c2r_shape(len, is_C2R));
+  View1D<Kokkos::complex<double>> x_in("x_in", get_c2r_shape(len, is_C2R));
 
-  auto shape = KokkosFFT::Impl::get_modified_shape(x, x_out, shape_type<1>{len},
-                                                   axes_type<1>{-1});
+  auto shape = KokkosFFT::Impl::get_modified_shape(
+      x_in, x_out, shape_type<1>{len}, axes_type<1>{-1});
   auto shape_pad = KokkosFFT::Impl::get_modified_shape(
-      x, x_out, shape_type<1>{len_pad}, axes_type<1>{-1});
+      x_in, x_out, shape_type<1>{len_pad}, axes_type<1>{-1});
   auto shape_crop = KokkosFFT::Impl::get_modified_shape(
-      x, x_out, shape_type<1>{len_crop}, axes_type<1>{-1});
+      x_in, x_out, shape_type<1>{len_crop}, axes_type<1>{-1});
 
   shape_type<1> ref_shape      = {get_c2r_shape(len, is_C2R)};
   shape_type<1> ref_shape_pad  = {get_c2r_shape(len_pad, is_C2R)};
@@ -78,14 +78,14 @@ void test_reshape1D_2DView() {
     shape_type<2> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1]        = in_shape;
-    View2D<Kokkos::complex<double>> x("x", _n0, _n1);
+    View2D<Kokkos::complex<double>> x_in("x_in", _n0, _n1);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<2> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -105,14 +105,14 @@ void test_reshape1D_3DView() {
     shape_type<3> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2]   = in_shape;
-    View3D<Kokkos::complex<double>> x("x", _n0, _n1, _n2);
+    View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<3> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -131,14 +131,14 @@ void test_reshape1D_4DView() {
     shape_type<4> in_shape    = default_shape;
     in_shape.at(axis0)        = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2, _n3] = in_shape;
-    View4D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3);
+    View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<4> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -158,14 +158,14 @@ void test_reshape1D_5DView() {
     shape_type<5> in_shape         = default_shape;
     in_shape.at(axis0)             = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-    View5D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4);
+    View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<5> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -184,14 +184,14 @@ void test_reshape1D_6DView() {
     shape_type<6> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-    View6D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5);
+    View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<6> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -210,14 +210,15 @@ void test_reshape1D_7DView() {
     shape_type<7> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-    View7D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+    View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
+                                         _n6);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<7> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -236,15 +237,15 @@ void test_reshape1D_8DView() {
     shape_type<8> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
     auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-    View8D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5, _n6,
-                                      _n7);
+    View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
+                                         _n6, _n7);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<8> ref_shape = default_shape;
-      std::size_t n_new       = static_cast<std::size_t>(x.extent(axis0) + i0);
-      ref_shape.at(axis0)     = get_c2r_shape(n_new, is_C2R);
+      std::size_t n_new   = static_cast<std::size_t>(x_in.extent(axis0) + i0);
+      ref_shape.at(axis0) = get_c2r_shape(n_new, is_C2R);
 
       auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-          x, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
+          x_in, x_out, shape_type<1>{n_new}, axes_type<1>{axis0});
 
       EXPECT_TRUE(modified_shape == ref_shape);
     }
@@ -306,19 +307,21 @@ void test_reshape2D_2DView() {
       shape_type<2> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1]        = in_shape;
-      View2D<Kokkos::complex<double>> x("x", _n0, _n1);
+      View2D<Kokkos::complex<double>> x_in("x_in", _n0, _n1);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<2> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -341,19 +344,21 @@ void test_reshape2D_3DView() {
       shape_type<3> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2]   = in_shape;
-      View3D<Kokkos::complex<double>> x("x", _n0, _n1, _n2);
+      View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<3> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -376,19 +381,21 @@ void test_reshape2D_4DView() {
       shape_type<4> in_shape    = default_shape;
       in_shape.at(axis1)        = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2, _n3] = in_shape;
-      View4D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3);
+      View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<4> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -411,19 +418,21 @@ void test_reshape2D_5DView() {
       shape_type<5> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-      View5D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4);
+      View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<5> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -446,19 +455,22 @@ void test_reshape2D_6DView() {
       shape_type<6> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-      View6D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5);
+      View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
+                                           _n5);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<6> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -481,19 +493,22 @@ void test_reshape2D_7DView() {
       shape_type<7> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-      View7D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+      View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
+                                           _n6);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<7> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -516,20 +531,22 @@ void test_reshape2D_8DView() {
       shape_type<8> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
       auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-      View8D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5, _n6,
-                                        _n7);
+      View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
+                                           _n6, _n7);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<8> ref_shape = default_shape;
-          std::size_t n0_new  = static_cast<std::size_t>(x.extent(axis0) + i0);
-          std::size_t n1_new  = static_cast<std::size_t>(x.extent(axis1) + i1);
+          std::size_t n0_new =
+              static_cast<std::size_t>(x_in.extent(axis0) + i0);
+          std::size_t n1_new =
+              static_cast<std::size_t>(x_in.extent(axis1) + i1);
           ref_shape.at(axis0) = n0_new;
           ref_shape.at(axis1) = get_c2r_shape(n1_new, is_C2R);
 
           shape_type<2> new_shape = {n0_new, n1_new};
 
           auto modified_shape =
-              KokkosFFT::Impl::get_modified_shape(x, x_out, new_shape, axes);
+              KokkosFFT::Impl::get_modified_shape(x_in, x_out, new_shape, axes);
           EXPECT_TRUE(modified_shape == ref_shape);
         }
       }
@@ -589,17 +606,17 @@ void test_reshape3D_3DView() {
         shape_type<3> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2]   = in_shape;
-        View3D<Kokkos::complex<double>> x("x", _n0, _n1, _n2);
+        View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<3> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -607,7 +624,7 @@ void test_reshape3D_3DView() {
 
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
               auto modified_shape     = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                      x_in, x_out, new_shape, axes);
 
               EXPECT_TRUE(modified_shape == ref_shape);
             }
@@ -635,17 +652,17 @@ void test_reshape3D_4DView() {
         shape_type<4> in_shape    = default_shape;
         in_shape.at(axis2)        = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2, _n3] = in_shape;
-        View4D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3);
+        View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<4> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -654,7 +671,7 @@ void test_reshape3D_4DView() {
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
 
               auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
               EXPECT_TRUE(modified_shape == ref_shape);
             }
           }
@@ -680,17 +697,17 @@ void test_reshape3D_5DView() {
         shape_type<5> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-        View5D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4);
+        View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<5> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -699,7 +716,7 @@ void test_reshape3D_5DView() {
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
 
               auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
               EXPECT_TRUE(modified_shape == ref_shape);
             }
           }
@@ -725,17 +742,18 @@ void test_reshape3D_6DView() {
         shape_type<6> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-        View6D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5);
+        View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
+                                             _n5);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<6> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -744,7 +762,7 @@ void test_reshape3D_6DView() {
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
 
               auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
               EXPECT_TRUE(modified_shape == ref_shape);
             }
           }
@@ -770,18 +788,18 @@ void test_reshape3D_7DView() {
         shape_type<7> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-        View7D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5,
-                                          _n6);
+        View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
+                                             _n5, _n6);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<7> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -790,7 +808,7 @@ void test_reshape3D_7DView() {
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
 
               auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
               EXPECT_TRUE(modified_shape == ref_shape);
             }
           }
@@ -815,18 +833,18 @@ void test_reshape3D_8DView() {
         shape_type<8> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
         auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-        View8D<Kokkos::complex<double>> x("x", _n0, _n1, _n2, _n3, _n4, _n5,
-                                          _n6, _n7);
+        View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
+                                             _n5, _n6, _n7);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
               shape_type<8> ref_shape = default_shape;
               std::size_t n0_new =
-                  static_cast<std::size_t>(x.extent(axis0) + i0);
+                  static_cast<std::size_t>(x_in.extent(axis0) + i0);
               std::size_t n1_new =
-                  static_cast<std::size_t>(x.extent(axis1) + i1);
+                  static_cast<std::size_t>(x_in.extent(axis1) + i1);
               std::size_t n2_new =
-                  static_cast<std::size_t>(x.extent(axis2) + i2);
+                  static_cast<std::size_t>(x_in.extent(axis2) + i2);
 
               ref_shape.at(axis0) = n0_new;
               ref_shape.at(axis1) = n1_new;
@@ -835,7 +853,7 @@ void test_reshape3D_8DView() {
               shape_type<3> new_shape = {n0_new, n1_new, n2_new};
 
               auto modified_shape = KokkosFFT::Impl::get_modified_shape(
-                  x, x_out, new_shape, axes);
+                  x_in, x_out, new_shape, axes);
               EXPECT_TRUE(modified_shape == ref_shape);
             }
           }

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -210,9 +210,6 @@ class Plan {
       s              = shape_type<1>({_n});
     }
 
-    bool is_C2R = is_complex<in_value_type>::value &&
-                  std::is_floating_point<out_value_type>::value;
-
     m_in_extents               = KokkosFFT::Impl::extract_extents(in);
     m_out_extents              = KokkosFFT::Impl::extract_extents(out);
     std::tie(m_map, m_map_inv) = KokkosFFT::Impl::get_map_axes(in, axis);
@@ -283,9 +280,6 @@ class Plan {
           "Plan::Plan: complex to real transform is constrcuted with forward "
           "direction.");
     }
-
-    bool is_C2R = is_complex<in_value_type>::value &&
-                  std::is_floating_point<out_value_type>::value;
 
     m_in_extents               = KokkosFFT::Impl::extract_extents(in);
     m_out_extents              = KokkosFFT::Impl::extract_extents(out);

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -334,25 +334,6 @@ class Plan {
                   "Plan::good: OutViewType for plan and "
                   "execution are not identical.");
 
-    /*
-    using in_value_type  = typename InViewType2::non_const_value_type;
-    using out_value_type = typename OutViewType2::non_const_value_type;
-
-    if (std::is_floating_point<in_value_type>::value &&
-        m_direction != KokkosFFT::Direction::forward) {
-      throw std::runtime_error(
-          "Plan::good: real to complex transform is constrcuted with backward "
-          "direction.");
-    }
-
-    if (std::is_floating_point<out_value_type>::value &&
-        m_direction != KokkosFFT::Direction::backward) {
-      throw std::runtime_error(
-          "Plan::good: complex to real transform is constrcuted with forward "
-          "direction.");
-    }
-    */
-
     auto in_extents  = KokkosFFT::Impl::extract_extents(in);
     auto out_extents = KokkosFFT::Impl::extract_extents(out);
     if (in_extents != m_in_extents) {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -217,7 +217,7 @@ class Plan {
     m_out_extents              = KokkosFFT::Impl::extract_extents(out);
     std::tie(m_map, m_map_inv) = KokkosFFT::Impl::get_map_axes(in, axis);
     m_is_transpose_needed      = KokkosFFT::Impl::is_transpose_needed(m_map);
-    m_shape = KokkosFFT::Impl::get_modified_shape(in, s, m_axes, is_C2R);
+    m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
     m_fft_size = KokkosFFT::Impl::_create(exec_space, m_plan, in, out, m_buffer,
@@ -291,7 +291,7 @@ class Plan {
     m_out_extents              = KokkosFFT::Impl::extract_extents(out);
     std::tie(m_map, m_map_inv) = KokkosFFT::Impl::get_map_axes(in, axes);
     m_is_transpose_needed      = KokkosFFT::Impl::is_transpose_needed(m_map);
-    m_shape = KokkosFFT::Impl::get_modified_shape(in, s, m_axes, is_C2R);
+    m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
     m_fft_size = KokkosFFT::Impl::_create(exec_space, m_plan, in, out, m_buffer,
@@ -333,6 +333,25 @@ class Plan {
     static_assert(std::is_same_v<nonConstOutViewType2, nonConstOutViewType>,
                   "Plan::good: OutViewType for plan and "
                   "execution are not identical.");
+
+    /*
+    using in_value_type  = typename InViewType2::non_const_value_type;
+    using out_value_type = typename OutViewType2::non_const_value_type;
+
+    if (std::is_floating_point<in_value_type>::value &&
+        m_direction != KokkosFFT::Direction::forward) {
+      throw std::runtime_error(
+          "Plan::good: real to complex transform is constrcuted with backward "
+          "direction.");
+    }
+
+    if (std::is_floating_point<out_value_type>::value &&
+        m_direction != KokkosFFT::Direction::backward) {
+      throw std::runtime_error(
+          "Plan::good: complex to real transform is constrcuted with forward "
+          "direction.");
+    }
+    */
 
     auto in_extents  = KokkosFFT::Impl::extract_extents(in);
     auto out_extents = KokkosFFT::Impl::extract_extents(out);


### PR DESCRIPTION
This PR aims to use the output type to compute the modified extents.
For `C2R` transform, the modified shape is computed differently, 
and thus we need to know whether the transform is `C2R` or not.
Previously, a boolean `is_C2R` is given to `get_modified_shape` function, 
but `is_C2R` is checked internally from input and output view types in this function. 

Following modifications are made:
1.  `is_C2R` is checked internally in `get_modified_shape` function
2. Tests are parameterized over output types. (Previously, we used parameterized over boolean `is_C2R`)