### PR TITLE
Cleaning up some warnings and enabling -Werror on AMD GPU CI tests

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -105,7 +105,7 @@ jobs:
               cxx: hipcc
             cmake_flags:
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DKokkosFFT_ENABLE_ROCFFT=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DKokkosFFT_ENABLE_ROCFFT=ON
           - name: rocm
             image: rocm
             compiler:
@@ -113,7 +113,7 @@ jobs:
               cxx: hipcc
             cmake_flags:
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: ""
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
           - name: sycl
             image: intel
             compiler:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -105,7 +105,7 @@ jobs:
               cxx: hipcc
             cmake_flags:
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DKokkosFFT_ENABLE_ROCFFT=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
           - name: rocm
             image: rocm
             compiler:
@@ -113,7 +113,7 @@ jobs:
               cxx: hipcc
             cmake_flags:
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
           - name: sycl
             image: intel
             compiler:

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -201,7 +201,9 @@ void _destroy_plan(std::unique_ptr<PlanType>& plan) {
 template <typename ExecutionSpace, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void _destroy_info(InfoType& plan) {}
+void _destroy_info(InfoType&) {
+  // not used, no finalization is required
+}
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_OpenMP_plans.hpp
+++ b/fft/src/KokkosFFT_OpenMP_plans.hpp
@@ -12,7 +12,7 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename ExecutionSpace, typename T>
-void _init_threads(const ExecutionSpace& exec_space) {
+void _init_threads([[maybe_unused]] const ExecutionSpace& exec_space) {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
   int nthreads = exec_space.concurrency();
 

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -100,7 +100,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   static_assert(
       InViewType::rank() >= fft_rank,
       "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
-  const int rank = fft_rank;
 
   constexpr auto type =
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
@@ -113,11 +112,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
                               std::multiplies<>());
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  auto* idata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-      ExecutionSpace, in_value_type>::type*>(in.data());
-  auto* odata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-      ExecutionSpace, out_value_type>::type*>(out.data());
 
   // For the moment, considering the contiguous layout only
   // Create plan
@@ -211,7 +205,6 @@ template <typename ExecutionSpace, typename InfoType,
 void _destroy_info(InfoType& execution_info) {
   rocfft_execution_info_destroy(execution_info);
 }
-
 }  // namespace Impl
 }  // namespace KokkosFFT
 


### PR DESCRIPTION
Improve https://github.com/kokkos/kokkos-fft/issues/106.

- Cleaning hipcc warnings on AMD GPUs
- Enabling warnings and warning as error (`-Werror`)