### PR TITLE
Setup CI heartbeat for self-hosted runners

### DIFF
--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -14,7 +14,11 @@ on:
 
 jobs:
   heartbeat:
-    runs-on: "self-hosted"
+    runs-on: ["self-hosted", ${{ matrix.runner }}]
+
+    strategy:
+      matrix:
+        runner: ["cuda"]
 
     steps:
       - name: Heartbeat

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -14,11 +14,12 @@ on:
 
 jobs:
   heartbeat:
-    runs-on: ["self-hosted", ${{ matrix.runner }}]
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
-        runner: ["cuda"]
+        runner:
+          - ["self-hosted", "cuda"]
 
     steps:
       - name: Heartbeat

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -9,7 +9,7 @@ name: CI self-hosted runners heartbeat
 
 on:
   schedule:
-    - cron: "0 1 1,15" # every 1st and 15th of the month at 1am UTC
+    - cron: "0 1 1,15 * *" # every 1st and 15th of the month at 1am UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+# Send a dummy job to the custom runners every two weeks to keep them alive.
+# See https://github.com/actions/runner/issues/756 .
+
+name: CI self-hosted runners heartbeat
+
+on:
+  schedule:
+    - cron: "0 1 1,15" # every 1st and 15th of the month at 1am UTC
+  workflow_dispatch:
+
+jobs:
+  heartbeat:
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      matrix:
+        runner:
+          - [self-hosted, cuda]
+
+    steps:
+      - name: Heartbeat
+        run: echo "Runner is alive"

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -14,12 +14,7 @@ on:
 
 jobs:
   heartbeat:
-    runs-on: ${{ matrix.runner }}
-
-    strategy:
-      matrix:
-        runner:
-          - [self-hosted, cuda]
+    runs-on: "self-hosted"
 
     steps:
       - name: Heartbeat


### PR DESCRIPTION
This PR uses a simple way to prevent any self-hosted runner to shutdown if not used for 30 consecutive days (as discussed in [this issue](https://github.com/actions/runner/issues/756)). It schedules a dummy job to execute on this runner twice a month