### PR TITLE
Cleaning up some warnings and enabling -Werror on NVIDIA GPU CI tests

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -96,8 +96,8 @@ jobs:
               c: gcc
               cxx: g++
             cmake_flags:
-              kokkos: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
-              kokkos_fft: ""
+              kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
           - name: hip
             image: rocm
             compiler:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -96,7 +96,7 @@ jobs:
               c: gcc
               cxx: g++
             cmake_flags:
-              kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+              kokkos: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
               kokkos_fft: ""
           - name: hip
             image: rocm

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -73,7 +73,7 @@ auto get_map_axes(const ViewType& view, axis_type<DIM> _axes) {
     map_inv.push_back(get_index(map, i));
   }
 
-  using full_axis_type = axis_type<rank>;
+  using full_axis_type     = axis_type<rank>;
   full_axis_type array_map = {0}, array_map_inv = {0};
   std::copy(map.begin(), map.end(), array_map.begin());
   std::copy(map_inv.begin(), map_inv.end(), array_map_inv.begin());

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -74,7 +74,7 @@ auto get_map_axes(const ViewType& view, axis_type<DIM> _axes) {
   }
 
   using full_axis_type = axis_type<rank>;
-  full_axis_type array_map, array_map_inv;
+  full_axis_type array_map = {0}, array_map_inv = {0};
   std::copy(map.begin(), map.end(), array_map.begin());
   std::copy(map_inv.begin(), map_inv.end(), array_map_inv.begin());
 

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -194,7 +194,9 @@ void _destroy_plan(std::unique_ptr<PlanType>& plan) {
 template <typename ExecutionSpace, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-void _destroy_info(InfoType& plan) {}
+void _destroy_info(InfoType&) {
+  // not used, no finalization is required
+}
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_OpenMP_plans.hpp
+++ b/fft/src/KokkosFFT_OpenMP_plans.hpp
@@ -73,7 +73,8 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-  auto sign = KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
+  [[maybe_unused]] auto sign =
+      KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
 
   plan = std::make_unique<PlanType>();
   if constexpr (type == KokkosFFT::Impl::FFTWTransformType::R2C) {


### PR DESCRIPTION
Improve https://github.com/kokkos/kokkos-fft/issues/106.

- Cleaning nvcc warnings on NVIDIA GPUs
- Enabling warnings and warning as error (`-Werror`)