### PR TITLE
Rename: KokkosFFT_OpenMP*.hpp to KokkosFFT_Host*.hpp for fftw backend

### DIFF
--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#ifndef KOKKOSFFT_OPENMP_PLANS_HPP
-#define KOKKOSFFT_OPENMP_PLANS_HPP
+#ifndef KOKKOSFFT_HOST_PLANS_HPP
+#define KOKKOSFFT_HOST_PLANS_HPP
 
 #include <numeric>
 #include "KokkosFFT_default_types.hpp"

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#ifndef KOKKOSFFT_OPENMP_TRANSFORM_HPP
-#define KOKKOSFFT_OPENMP_TRANSFORM_HPP
+#ifndef KOKKOSFFT_HOST_TRANSFORM_HPP
+#define KOKKOSFFT_HOST_TRANSFORM_HPP
 
 #include <fftw3.h>
 

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#ifndef KOKKOSFFT_OPENMP_TYPES_HPP
-#define KOKKOSFFT_OPENMP_TYPES_HPP
+#ifndef KOKKOSFFT_HOST_TYPES_HPP
+#define KOKKOSFFT_HOST_TYPES_HPP
 
 #include <fftw3.h>
 #include "KokkosFFT_common_types.hpp"

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -20,7 +20,7 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 #include "KokkosFFT_Cuda_plans.hpp"
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_HIP)
 #if defined(KOKKOSFFT_ENABLE_TPL_ROCFFT)
@@ -29,19 +29,19 @@
 #include "KokkosFFT_HIP_plans.hpp"
 #endif
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_SYCL)
 #include "KokkosFFT_SYCL_plans.hpp"
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_OPENMP)
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #elif defined(KOKKOS_ENABLE_THREADS)
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #else
-#include "KokkosFFT_OpenMP_plans.hpp"
+#include "KokkosFFT_Host_plans.hpp"
 #endif
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -16,7 +16,7 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 #include "KokkosFFT_Cuda_transform.hpp"
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_HIP)
 #if defined(KOKKOSFFT_ENABLE_TPL_ROCFFT)
@@ -25,19 +25,19 @@
 #include "KokkosFFT_HIP_transform.hpp"
 #endif
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_SYCL)
 #include "KokkosFFT_SYCL_transform.hpp"
 #ifdef ENABLE_HOST_AND_DEVICE
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_OPENMP)
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #elif defined(KOKKOS_ENABLE_THREADS)
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #else
-#include "KokkosFFT_OpenMP_transform.hpp"
+#include "KokkosFFT_Host_transform.hpp"
 #endif
 
 #include <type_traits>

--- a/fft/src/KokkosFFT_default_types.hpp
+++ b/fft/src/KokkosFFT_default_types.hpp
@@ -18,11 +18,11 @@
 #elif defined(KOKKOS_ENABLE_SYCL)
 #include "KokkosFFT_SYCL_types.hpp"
 #elif defined(KOKKOS_ENABLE_OPENMP)
-#include "KokkosFFT_OpenMP_types.hpp"
+#include "KokkosFFT_Host_types.hpp"
 #elif defined(KOKKOS_ENABLE_THREADS)
-#include "KokkosFFT_OpenMP_types.hpp"
+#include "KokkosFFT_Host_types.hpp"
 #else
-#include "KokkosFFT_OpenMP_types.hpp"
+#include "KokkosFFT_Host_types.hpp"
 #endif
 
 #include "KokkosFFT_utils.hpp"


### PR DESCRIPTION
Resolves #110 

Renaming files for fftw backend:
```
 rename fft/src/{KokkosFFT_OpenMP_plans.hpp => KokkosFFT_Host_plans.hpp} (98%)
 rename fft/src/{KokkosFFT_OpenMP_transform.hpp => KokkosFFT_Host_transform.hpp} (94%)
 rename fft/src/{KokkosFFT_OpenMP_types.hpp => KokkosFFT_Host_types.hpp} (97%)
```