### PR TITLE
Cleaning up some warnings and enabling -Werror on Intel GPU CI tests

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -123,7 +123,7 @@ jobs:
               # building for Intel PVC was unsuccessful without the proper
               # device, so for now, we simply generate generic Intel GPU code
               kokkos: -DKokkos_ENABLE_SYCL=ON -DKokkos_ARCH_INTEL_GEN=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
         target:
           - name: native
             cmake_flags: ""

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -123,7 +123,7 @@ jobs:
               # building for Intel PVC was unsuccessful without the proper
               # device, so for now, we simply generate generic Intel GPU code
               kokkos: -DKokkos_ENABLE_SYCL=ON -DKokkos_ARCH_INTEL_GEN=ON
-              kokkos_fft: ""
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
         target:
           - name: native
             cmake_flags: ""

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -18,10 +18,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<1> axes,
              shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -57,10 +55,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<2> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<2> axes,
              shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -96,10 +92,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<3> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<3> axes,
              shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -137,10 +131,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
              shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -11,8 +11,7 @@ namespace KokkosFFT {
 namespace Impl {
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
-                  [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecR2C(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecR2C failed");
@@ -20,8 +19,7 @@ inline void _exec(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
 
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftDoubleReal* idata,
-                  cufftDoubleComplex* odata, [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  cufftDoubleComplex* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecD2Z(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecD2Z failed");
@@ -29,8 +27,7 @@ inline void _exec(cufftHandle& plan, cufftDoubleReal* idata,
 
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
-                  [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecC2R(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecC2R failed");
@@ -38,8 +35,7 @@ inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
 
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftDoubleComplex* idata,
-                  cufftDoubleReal* odata, [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  cufftDoubleReal* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecZ2D(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecZ2D failed");
@@ -47,7 +43,7 @@ inline void _exec(cufftHandle& plan, cufftDoubleComplex* idata,
 
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftComplex* odata,
-                  int direction, [[maybe_unused]] Args... args) {
+                  int direction, Args...) {
   cufftResult cufft_rt = cufftExecC2C(plan, idata, odata, direction);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecC2C failed");
@@ -55,8 +51,7 @@ inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftComplex* odata,
 
 template <typename... Args>
 inline void _exec(cufftHandle& plan, cufftDoubleComplex* idata,
-                  cufftDoubleComplex* odata, int direction,
-                  [[maybe_unused]] Args... args) {
+                  cufftDoubleComplex* odata, int direction, Args...) {
   cufftResult cufft_rt = cufftExecZ2Z(plan, idata, odata, direction);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecZ2Z failed");

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -18,10 +18,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<1> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<1> axes,
              shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -59,10 +57,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<2> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<2> axes,
              shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -100,10 +96,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<3> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<3> axes,
              shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -143,10 +137,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
              shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -11,8 +11,7 @@ namespace KokkosFFT {
 namespace Impl {
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftReal* idata, hipfftComplex* odata,
-                  [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecR2C(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecR2C failed");
@@ -20,8 +19,7 @@ inline void _exec(hipfftHandle& plan, hipfftReal* idata, hipfftComplex* odata,
 
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftDoubleReal* idata,
-                  hipfftDoubleComplex* odata, [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  hipfftDoubleComplex* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecD2Z(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecD2Z failed");
@@ -29,8 +27,7 @@ inline void _exec(hipfftHandle& plan, hipfftDoubleReal* idata,
 
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftComplex* idata, hipfftReal* odata,
-                  [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2R(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecC2R failed");
@@ -38,8 +35,7 @@ inline void _exec(hipfftHandle& plan, hipfftComplex* idata, hipfftReal* odata,
 
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                  hipfftDoubleReal* odata, [[maybe_unused]] int direction,
-                  [[maybe_unused]] Args... args) {
+                  hipfftDoubleReal* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2D(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecZ2D failed");
@@ -47,8 +43,7 @@ inline void _exec(hipfftHandle& plan, hipfftDoubleComplex* idata,
 
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftComplex* idata,
-                  hipfftComplex* odata, int direction,
-                  [[maybe_unused]] Args... args) {
+                  hipfftComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2C(plan, idata, odata, direction);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecC2C failed");
@@ -56,8 +51,7 @@ inline void _exec(hipfftHandle& plan, hipfftComplex* idata,
 
 template <typename... Args>
 inline void _exec(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                  hipfftDoubleComplex* odata, int direction,
-                  [[maybe_unused]] Args... args) {
+                  hipfftDoubleComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2Z(plan, idata, odata, direction);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecZ2Z failed");

--- a/fft/src/KokkosFFT_OpenMP_plans.hpp
+++ b/fft/src/KokkosFFT_OpenMP_plans.hpp
@@ -34,11 +34,9 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
               std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
               std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
-             shape_type<fft_rank> s) {
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, [[maybe_unused]] Direction direction,
+             axis_type<fft_rank> axes, shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,

--- a/fft/src/KokkosFFT_OpenMP_transform.hpp
+++ b/fft/src/KokkosFFT_OpenMP_transform.hpp
@@ -11,37 +11,37 @@ namespace KokkosFFT {
 namespace Impl {
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, float* idata, fftwf_complex* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftwf_execute_dft_r2c(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, double* idata, fftw_complex* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftw_execute_dft_r2c(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, fftwf_complex* idata, float* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftwf_execute_dft_c2r(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, fftw_complex* idata, double* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftw_execute_dft_c2r(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType& plan, fftwf_complex* idata, fftwf_complex* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftwf_execute_dft(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
 void _exec(PlanType plan, fftw_complex* idata, fftw_complex* odata,
-           [[maybe_unused]] int direction, [[maybe_unused]] Args... args) {
+           int /*direction*/, Args...) {
   fftw_execute_dft(plan, idata, odata);
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -88,7 +88,7 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
              const InViewType& in, const OutViewType& out,
              BufferViewType& buffer, InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             Direction direction, axis_type<fft_rank> axes,
              shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -11,7 +11,7 @@
 namespace KokkosFFT {
 namespace Impl {
 inline void _exec(rocfft_plan& plan, float* idata, std::complex<float>* odata,
-                  [[maybe_unused]] int direction,
+                  int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
@@ -20,7 +20,7 @@ inline void _exec(rocfft_plan& plan, float* idata, std::complex<float>* odata,
 }
 
 inline void _exec(rocfft_plan& plan, double* idata, std::complex<double>* odata,
-                  [[maybe_unused]] int direction,
+                  int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
@@ -29,7 +29,7 @@ inline void _exec(rocfft_plan& plan, double* idata, std::complex<double>* odata,
 }
 
 inline void _exec(rocfft_plan& plan, std::complex<float>* idata, float* odata,
-                  [[maybe_unused]] int direction,
+                  int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
@@ -38,7 +38,7 @@ inline void _exec(rocfft_plan& plan, std::complex<float>* idata, float* odata,
 }
 
 inline void _exec(rocfft_plan& plan, std::complex<double>* idata, double* odata,
-                  [[maybe_unused]] int direction,
+                  int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
@@ -47,7 +47,7 @@ inline void _exec(rocfft_plan& plan, std::complex<double>* idata, double* odata,
 }
 
 inline void _exec(rocfft_plan& plan, std::complex<float>* idata,
-                  std::complex<float>* odata, [[maybe_unused]] int direction,
+                  std::complex<float>* odata, int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
@@ -56,7 +56,7 @@ inline void _exec(rocfft_plan& plan, std::complex<float>* idata,
 }
 
 inline void _exec(rocfft_plan& plan, std::complex<double>* idata,
-                  std::complex<double>* odata, [[maybe_unused]] int direction,
+                  std::complex<double>* odata, int /*direction*/,
                   const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -49,10 +49,8 @@ template <
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
 auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             [[maybe_unused]] BufferViewType& buffer,
-             [[maybe_unused]] InfoType& execution_info,
-             [[maybe_unused]] Direction direction, axis_type<fft_rank> axes,
+             const InViewType& in, const OutViewType& out, BufferViewType&,
+             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
              shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
                 "KokkosFFT::_create: InViewType is not a Kokkos::View.");
@@ -76,9 +74,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
                               std::multiplies<>());
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  // For the moment, considering the contiguous layout only
-  auto sign = KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
 
   // Create plan
   auto in_strides   = compute_strides<int, std::int64_t>(in_extents);

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -63,9 +63,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
       InViewType::rank() >= fft_rank,
       "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
 
-  constexpr auto type =
-      KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
-                                      out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
       KokkosFFT::Impl::get_extents(in, out, axes, s);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -64,7 +64,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   static_assert(
       InViewType::rank() >= fft_rank,
       "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
-  const int rank = fft_rank;
 
   constexpr auto type =
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
@@ -77,11 +76,6 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
                               std::multiplies<>());
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  auto* idata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-      ExecutionSpace, in_value_type>::type*>(in.data());
-  auto* odata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-      ExecutionSpace, out_value_type>::type*>(out.data());
 
   // For the moment, considering the contiguous layout only
   auto sign = KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
@@ -118,18 +112,21 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   return fft_size;
 }
 
-// In oneMKL, plans are destroybed by destructor
 template <
     typename ExecutionSpace, typename PlanType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void _destroy_plan(std::unique_ptr<PlanType>& plan) {}
+void _destroy_plan(std::unique_ptr<PlanType>&) {
+  // In oneMKL, plans are destroybed by destructor
+}
 
 template <
     typename ExecutionSpace, typename InfoType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void _destroy_info(InfoType& plan) {}
+void _destroy_info(InfoType) {
+  // not used, no finalization is required
+}
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -119,7 +119,7 @@ template <
     typename ExecutionSpace, typename InfoType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void _destroy_info(InfoType) {
+void _destroy_info(InfoType&) {
   // not used, no finalization is required
 }
 }  // namespace Impl


### PR DESCRIPTION
Resolves https://github.com/kokkos/kokkos-fft/issues/106.

- Cleaning icpx warnings on Intel GPUs
- Enabling warnings, but cannot use `-Werror` because there are already many warnings from Kokkos