### PR TITLE
Rename functions starting from under score

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -38,10 +38,10 @@ auto get_shift(const ViewType& inout, axis_type<DIM> _axes, int direction = 1) {
 }
 
 template <typename ExecutionSpace, typename ViewType>
-void roll_impl(const ExecutionSpace& exec_space, ViewType& inout,
-               axis_type<1> shift, axis_type<1>) {
+void roll(const ExecutionSpace& exec_space, ViewType& inout, axis_type<1> shift,
+          axis_type<1>) {
   // Last parameter is ignored but present for keeping the interface consistent
-  static_assert(ViewType::rank() == 1, "roll_impl: Rank of View must be 1.");
+  static_assert(ViewType::rank() == 1, "roll: Rank of View must be 1.");
   std::size_t n0 = inout.extent(0);
 
   ViewType tmp("tmp", n0);
@@ -68,10 +68,10 @@ void roll_impl(const ExecutionSpace& exec_space, ViewType& inout,
 }
 
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM1 = 1>
-void roll_impl(const ExecutionSpace& exec_space, ViewType& inout,
-               axis_type<2> shift, axis_type<DIM1> axes) {
+void roll(const ExecutionSpace& exec_space, ViewType& inout, axis_type<2> shift,
+          axis_type<DIM1> axes) {
   constexpr int DIM0 = 2;
-  static_assert(ViewType::rank() == DIM0, "roll_impl: Rank of View must be 2.");
+  static_assert(ViewType::rank() == DIM0, "roll: Rank of View must be 2.");
   int n0 = inout.extent(0), n1 = inout.extent(1);
 
   ViewType tmp("tmp", n0, n1);
@@ -145,7 +145,7 @@ void fftshift_impl(const ExecutionSpace& exec_space, ViewType& inout,
                 "fftshift_impl: Rank of View must be larger thane "
                 "or equal to the Rank of shift axes.");
   auto shift = get_shift(inout, axes);
-  roll_impl(exec_space, inout, shift, axes);
+  roll(exec_space, inout, shift, axes);
 }
 
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
@@ -165,7 +165,7 @@ void ifftshift_impl(const ExecutionSpace& exec_space, ViewType& inout,
                 "ifftshift_impl: Rank of View must be larger "
                 "thane or equal to the Rank of shift axes.");
   auto shift = get_shift(inout, axes, -1);
-  roll_impl(exec_space, inout, shift, axes);
+  roll(exec_space, inout, shift, axes);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -24,8 +24,8 @@ void normalize_impl(const ExecutionSpace& exec_space, ViewType& inout,
 }
 
 template <typename ViewType>
-auto coefficients_impl(ViewType, Direction direction,
-                       Normalization normalization, std::size_t fft_size) {
+auto get_coefficients(ViewType, Direction direction,
+                      Normalization normalization, std::size_t fft_size) {
   using value_type =
       KokkosFFT::Impl::real_type_t<typename ViewType::non_const_value_type>;
   value_type coef                    = 1;
@@ -63,7 +63,7 @@ void normalize(const ExecutionSpace& exec_space, ViewType& inout,
                Direction direction, Normalization normalization,
                std::size_t fft_size) {
   auto [coef, to_normalize] =
-      coefficients_impl(inout, direction, normalization, fft_size);
+      get_coefficients(inout, direction, normalization, fft_size);
   if (to_normalize) normalize_impl(exec_space, inout, coef);
 }
 

--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -12,8 +12,8 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename ExecutionSpace, typename ViewType, typename T>
-void _normalize(const ExecutionSpace& exec_space, ViewType& inout,
-                const T coef) {
+void normalize_impl(const ExecutionSpace& exec_space, ViewType& inout,
+                    const T coef) {
   std::size_t size = inout.size();
   auto* data       = inout.data();
 
@@ -24,8 +24,8 @@ void _normalize(const ExecutionSpace& exec_space, ViewType& inout,
 }
 
 template <typename ViewType>
-auto _coefficients(ViewType, Direction direction, Normalization normalization,
-                   std::size_t fft_size) {
+auto coefficients_impl(ViewType, Direction direction,
+                       Normalization normalization, std::size_t fft_size) {
   using value_type =
       KokkosFFT::Impl::real_type_t<typename ViewType::non_const_value_type>;
   value_type coef                    = 1;
@@ -63,8 +63,8 @@ void normalize(const ExecutionSpace& exec_space, ViewType& inout,
                Direction direction, Normalization normalization,
                std::size_t fft_size) {
   auto [coef, to_normalize] =
-      _coefficients(inout, direction, normalization, fft_size);
-  if (to_normalize) _normalize(exec_space, inout, coef);
+      coefficients_impl(inout, direction, normalization, fft_size);
+  if (to_normalize) normalize_impl(exec_space, inout, coef);
 }
 
 inline auto swap_direction(Normalization normalization) {

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -88,10 +88,8 @@ auto is_crop_or_pad_needed(const ViewType& view,
                 "is_crop_or_pad_needed: Rank of View must be equal to Rank "
                 "of extended shape.");
 
-  // [TO DO] Add a is_C2R arg. If is_C2R is true, then shape should be shape/2+1
   constexpr int rank = static_cast<int>(ViewType::rank());
-
-  bool not_same = false;
+  bool not_same      = false;
   for (int i = 0; i < rank; i++) {
     if (modified_shape.at(i) != view.extent(i)) {
       not_same = true;
@@ -103,8 +101,8 @@ auto is_crop_or_pad_needed(const ViewType& view,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<1> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<1> s) {
   auto _n0 = s.at(0);
   out      = OutViewType("out", _n0);
 
@@ -117,8 +115,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<2> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<2> s) {
   constexpr std::size_t DIM = 2;
 
   auto [_n0, _n1] = s;
@@ -143,8 +141,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<3> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<3> s) {
   constexpr std::size_t DIM = 3;
 
   auto [_n0, _n1, _n2] = s;
@@ -172,8 +170,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<4> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<4> s) {
   constexpr std::size_t DIM = 4;
 
   auto [_n0, _n1, _n2, _n3] = s;
@@ -202,8 +200,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<5> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<5> s) {
   constexpr std::size_t DIM = 5;
 
   auto [_n0, _n1, _n2, _n3, _n4] = s;
@@ -233,8 +231,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<6> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<6> s) {
   constexpr std::size_t DIM = 6;
 
   auto [_n0, _n1, _n2, _n3, _n4, _n5] = s;
@@ -266,8 +264,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<7> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<7> s) {
   constexpr std::size_t DIM = 6;
 
   auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = s;
@@ -302,8 +300,8 @@ void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
 }
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void _crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                  OutViewType& out, shape_type<8> s) {
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
+                      OutViewType& out, shape_type<8> s) {
   constexpr std::size_t DIM = 6;
 
   auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = s;
@@ -351,7 +349,7 @@ void crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(OutViewType::rank() == DIM,
                 "crop_or_pad: Rank of View must be equal to Rank "
                 "of extended shape.");
-  _crop_or_pad(exec_space, in, out, s);
+  crop_or_pad_impl(exec_space, in, out, s);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/common/unit_test/Test_Helpers.cpp
+++ b/common/unit_test/Test_Helpers.cpp
@@ -154,21 +154,21 @@ void test_get_shift(int direction) {
   KokkosFFT::axis_type<2> shift2_even_ref       = {direction * n_even / 2,
                                              direction * n2 / 2};
 
-  auto shift1_odd = KokkosFFT::Impl::_get_shift(
+  auto shift1_odd = KokkosFFT::Impl::get_shift(
       x1_odd, KokkosFFT::axis_type<1>({0}), direction);
-  auto shift1_even = KokkosFFT::Impl::_get_shift(
+  auto shift1_even = KokkosFFT::Impl::get_shift(
       x1_even, KokkosFFT::axis_type<1>({0}), direction);
-  auto shift1_axis0_odd = KokkosFFT::Impl::_get_shift(
+  auto shift1_axis0_odd = KokkosFFT::Impl::get_shift(
       x2_odd, KokkosFFT::axis_type<1>({0}), direction);
-  auto shift1_axis0_even = KokkosFFT::Impl::_get_shift(
+  auto shift1_axis0_even = KokkosFFT::Impl::get_shift(
       x2_even, KokkosFFT::axis_type<1>({0}), direction);
-  auto shift1_axis1_odd = KokkosFFT::Impl::_get_shift(
+  auto shift1_axis1_odd = KokkosFFT::Impl::get_shift(
       x2_odd, KokkosFFT::axis_type<1>({1}), direction);
-  auto shift1_axis1_even = KokkosFFT::Impl::_get_shift(
+  auto shift1_axis1_even = KokkosFFT::Impl::get_shift(
       x2_even, KokkosFFT::axis_type<1>({1}), direction);
-  auto shift2_odd = KokkosFFT::Impl::_get_shift(
+  auto shift2_odd = KokkosFFT::Impl::get_shift(
       x2_odd, KokkosFFT::axis_type<2>({0, 1}), direction);
-  auto shift2_even = KokkosFFT::Impl::_get_shift(
+  auto shift2_even = KokkosFFT::Impl::get_shift(
       x2_even, KokkosFFT::axis_type<2>({0, 1}), direction);
 
   EXPECT_TRUE(shift1_odd == shift1_odd_ref);

--- a/common/unit_test/Test_prep_transpose_view.cpp
+++ b/common/unit_test/Test_prep_transpose_view.cpp
@@ -42,7 +42,7 @@ void test_managed_prep_transpose_view() {
     InViewType in("in", layout);
     OutViewType out("out", layout);
     auto data_prev = out.data();
-    KokkosFFT::Impl::_prep_transpose_view(in, out, map);
+    KokkosFFT::Impl::prep_transpose_view(in, out, map);
     // ensure no allocation
     EXPECT_EQ(data_prev, out.data());
     // check shape
@@ -60,7 +60,7 @@ void test_managed_prep_transpose_view() {
     }
     InViewType in("in", layout);
     OutViewType out;
-    KokkosFFT::Impl::_prep_transpose_view(in, out, map);
+    KokkosFFT::Impl::prep_transpose_view(in, out, map);
     // check shape
     for (int i = 0; i < DIMS; ++i) {
       EXPECT_EQ(out.extent(i), 5);
@@ -96,7 +96,7 @@ void test_unmanaged_prep_transpose_view() {
     OutManagedViewType out("out", layout);
     OutViewType u_out(out.data(), layout);
     auto data_prev = out.data();
-    KokkosFFT::Impl::_prep_transpose_view(in, u_out, map);
+    KokkosFFT::Impl::prep_transpose_view(in, u_out, map);
     EXPECT_EQ(data_prev, u_out.data());
     // check shape
     for (int i = 0; i < DIMS; ++i) {
@@ -126,7 +126,7 @@ void test_unmanaged_prep_transpose_view() {
     InManagedViewType in("in", layout);
     OutManagedViewType out("out", layout_orig);
     OutViewType u_out(out.data(), layout_orig);
-    KokkosFFT::Impl::_prep_transpose_view(in, u_out, map);
+    KokkosFFT::Impl::prep_transpose_view(in, u_out, map);
     // check shape
     for (int i = 0; i < DIMS; ++i) {
       EXPECT_EQ(u_out.extent(i), 5);
@@ -148,7 +148,7 @@ void test_unmanaged_prep_transpose_view() {
     InManagedViewType in("in", layout);
     OutManagedViewType out("out", layout_orig);
     OutViewType u_out(out.data(), layout_orig);
-    EXPECT_THROW(KokkosFFT::Impl::_prep_transpose_view(in, u_out, map),
+    EXPECT_THROW(KokkosFFT::Impl::prep_transpose_view(in, u_out, map),
                  std::runtime_error);
   }
 }

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -177,11 +177,18 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType, typename InfoType,
+template <typename ExecutionSpace, typename PlanType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
+void destroy_plan(std::unique_ptr<PlanType>& plan) {
   cufftDestroy(*plan);
+}
+
+template <typename ExecutionSpace, typename InfoType,
+          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
+                           std::nullptr_t> = nullptr>
+void destroy_info(InfoType&) {
+  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -17,14 +17,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 1 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<1> axes,
-             shape_type<1> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -54,14 +54,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 2 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<2> axes,
-             shape_type<2> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -91,14 +91,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 3 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<3> axes,
-             shape_type<3> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -130,14 +130,15 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::size_t fft_rank             = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
-             shape_type<fft_rank> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<fft_rank> axes,
+                 shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -176,18 +177,11 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-void _destroy_plan(std::unique_ptr<PlanType>& plan) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   cufftDestroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
-                           std::nullptr_t> = nullptr>
-void _destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -10,48 +10,48 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
-                  int /*direction*/, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
+                      int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecR2C(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecR2C failed");
 }
 
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftDoubleReal* idata,
-                  cufftDoubleComplex* odata, int /*direction*/, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftDoubleReal* idata,
+                      cufftDoubleComplex* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecD2Z(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecD2Z failed");
 }
 
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
-                  int /*direction*/, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
+                      int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecC2R(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecC2R failed");
 }
 
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftDoubleComplex* idata,
-                  cufftDoubleReal* odata, int /*direction*/, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
+                      cufftDoubleReal* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecZ2D(plan, idata, odata);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecZ2D failed");
 }
 
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftComplex* idata, cufftComplex* odata,
-                  int direction, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftComplex* idata,
+                      cufftComplex* odata, int direction, Args...) {
   cufftResult cufft_rt = cufftExecC2C(plan, idata, odata, direction);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecC2C failed");
 }
 
 template <typename... Args>
-inline void _exec(cufftHandle& plan, cufftDoubleComplex* idata,
-                  cufftDoubleComplex* odata, int direction, Args...) {
+inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
+                      cufftDoubleComplex* odata, int direction, Args...) {
   cufftResult cufft_rt = cufftExecZ2Z(plan, idata, odata, direction);
   if (cufft_rt != CUFFT_SUCCESS)
     throw std::runtime_error("cufftExecZ2Z failed");

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -184,11 +184,18 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType, typename InfoType,
+template <typename ExecutionSpace, typename PlanType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
+void destroy_plan(std::unique_ptr<PlanType>& plan) {
   hipfftDestroy(*plan);
+}
+
+template <typename ExecutionSpace, typename InfoType,
+          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
+                           std::nullptr_t> = nullptr>
+void destroy_info(InfoType&) {
+  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -17,14 +17,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 1 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<1> axes,
-             shape_type<1> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -56,14 +56,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 2 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<2> axes,
-             shape_type<2> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -95,14 +95,14 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::enable_if_t<InViewType::rank() == 3 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<3> axes,
-             shape_type<3> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -136,20 +136,21 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::size_t fft_rank             = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
-             shape_type<fft_rank> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<fft_rank> axes,
+                 shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
   static_assert(
       InViewType::rank() >= fft_rank,
-      "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
+      "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
   const int rank = fft_rank;
   constexpr auto type =
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
@@ -183,18 +184,11 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void _destroy_plan(std::unique_ptr<PlanType>& plan) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   hipfftDestroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                           std::nullptr_t> = nullptr>
-void _destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -10,48 +10,48 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftReal* idata, hipfftComplex* odata,
-                  int /*direction*/, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftReal* idata,
+                      hipfftComplex* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecR2C(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecR2C failed");
 }
 
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftDoubleReal* idata,
-                  hipfftDoubleComplex* odata, int /*direction*/, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftDoubleReal* idata,
+                      hipfftDoubleComplex* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecD2Z(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecD2Z failed");
 }
 
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftComplex* idata, hipfftReal* odata,
-                  int /*direction*/, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
+                      hipfftReal* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2R(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecC2R failed");
 }
 
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                  hipfftDoubleReal* odata, int /*direction*/, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
+                      hipfftDoubleReal* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2D(plan, idata, odata);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecZ2D failed");
 }
 
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftComplex* idata,
-                  hipfftComplex* odata, int direction, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
+                      hipfftComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2C(plan, idata, odata, direction);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecC2C failed");
 }
 
 template <typename... Args>
-inline void _exec(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                  hipfftDoubleComplex* odata, int direction, Args...) {
+inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
+                      hipfftDoubleComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2Z(plan, idata, odata, direction);
   if (hipfft_rt != HIPFFT_SUCCESS)
     throw std::runtime_error("hipfftExecZ2Z failed");

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -105,11 +105,11 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType, typename InfoType,
+template <typename ExecutionSpace, typename PlanType,
           std::enable_if_t<
               std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
               std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
+void destroy_plan(std::unique_ptr<PlanType>& plan) {
   if constexpr (std::is_same_v<PlanType, fftwf_plan>) {
     fftwf_destroy_plan(*plan);
   } else {
@@ -117,6 +117,13 @@ void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   }
 }
 
+template <typename ExecutionSpace, typename InfoType,
+          std::enable_if_t<
+              std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
+              std::nullptr_t> = nullptr>
+void destroy_info(InfoType&) {
+  // not used, no finalization is required
+}
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -10,38 +10,38 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, float* idata, fftwf_complex* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, float* idata, fftwf_complex* odata,
+               int /*direction*/, Args...) {
   fftwf_execute_dft_r2c(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, double* idata, fftw_complex* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, double* idata, fftw_complex* odata,
+               int /*direction*/, Args...) {
   fftw_execute_dft_r2c(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, fftwf_complex* idata, float* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, fftwf_complex* idata, float* odata,
+               int /*direction*/, Args...) {
   fftwf_execute_dft_c2r(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, fftw_complex* idata, double* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, fftw_complex* idata, double* odata,
+               int /*direction*/, Args...) {
   fftw_execute_dft_c2r(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, fftwf_complex* idata, fftwf_complex* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, fftwf_complex* idata, fftwf_complex* odata,
+               int /*direction*/, Args...) {
   fftwf_execute_dft(plan, idata, odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType plan, fftw_complex* idata, fftw_complex* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType plan, fftw_complex* idata, fftw_complex* odata,
+               int /*direction*/, Args...) {
   fftw_execute_dft(plan, idata, odata);
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -285,8 +285,8 @@ class Plan {
   }
 
   ~Plan() {
-    destroy_plan_and_info<ExecutionSpace, fft_plan_type, fft_info_type>(m_plan,
-                                                                        m_info);
+    destroy_info<ExecutionSpace, fft_info_type>(m_info);
+    destroy_plan<ExecutionSpace, fft_plan_type>(m_plan);
   }
 
   Plan(const Plan&) = delete;

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -213,8 +213,8 @@ class Plan {
     m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
-    m_fft_size = KokkosFFT::Impl::_create(exec_space, m_plan, in, out, m_buffer,
-                                          m_info, direction, m_axes, s);
+    m_fft_size = KokkosFFT::Impl::create_plan(
+        exec_space, m_plan, in, out, m_buffer, m_info, direction, m_axes, s);
   }
 
   /// \brief Constructor for multidimensional FFT
@@ -280,13 +280,13 @@ class Plan {
     m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
-    m_fft_size = KokkosFFT::Impl::_create(exec_space, m_plan, in, out, m_buffer,
-                                          m_info, direction, axes, s);
+    m_fft_size = KokkosFFT::Impl::create_plan(
+        exec_space, m_plan, in, out, m_buffer, m_info, direction, axes, s);
   }
 
   ~Plan() {
-    _destroy_info<ExecutionSpace, fft_info_type>(m_info);
-    _destroy_plan<ExecutionSpace, fft_plan_type>(m_plan);
+    destroy_plan_and_info<ExecutionSpace, fft_plan_type, fft_info_type>(m_plan,
+                                                                        m_info);
   }
 
   Plan(const Plan&) = delete;

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -85,21 +85,21 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           std::size_t fft_rank             = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out,
-             BufferViewType& buffer, InfoType& execution_info,
-             Direction direction, axis_type<fft_rank> axes,
-             shape_type<fft_rank> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType& buffer,
+                 InfoType& execution_info, Direction direction,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
   static_assert(
       InViewType::rank() >= fft_rank,
-      "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
+      "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
 
   constexpr auto type =
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
@@ -192,18 +192,13 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void _destroy_plan(std::unique_ptr<PlanType>& plan) {
-  rocfft_plan_destroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                           std::nullptr_t> = nullptr>
-void _destroy_info(InfoType& execution_info) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan,
+                           InfoType& execution_info) {
   rocfft_execution_info_destroy(execution_info);
+  rocfft_plan_destroy(*plan);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -192,13 +192,18 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType, typename InfoType,
+template <typename ExecutionSpace, typename PlanType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>& plan,
-                           InfoType& execution_info) {
-  rocfft_execution_info_destroy(execution_info);
+void destroy_plan(std::unique_ptr<PlanType>& plan) {
   rocfft_plan_destroy(*plan);
+}
+
+template <typename ExecutionSpace, typename InfoType,
+          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
+                           std::nullptr_t> = nullptr>
+void destroy_info(InfoType& execution_info) {
+  rocfft_execution_info_destroy(execution_info);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -10,54 +10,54 @@
 
 namespace KokkosFFT {
 namespace Impl {
-inline void _exec(rocfft_plan& plan, float* idata, std::complex<float>* odata,
-                  int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, float* idata,
+                      std::complex<float>* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)
     throw std::runtime_error("rocfft_execute for R2C failed");
 }
 
-inline void _exec(rocfft_plan& plan, double* idata, std::complex<double>* odata,
-                  int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, double* idata,
+                      std::complex<double>* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)
     throw std::runtime_error("rocfft_execute for D2Z failed");
 }
 
-inline void _exec(rocfft_plan& plan, std::complex<float>* idata, float* odata,
-                  int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
+                      float* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)
     throw std::runtime_error("rocfft_execute for C2R failed");
 }
 
-inline void _exec(rocfft_plan& plan, std::complex<double>* idata, double* odata,
-                  int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
+                      double* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)
     throw std::runtime_error("rocfft_execute for Z2D failed");
 }
 
-inline void _exec(rocfft_plan& plan, std::complex<float>* idata,
-                  std::complex<float>* odata, int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
+                      std::complex<float>* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)
     throw std::runtime_error("rocfft_execute for C2C failed");
 }
 
-inline void _exec(rocfft_plan& plan, std::complex<double>* idata,
-                  std::complex<double>* odata, int /*direction*/,
-                  const rocfft_execution_info& execution_info) {
+inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
+                      std::complex<double>* odata, int /*direction*/,
+                      const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
   if (status != rocfft_status_success)

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -48,20 +48,21 @@ template <
     std::size_t fft_rank             = 1,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
-             const InViewType& in, const OutViewType& out, BufferViewType&,
-             InfoType&, Direction /*direction*/, axis_type<fft_rank> axes,
-             shape_type<fft_rank> s) {
+auto create_plan(const ExecutionSpace& exec_space,
+                 std::unique_ptr<PlanType>& plan, const InViewType& in,
+                 const OutViewType& out, BufferViewType&, InfoType&,
+                 Direction /*direction*/, axis_type<fft_rank> axes,
+                 shape_type<fft_rank> s) {
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: InViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: InViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<InViewType>::value,
-                "KokkosFFT::_create: OutViewType is not a Kokkos::View.");
+                "KokkosFFT::create_plan: OutViewType is not a Kokkos::View.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
   static_assert(
       InViewType::rank() >= fft_rank,
-      "KokkosFFT::_create: Rank of View must be larger than Rank of FFT.");
+      "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
 
   auto [in_extents, out_extents, fft_extents, howmany] =
       KokkosFFT::Impl::get_extents(in, out, axes, s);
@@ -105,19 +106,11 @@ auto _create(const ExecutionSpace& exec_space, std::unique_ptr<PlanType>& plan,
 }
 
 template <
-    typename ExecutionSpace, typename PlanType,
+    typename ExecutionSpace, typename PlanType, typename InfoType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void _destroy_plan(std::unique_ptr<PlanType>&) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>&, InfoType&) {
   // In oneMKL, plans are destroybed by destructor
-}
-
-template <
-    typename ExecutionSpace, typename InfoType,
-    std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
-                     std::nullptr_t> = nullptr>
-void _destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -106,11 +106,19 @@ auto create_plan(const ExecutionSpace& exec_space,
 }
 
 template <
-    typename ExecutionSpace, typename PlanType, typename InfoType,
+    typename ExecutionSpace, typename PlanType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>&, InfoType&) {
+void destroy_plan(std::unique_ptr<PlanType>&) {
   // In oneMKL, plans are destroybed by destructor
+}
+
+template <
+    typename ExecutionSpace, typename InfoType,
+    std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
+                     std::nullptr_t> = nullptr>
+void destroy_info(InfoType&) {
+  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_SYCL_transform.hpp
+++ b/fft/src/KokkosFFT_SYCL_transform.hpp
@@ -11,36 +11,36 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, float* idata, std::complex<float>* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, float* idata, std::complex<float>* odata,
+               int /*direction*/, Args...) {
   oneapi::mkl::dft::compute_forward(plan, idata,
                                     reinterpret_cast<float*>(odata));
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, double* idata, std::complex<double>* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, double* idata, std::complex<double>* odata,
+               int /*direction*/, Args...) {
   oneapi::mkl::dft::compute_forward(plan, idata,
                                     reinterpret_cast<double*>(odata));
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, std::complex<float>* idata, float* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, std::complex<float>* idata, float* odata,
+               int /*direction*/, Args...) {
   oneapi::mkl::dft::compute_backward(plan, reinterpret_cast<float*>(idata),
                                      odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, std::complex<double>* idata, double* odata,
-           int /*direction*/, Args...) {
+void exec_plan(PlanType& plan, std::complex<double>* idata, double* odata,
+               int /*direction*/, Args...) {
   oneapi::mkl::dft::compute_backward(plan, reinterpret_cast<double*>(idata),
                                      odata);
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, std::complex<float>* idata,
-           std::complex<float>* odata, int direction, Args...) {
+void exec_plan(PlanType& plan, std::complex<float>* idata,
+               std::complex<float>* odata, int direction, Args...) {
   if (direction == 1) {
     oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {
@@ -49,8 +49,8 @@ void _exec(PlanType& plan, std::complex<float>* idata,
 }
 
 template <typename PlanType, typename... Args>
-void _exec(PlanType& plan, std::complex<double>* idata,
-           std::complex<double>* odata, int direction, Args...) {
+void exec_plan(PlanType& plan, std::complex<double>* idata,
+               std::complex<double>* odata, int direction, Args...) {
   if (direction == 1) {
     oneapi::mkl::dft::compute_forward(plan, idata, odata);
   } else {

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -89,7 +89,7 @@ void exec_impl(
 
   auto const exec_space = plan.exec_space();
   auto const direction  = direction_type<ExecutionSpace>(plan.direction());
-  KokkosFFT::Impl::_exec(plan.plan(), idata, odata, direction, plan.info());
+  KokkosFFT::Impl::exec_plan(plan.plan(), idata, odata, direction, plan.info());
   KokkosFFT::Impl::normalize(exec_space, out, plan.direction(), norm,
                              plan.fft_size());
 }


### PR DESCRIPTION
Improves #81 

Following functions have been renamed

```
_get_shift => get_shift
_roll => roll_impl
_fftshift => fftshift_impl
_ifftshift => ifftshift_impl
_normalize => normalize_impl
_coefficients => coefficients_impl
_crop_or_pad => crop_or_pad_impl
_prep_transpose_view => prep_transpose_view
_transpose => transpose_impl
_create => create_plan
_init_threads => init_threads
_exec => exec_plan
_destroy_plan, _destroy_info => destroy_plan_and_info
```

After review, following changes are made.

```
_roll => roll
_coefficients => get_coefficients
_destroy_plan => destroy_plan
_destroy_info => destroy_info
```

