### PR TITLE
Fix path to FindFFTW.cmake when using KokkosFFT as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ install(
 )
 
 install(
-    FILES ${CMAKE_SOURCE_DIR}/cmake/FindFFTW.cmake
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindFFTW.cmake
     DESTINATION ${INSTALL_LIBDIR}
 )
 


### PR DESCRIPTION
When KokkosFFT is used as a subdirectory, CMAKE_SOURCE_DIR points to top level of the current CMake source tree. CMAKE_CURRENT_SOURCE_DIR points to the source directory that is currently being processed by cmake.

Example error when installing project that is using KokkosFFT before this fix:
```
CMake Error at src/gpl2/kokkos-fft/cmake_install.cmake:107 (file):
  file INSTALL cannot find
  "project-name/cmake/FindFFTW.cmake":
  No such file or directory.
Call Stack (most recent call first):
  src/gpl2/cmake_install.cmake:47 (include)
  src/cmake_install.cmake:87 (include)
  cmake_install.cmake:52 (include)
```
