### PR TITLE
Simplify the cleanup of Plan class

### DIFF
--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -177,18 +177,11 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
-void destroy_plan(std::unique_ptr<PlanType>& plan) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   cufftDestroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
-                           std::nullptr_t> = nullptr>
-void destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -184,18 +184,11 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void destroy_plan(std::unique_ptr<PlanType>& plan) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   hipfftDestroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                           std::nullptr_t> = nullptr>
-void destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -105,24 +105,16 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<
               std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
               std::nullptr_t> = nullptr>
-void destroy_plan(std::unique_ptr<PlanType>& plan) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   if constexpr (std::is_same_v<PlanType, fftwf_plan>) {
     fftwf_destroy_plan(*plan);
   } else {
     fftw_destroy_plan(*plan);
   }
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<
-              std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
-              std::nullptr_t> = nullptr>
-void destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -285,8 +285,8 @@ class Plan {
   }
 
   ~Plan() {
-    destroy_info<ExecutionSpace, fft_info_type>(m_info);
-    destroy_plan<ExecutionSpace, fft_plan_type>(m_plan);
+    destroy_plan_and_info<ExecutionSpace, fft_plan_type, fft_info_type>(m_plan,
+                                                                        m_info);
   }
 
   Plan(const Plan&) = delete;

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -192,18 +192,13 @@ auto create_plan(const ExecutionSpace& exec_space,
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType,
+template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
-void destroy_plan(std::unique_ptr<PlanType>& plan) {
-  rocfft_plan_destroy(*plan);
-}
-
-template <typename ExecutionSpace, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                           std::nullptr_t> = nullptr>
-void destroy_info(InfoType& execution_info) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>& plan,
+                           InfoType& execution_info) {
   rocfft_execution_info_destroy(execution_info);
+  rocfft_plan_destroy(*plan);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -106,19 +106,11 @@ auto create_plan(const ExecutionSpace& exec_space,
 }
 
 template <
-    typename ExecutionSpace, typename PlanType,
+    typename ExecutionSpace, typename PlanType, typename InfoType,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
-void destroy_plan(std::unique_ptr<PlanType>&) {
+void destroy_plan_and_info(std::unique_ptr<PlanType>&, InfoType&) {
   // In oneMKL, plans are destroybed by destructor
-}
-
-template <
-    typename ExecutionSpace, typename InfoType,
-    std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
-                     std::nullptr_t> = nullptr>
-void destroy_info(InfoType&) {
-  // not used, no finalization is required
 }
 }  // namespace Impl
 }  // namespace KokkosFFT


### PR DESCRIPTION
This PR aims at simplifying the plan destruction. 

`destroy_plan` and `destroy_info` have been merged into `destroy_plan_and_info`
