### PR TITLE
README: drop unofficial and call it experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ cmake --build build -j 8
 This way, all the functionalities are executed on A100 GPUs. For installation, details are provided in the [documentation](https://kokkosfft.readthedocs.io/en/latest/intro/building.html#install-kokkosfft-as-a-library).
 
 ## LICENCE
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache--2.0_WITH_LLVM--exception-blue)](https://spdx.org/licenses/LLVM-exception.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Kokkos-FFT is distributed under either the MIT license, or at your option, the Apache-2.0 licence with LLVM exception.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 [![docs](https://readthedocs.org/projects/kokkosfft/badge/?version=latest)](https://kokkosfft.readthedocs.io/en/latest/?badge=latest)
 
 > [!WARNING]
-> UNOFFICIAL FFT interfaces for Kokkos C++ Performance Portability Programming EcoSystem
+> EXPERIMENTAL FFT interfaces for Kokkos C++ Performance Portability Programming EcoSystem
 
 Kokkos-fft implements local interfaces between [Kokkos](https://github.com/kokkos/kokkos) and de facto standard FFT libraries, including [fftw](http://www.fftw.org), [cufft](https://developer.nvidia.com/cufft), [hipfft](https://github.com/ROCm/hipFFT) ([rocfft](https://github.com/ROCm/rocFFT)), and [oneMKL](https://spec.oneapi.io/versions/latest/elements/oneMKL/source/index.html). "Local" means not using MPI, or running within a single MPI process without knowing about MPI. We are inclined to implement the [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html)-like interfaces adapted for [Kokkos](https://github.com/kokkos/kokkos).
 A key concept is that **"As easy as numpy, as fast as vendor libraries"**. Accordingly, our API follows the API by [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html) with minor differences. A fft library dedicated to Kokkos Device backend (e.g. [cufft](https://developer.nvidia.com/cufft) for CUDA backend) is automatically used. If something is wrong with runtime values (say `View` extents), it will raise runtime errors (C++ exceptions or assertions). See [documentations](https://kokkosfft.readthedocs.io/) for more information.


### PR DESCRIPTION
In this PR, we have updated README.md.

- Modify the warning message as UNOFFICIAL to EXPERIMENTAL.
- Fix the license badge to `Apache--2.0_WITH_LLVM--exception`