### PR TITLE
add missing execution space in mdrange

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -85,8 +85,8 @@ void _roll(const ExecutionSpace& exec_space, ViewType& inout,
   using point_type = typename range_type::point_type;
 
   range_type range(
-      point_type{{0, 0}}, point_type{{len0, len1}}, tile_type{{4, 4}}
-      // [TO DO] Choose optimal tile sizes for each device
+      exec_space, point_type{{0, 0}}, point_type{{len0, len1}},
+      tile_type{{4, 4}}  // [TO DO] Choose optimal tile sizes for each device
   );
 
   axis_type<2> shift0 = {0}, shift1 = {0}, shift2 = {n0 / 2, n1 / 2};
@@ -179,7 +179,7 @@ namespace KokkosFFT {
 ///
 /// \return Sampling frequency
 template <typename ExecutionSpace, typename RealType>
-auto fftfreq(const ExecutionSpace& exec_space, const std::size_t n,
+auto fftfreq(const ExecutionSpace&, const std::size_t n,
              const RealType d = 1.0) {
   static_assert(std::is_floating_point<RealType>::value,
                 "fftfreq: d must be float or double");
@@ -214,7 +214,7 @@ auto fftfreq(const ExecutionSpace& exec_space, const std::size_t n,
 ///
 /// \return Sampling frequency starting from zero
 template <typename ExecutionSpace, typename RealType>
-auto rfftfreq(const ExecutionSpace& exec_space, const std::size_t n,
+auto rfftfreq(const ExecutionSpace&, const std::size_t n,
               const RealType d = 1.0) {
   static_assert(std::is_floating_point<RealType>::value,
                 "fftfreq: d must be float or double");

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -179,7 +179,7 @@ namespace KokkosFFT {
 ///
 /// \return Sampling frequency
 template <typename ExecutionSpace, typename RealType>
-auto fftfreq(const ExecutionSpace&, const std::size_t n,
+auto fftfreq(const ExecutionSpace& exec_space, const std::size_t n,
              const RealType d = 1.0) {
   static_assert(std::is_floating_point<RealType>::value,
                 "fftfreq: d must be float or double");
@@ -214,7 +214,7 @@ auto fftfreq(const ExecutionSpace&, const std::size_t n,
 ///
 /// \return Sampling frequency starting from zero
 template <typename ExecutionSpace, typename RealType>
-auto rfftfreq(const ExecutionSpace&, const std::size_t n,
+auto rfftfreq(const ExecutionSpace& exec_space, const std::size_t n,
               const RealType d = 1.0) {
   static_assert(std::is_floating_point<RealType>::value,
                 "fftfreq: d must be float or double");

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -133,8 +133,9 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0}}, point_type{{n0, n1}}, tile_type{{4, 4}}
-                   // [TO DO] Choose optimal tile sizes for each device
+  range_type range(
+      exec_space, point_type{{0, 0}}, point_type{{n0, n1}}, tile_type{{4, 4}}
+      // [TO DO] Choose optimal tile sizes for each device
   );
 
   Kokkos::parallel_for(
@@ -160,8 +161,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using point_type = typename range_type::point_type;
 
   range_type range(
-      point_type{{0, 0, 0}}, point_type{{n0, n1, n2}}, tile_type{{4, 4, 4}}
-      // [TO DO] Choose optimal tile sizes for each device
+      exec_space, point_type{{0, 0, 0}}, point_type{{n0, n1, n2}},
+      tile_type{{4, 4, 4}}  // [TO DO] Choose optimal tile sizes for each device
   );
 
   Kokkos::parallel_for(
@@ -189,8 +190,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0, 0, 0}}, point_type{{n0, n1, n2, n3}},
-                   tile_type{{4, 4, 4, 4}}
+  range_type range(exec_space, point_type{{0, 0, 0, 0}},
+                   point_type{{n0, n1, n2, n3}}, tile_type{{4, 4, 4, 4}}
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
@@ -220,7 +221,7 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4}}, tile_type{{4, 4, 4, 4, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
   );
@@ -252,7 +253,7 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
@@ -286,7 +287,7 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
@@ -323,7 +324,7 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   using tile_type  = typename range_type::tile_type;
   using point_type = typename range_type::point_type;
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -113,8 +113,8 @@ void _prep_transpose_view(InViewType& in, OutViewType& out,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::enable_if_t<InViewType::rank() == 1, std::nullptr_t> = nullptr>
-void _transpose(const ExecutionSpace& exec_space, InViewType& in,
-                OutViewType& out, [[maybe_unused]] axis_type<1> _map) {}
+void _transpose(const ExecutionSpace&, InViewType& in, OutViewType& out,
+                [[maybe_unused]] axis_type<1> _map) {}
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void _transpose(const ExecutionSpace& exec_space, InViewType& in,
@@ -131,8 +131,9 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
 
   int n0 = in.extent(0), n1 = in.extent(1);
 
-  range_type range(point_type{{0, 0}}, point_type{{n0, n1}}, tile_type{{4, 4}}
-                   // [TO DO] Choose optimal tile sizes for each device
+  range_type range(
+      exec_space, point_type{{0, 0}}, point_type{{n0, n1}}, tile_type{{4, 4}}
+      // [TO DO] Choose optimal tile sizes for each device
   );
 
   _prep_transpose_view(in, out, _map);
@@ -157,8 +158,8 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
   int n0 = in.extent(0), n1 = in.extent(1), n2 = in.extent(2);
 
   range_type range(
-      point_type{{0, 0, 0}}, point_type{{n0, n1, n2}}, tile_type{{4, 4, 4}}
-      // [TO DO] Choose optimal tile sizes for each device
+      exec_space, point_type{{0, 0, 0}}, point_type{{n0, n1, n2}},
+      tile_type{{4, 4, 4}}  // [TO DO] Choose optimal tile sizes for each device
   );
 
   _prep_transpose_view(in, out, _map);
@@ -191,8 +192,8 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
   int n0 = in.extent(0), n1 = in.extent(1), n2 = in.extent(2),
       n3 = in.extent(3);
 
-  range_type range(point_type{{0, 0, 0, 0}}, point_type{{n0, n1, n2, n3}},
-                   tile_type{{4, 4, 4, 4}}
+  range_type range(exec_space, point_type{{0, 0, 0, 0}},
+                   point_type{{n0, n1, n2, n3}}, tile_type{{4, 4, 4, 4}}
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
@@ -228,7 +229,7 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
       n3 = in.extent(3);
   int n4 = in.extent(4);
 
-  range_type range(point_type{{0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4}}, tile_type{{4, 4, 4, 4, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
   );
@@ -266,7 +267,7 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
       n3 = in.extent(3);
   int n4 = in.extent(4), n5 = in.extent(5);
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
@@ -307,7 +308,7 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
       n3 = in.extent(3);
   int n4 = in.extent(4), n5 = in.extent(5), n6 = in.extent(6);
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device
@@ -354,7 +355,7 @@ void _transpose(const ExecutionSpace& exec_space, InViewType& in,
   int n4 = in.extent(4), n5 = in.extent(5), n6 = in.extent(6),
       n7 = in.extent(7);
 
-  range_type range(point_type{{0, 0, 0, 0, 0, 0}},
+  range_type range(exec_space, point_type{{0, 0, 0, 0, 0, 0}},
                    point_type{{n0, n1, n2, n3, n4, n5}},
                    tile_type{{4, 4, 4, 4, 1, 1}}
                    // [TO DO] Choose optimal tile sizes for each device

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -113,8 +113,8 @@ void _prep_transpose_view(InViewType& in, OutViewType& out,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::enable_if_t<InViewType::rank() == 1, std::nullptr_t> = nullptr>
-void _transpose(const ExecutionSpace&, InViewType& in, OutViewType& out,
-                [[maybe_unused]] axis_type<1> _map) {}
+void _transpose(const ExecutionSpace& exec_space, InViewType& in,
+                OutViewType& out, [[maybe_unused]] axis_type<1> _map) {}
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void _transpose(const ExecutionSpace& exec_space, InViewType& in,


### PR DESCRIPTION
This PR aims at fixing bugs about execution space in MDRange in some internal helpers.
For example, following modifications are made

```C++
// Previous, exec_space was missing
range_type range(
    point_type{{0, 0}}, point_type{{len0, len1}}, tile_type{{4, 4}}
    // [TO DO] Choose optimal tile sizes for each device
 );

// After fix
range_type range(
    exec_space, point_type{{0, 0}}, point_type{{len0, len1}},
    tile_type{{4, 4}}  // [TO DO] Choose optimal tile sizes for each device
);
```