### PR TITLE
Add traits to help type checks

### DIFF
--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -26,8 +26,8 @@ void normalize_impl(const ExecutionSpace& exec_space, ViewType& inout,
 template <typename ViewType>
 auto get_coefficients(ViewType, Direction direction,
                       Normalization normalization, std::size_t fft_size) {
-  using value_type =
-      KokkosFFT::Impl::real_type_t<typename ViewType::non_const_value_type>;
+  using value_type = KokkosFFT::Impl::base_floating_point_type<
+      typename ViewType::non_const_value_type>;
   value_type coef                    = 1;
   [[maybe_unused]] bool to_normalize = false;
 

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_TRAITS_HPP
+#define KOKKOSFFT_TRAITS_HPP
+
+#include <Kokkos_Core.hpp>
+#include <vector>
+#include <set>
+#include <algorithm>
+#include <numeric>
+
+namespace KokkosFFT {
+namespace Impl {
+template <typename T>
+struct real_type {
+  using type = T;
+};
+
+template <typename T>
+struct real_type<Kokkos::complex<T>> {
+  using type = T;
+};
+
+template <typename T>
+using real_type_t = typename real_type<T>::type;
+
+template <typename T, typename Enable = void>
+struct is_real : std::false_type {};
+
+template <typename T>
+struct is_real<
+    T, std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_real_v = is_real<T>::value;
+
+template <typename T, typename Enable = void>
+struct is_complex : std::false_type {};
+
+template <typename T>
+struct is_complex<
+    Kokkos::complex<T>,
+    std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_complex_v = is_complex<T>::value;
+
+// is value type admissible for KokkosFFT
+template <typename T, typename Enable = void>
+struct is_admissible_value_type : std::false_type {};
+
+template <typename T>
+struct is_admissible_value_type<
+    T, std::enable_if_t<is_real_v<T> || is_complex_v<T>>> : std::true_type {};
+
+template <typename T>
+struct is_admissible_value_type<
+    T, std::enable_if_t<Kokkos::is_view<T>::value &&
+                        (is_real_v<typename T::non_const_value_type> ||
+                         is_complex_v<typename T::non_const_value_type>)>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_admissible_value_type_v =
+    is_admissible_value_type<T>::value;
+
+// is layout admissible for KokkosFFT
+template <typename ViewType, typename Enable = void>
+struct is_layout_left_or_right : std::false_type {};
+
+template <typename ViewType>
+struct is_layout_left_or_right<
+    ViewType,
+    std::enable_if_t<
+        Kokkos::is_view<ViewType>::value &&
+        (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutLeft> ||
+         std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>)>>
+    : std::true_type {};
+
+template <typename ViewType>
+inline constexpr bool is_layout_left_or_right_v =
+    is_layout_left_or_right<ViewType>::value;
+
+// is view admissible for KokkosFFT
+template <typename ViewType, typename Enable = void>
+struct is_admissible_view : std::false_type {};
+
+template <typename ViewType>
+struct is_admissible_view<
+    ViewType, std::enable_if_t<Kokkos::is_view<ViewType>::value &&
+                               is_layout_left_or_right_v<ViewType> &&
+                               is_admissible_value_type_v<ViewType>>>
+    : std::true_type {};
+
+template <typename ViewType>
+inline constexpr bool is_admissible_view_v =
+    is_admissible_view<ViewType>::value;
+
+template <typename T>
+struct managable_view_type {
+  using type = Kokkos::View<typename T::data_type, typename T::array_layout,
+                            typename T::memory_space,
+                            Kokkos::MemoryTraits<T::memory_traits::impl_value &
+                                                 ~unsigned(Kokkos::Unmanaged)>>;
+};
+
+template <typename ExecutionSpace, typename ViewType,
+          std::enable_if_t<ViewType::rank() == 1, std::nullptr_t> = nullptr>
+struct complex_view_type {
+  using value_type        = typename ViewType::non_const_value_type;
+  using float_type        = KokkosFFT::Impl::real_type_t<value_type>;
+  using complex_type      = Kokkos::complex<float_type>;
+  using array_layout_type = typename ViewType::array_layout;
+  using type = Kokkos::View<complex_type*, array_layout_type, ExecutionSpace>;
+};
+
+}  // namespace Impl
+}  // namespace KokkosFFT
+
+#endif

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -6,25 +6,21 @@
 #define KOKKOSFFT_TRAITS_HPP
 
 #include <Kokkos_Core.hpp>
-#include <vector>
-#include <set>
-#include <algorithm>
-#include <numeric>
 
 namespace KokkosFFT {
 namespace Impl {
 template <typename T>
-struct real_type {
-  using type = T;
+struct base_floating_point {
+  using value_type = T;
 };
 
 template <typename T>
-struct real_type<Kokkos::complex<T>> {
-  using type = T;
+struct base_floating_point<Kokkos::complex<T>> {
+  using value_type = T;
 };
 
 template <typename T>
-using real_type_t = typename real_type<T>::type;
+using base_floating_point_type = typename base_floating_point<T>::value_type;
 
 template <typename T, typename Enable = void>
 struct is_real : std::false_type {};
@@ -111,9 +107,9 @@ struct managable_view_type {
 template <typename ExecutionSpace, typename ViewType,
           std::enable_if_t<ViewType::rank() == 1, std::nullptr_t> = nullptr>
 struct complex_view_type {
-  using value_type        = typename ViewType::non_const_value_type;
-  using float_type        = KokkosFFT::Impl::real_type_t<value_type>;
-  using complex_type      = Kokkos::complex<float_type>;
+  using value_type   = typename ViewType::non_const_value_type;
+  using float_type   = KokkosFFT::Impl::base_floating_point_type<value_type>;
+  using complex_type = Kokkos::complex<float_type>;
   using array_layout_type = typename ViewType::array_layout;
   using type = Kokkos::View<complex_type*, array_layout_type, ExecutionSpace>;
 };

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -19,6 +19,7 @@ struct base_floating_point<Kokkos::complex<T>> {
   using value_type = T;
 };
 
+/// \brief Helper to extract the base floating point type from a complex type
 template <typename T>
 using base_floating_point_type = typename base_floating_point<T>::value_type;
 
@@ -30,6 +31,8 @@ struct is_real<
     T, std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
     : std::true_type {};
 
+/// \brief Helper to check if a type is an acceptable real type (float/double)
+/// for Kokkos-FFT
 template <typename T>
 inline constexpr bool is_real_v = is_real<T>::value;
 
@@ -42,6 +45,8 @@ struct is_complex<
     std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
     : std::true_type {};
 
+/// \brief Helper to check if a type is an acceptable complex type
+/// (Kokkos::complex<float>/Kokkos::complex<double>) for Kokkos-FFT
 template <typename T>
 inline constexpr bool is_complex_v = is_complex<T>::value;
 
@@ -60,11 +65,14 @@ struct is_admissible_value_type<
                          is_complex_v<typename T::non_const_value_type>)>>
     : std::true_type {};
 
+/// \brief Helper to check if a type is an acceptable value type
+/// (float/double/Kokkos::complex<float>/Kokkos::complex<double>) for Kokkos-FFT
+///        When applied to Kokkos::View, then check if a value type is an
+///        acceptable real/complex type.
 template <typename T>
 inline constexpr bool is_admissible_value_type_v =
     is_admissible_value_type<T>::value;
 
-// is layout admissible for KokkosFFT
 template <typename ViewType, typename Enable = void>
 struct is_layout_left_or_right : std::false_type {};
 
@@ -77,11 +85,12 @@ struct is_layout_left_or_right<
          std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>)>>
     : std::true_type {};
 
+/// \brief Helper to check if a View layout is an acceptable layout type
+/// (Kokkos::LayoutLeft/Kokkos::LayoutRight) for Kokkos-FFT
 template <typename ViewType>
 inline constexpr bool is_layout_left_or_right_v =
     is_layout_left_or_right<ViewType>::value;
 
-// is view admissible for KokkosFFT
 template <typename ViewType, typename Enable = void>
 struct is_admissible_view : std::false_type {};
 
@@ -92,10 +101,13 @@ struct is_admissible_view<
                                is_admissible_value_type_v<ViewType>>>
     : std::true_type {};
 
+/// \brief Helper to check if a View is an acceptable for Kokkos-FFT. Values and
+/// layout are checked
 template <typename ViewType>
 inline constexpr bool is_admissible_view_v =
     is_admissible_view<ViewType>::value;
 
+/// \brief Helper to define a managable View type from the original view type
 template <typename T>
 struct managable_view_type {
   using type = Kokkos::View<typename T::data_type, typename T::array_layout,
@@ -104,6 +116,8 @@ struct managable_view_type {
                                                  ~unsigned(Kokkos::Unmanaged)>>;
 };
 
+/// \brief Helper to define a complex 1D View type from a real/complex 1D View
+/// type, while keeping other properties
 template <typename ExecutionSpace, typename ViewType,
           std::enable_if_t<ViewType::rank() == 1, std::nullptr_t> = nullptr>
 struct complex_view_type {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -10,60 +10,10 @@
 #include <set>
 #include <algorithm>
 #include <numeric>
+#include "KokkosFFT_traits.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename T>
-struct real_type {
-  using type = T;
-};
-
-template <typename T>
-struct real_type<Kokkos::complex<T>> {
-  using type = T;
-};
-
-template <typename T>
-struct managable_view_type {
-  using type = Kokkos::View<typename T::data_type, typename T::array_layout,
-                            typename T::memory_space,
-                            Kokkos::MemoryTraits<T::memory_traits::impl_value &
-                                                 ~unsigned(Kokkos::Unmanaged)>>;
-};
-
-template <typename T>
-using real_type_t = typename real_type<T>::type;
-
-template <typename T>
-struct is_complex : std::false_type {};
-
-template <typename T>
-struct is_complex<Kokkos::complex<T>> : std::true_type {};
-
-template <typename ViewType, typename Enable = void>
-struct is_layout_left_or_right : std::false_type {};
-
-template <typename ViewType>
-struct is_layout_left_or_right<
-    ViewType,
-    std::enable_if_t<
-        std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutLeft> ||
-        std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>>>
-    : std::true_type {};
-
-template <typename ViewType>
-inline constexpr bool is_layout_left_or_right_v =
-    is_layout_left_or_right<ViewType>::value;
-
-template <typename ExecutionSpace, typename ViewType,
-          std::enable_if_t<ViewType::rank() == 1, std::nullptr_t> = nullptr>
-struct complex_view_type {
-  using value_type        = typename ViewType::non_const_value_type;
-  using float_type        = KokkosFFT::Impl::real_type_t<value_type>;
-  using complex_type      = Kokkos::complex<float_type>;
-  using array_layout_type = typename ViewType::array_layout;
-  using type = Kokkos::View<complex_type*, array_layout_type, ExecutionSpace>;
-};
 
 template <typename ViewType>
 auto convert_negative_axis(ViewType, int _axis = -1) {

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -1,23 +1,23 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#SPDX - FileCopyrightText : (C)The Kokkos - FFT development team, \
+    see COPYRIGHT.md file
 #
-# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+#SPDX - License - Identifier : MIT OR Apache - 2.0 WITH LLVM - exception
 
-add_executable(unit-tests-kokkos-fft-common
-    Test_Main.cpp
-    Test_Utils.cpp
-    Test_Normalization.cpp
-    Test_Transpose.cpp
-    Test_Layouts.cpp
-    Test_Padding.cpp
-    Test_Helpers.cpp
-    Test_prep_transpose_view.cpp
-)
+add_executable(
+    unit - tests - kokkos - fft -
+    common Test_Main.cpp Test_Utils.cpp Test_Traits.cpp Test_Normalization
+        .cpp Test_Transpose.cpp Test_Layouts.cpp Test_Padding.cpp Test_Helpers
+        .cpp Test_prep_transpose_view.cpp)
 
-target_compile_features(unit-tests-kokkos-fft-common PUBLIC cxx_std_17)
-target_compile_options(unit-tests-kokkos-fft-common PUBLIC -std=c++17)
+    target_compile_features(unit - tests - kokkos - fft -
+                            common PUBLIC cxx_std_17)
+        target_compile_options(unit - tests - kokkos - fft - common PUBLIC -
+                                   std = c++ 17)
 
-target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common GTest::gtest)
+            target_link_libraries(unit - tests - kokkos - fft -
+                                  common PUBLIC common GTest::gtest)
 
-# Enable GoogleTest
-include(GoogleTest)
-gtest_discover_tests(unit-tests-kokkos-fft-common PROPERTIES DISCOVERY_TIMEOUT 600)
+#Enable GoogleTest
+                include(GoogleTest) gtest_discover_tests(
+                    unit - tests - kokkos - fft -
+                    common PROPERTIES DISCOVERY_TIMEOUT 600)

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -1,23 +1,24 @@
-#SPDX - FileCopyrightText : (C)The Kokkos - FFT development team, \
-    see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
 #
-#SPDX - License - Identifier : MIT OR Apache - 2.0 WITH LLVM - exception
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-add_executable(
-    unit - tests - kokkos - fft -
-    common Test_Main.cpp Test_Utils.cpp Test_Traits.cpp Test_Normalization
-        .cpp Test_Transpose.cpp Test_Layouts.cpp Test_Padding.cpp Test_Helpers
-        .cpp Test_prep_transpose_view.cpp)
+add_executable(unit-tests-kokkos-fft-common
+    Test_Main.cpp
+    Test_Utils.cpp
+    Test_Traits.cpp
+    Test_Normalization.cpp
+    Test_Transpose.cpp
+    Test_Layouts.cpp
+    Test_Padding.cpp
+    Test_Helpers.cpp
+    Test_prep_transpose_view.cpp
+)
 
-    target_compile_features(unit - tests - kokkos - fft -
-                            common PUBLIC cxx_std_17)
-        target_compile_options(unit - tests - kokkos - fft - common PUBLIC -
-                                   std = c++ 17)
+target_compile_features(unit-tests-kokkos-fft-common PUBLIC cxx_std_17)
+target_compile_options(unit-tests-kokkos-fft-common PUBLIC -std=c++17)
 
-            target_link_libraries(unit - tests - kokkos - fft -
-                                  common PUBLIC common GTest::gtest)
+target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common GTest::gtest)
 
-#Enable GoogleTest
-                include(GoogleTest) gtest_discover_tests(
-                    unit - tests - kokkos - fft -
-                    common PROPERTIES DISCOVERY_TIMEOUT 600)
+# Enable GoogleTest
+include(GoogleTest)
+gtest_discover_tests(unit-tests-kokkos-fft-common PROPERTIES DISCOVERY_TIMEOUT 600)

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -37,8 +37,10 @@ TYPED_TEST_SUITE(RealAndComplexViewTypes, view_types);
 // Tests for real type deduction
 template <typename RealType, typename ComplexType>
 void test_get_real_type() {
-  using real_type_from_RealType    = KokkosFFT::Impl::real_type_t<RealType>;
-  using real_type_from_ComplexType = KokkosFFT::Impl::real_type_t<ComplexType>;
+  using real_type_from_RealType =
+      KokkosFFT::Impl::base_floating_point_type<RealType>;
+  using real_type_from_ComplexType =
+      KokkosFFT::Impl::base_floating_point_type<ComplexType>;
 
   static_assert(std::is_same_v<real_type_from_RealType, RealType>,
                 "Real type not deduced correctly from real type");
@@ -60,7 +62,7 @@ void test_admissible_real_type() {
 
 template <typename T>
 void test_admissible_complex_type() {
-  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  using real_type = KokkosFFT::Impl::base_floating_point_type<T>;
   if constexpr (std::is_same_v<real_type, float> ||
                 std::is_same_v<real_type, double>) {
     static_assert(KokkosFFT::Impl::is_complex_v<T>,
@@ -96,7 +98,7 @@ TYPED_TEST(RealAndComplexTypes, admissible_complex_type) {
 template <typename T, typename LayoutType>
 void test_admissible_value_type() {
   using ViewType  = Kokkos::View<T*, LayoutType>;
-  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  using real_type = KokkosFFT::Impl::base_floating_point_type<T>;
   if constexpr (std::is_same_v<real_type, float> ||
                 std::is_same_v<real_type, double>) {
     static_assert(KokkosFFT::Impl::is_admissible_value_type_v<ViewType>,
@@ -123,7 +125,7 @@ void test_admissible_layout_type() {
 template <typename T, typename LayoutType>
 void test_admissible_view_type() {
   using ViewType  = Kokkos::View<T*, LayoutType>;
-  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  using real_type = KokkosFFT::Impl::base_floating_point_type<T>;
   if constexpr (
       (std::is_same_v<real_type, float> || std::is_same_v<real_type, double>)&&(
           std::is_same_v<LayoutType, Kokkos::LayoutLeft> ||

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -6,19 +6,9 @@
 #include "KokkosFFT_traits.hpp"
 #include "Test_Utils.hpp"
 
-using half_t  = Kokkos::Experimental::half_t;
-using bhalf_t = Kokkos::Experimental::bhalf_t;
-
-using real_types =
-    ::testing::Types<half_t, bhalf_t, float, double, long double>;
+using real_types = ::testing::Types<float, double, long double>;
 using view_types =
-    ::testing::Types<std::pair<half_t, Kokkos::LayoutLeft>,
-                     std::pair<half_t, Kokkos::LayoutRight>,
-                     std::pair<half_t, Kokkos::LayoutStride>,
-                     std::pair<bhalf_t, Kokkos::LayoutLeft>,
-                     std::pair<bhalf_t, Kokkos::LayoutRight>,
-                     std::pair<bhalf_t, Kokkos::LayoutStride>,
-                     std::pair<float, Kokkos::LayoutLeft>,
+    ::testing::Types<std::pair<float, Kokkos::LayoutLeft>,
                      std::pair<float, Kokkos::LayoutRight>,
                      std::pair<float, Kokkos::LayoutStride>,
                      std::pair<double, Kokkos::LayoutLeft>,

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include "KokkosFFT_traits.hpp"
+#include "Test_Utils.hpp"
+
+using half_t  = Kokkos::Experimental::half_t;
+using bhalf_t = Kokkos::Experimental::bhalf_t;
+
+using real_types =
+    ::testing::Types<half_t, bhalf_t, float, double, long double>;
+using view_types =
+    ::testing::Types<std::pair<half_t, Kokkos::LayoutLeft>,
+                     std::pair<half_t, Kokkos::LayoutRight>,
+                     std::pair<half_t, Kokkos::LayoutStride>,
+                     std::pair<bhalf_t, Kokkos::LayoutLeft>,
+                     std::pair<bhalf_t, Kokkos::LayoutRight>,
+                     std::pair<bhalf_t, Kokkos::LayoutStride>,
+                     std::pair<float, Kokkos::LayoutLeft>,
+                     std::pair<float, Kokkos::LayoutRight>,
+                     std::pair<float, Kokkos::LayoutStride>,
+                     std::pair<double, Kokkos::LayoutLeft>,
+                     std::pair<double, Kokkos::LayoutRight>,
+                     std::pair<double, Kokkos::LayoutStride>,
+                     std::pair<long double, Kokkos::LayoutLeft>,
+                     std::pair<long double, Kokkos::LayoutRight>,
+                     std::pair<long double, Kokkos::LayoutStride>>;
+
+template <typename T>
+struct RealAndComplexTypes : public ::testing::Test {
+  using real_type    = T;
+  using complex_type = Kokkos::complex<T>;
+};
+
+template <typename T>
+struct RealAndComplexViewTypes : public ::testing::Test {
+  using real_type    = typename T::first_type;
+  using complex_type = Kokkos::complex<real_type>;
+  using layout_type  = typename T::second_type;
+};
+
+TYPED_TEST_SUITE(RealAndComplexTypes, real_types);
+TYPED_TEST_SUITE(RealAndComplexViewTypes, view_types);
+
+// Tests for real type deduction
+template <typename RealType, typename ComplexType>
+void test_get_real_type() {
+  using real_type_from_RealType    = KokkosFFT::Impl::real_type_t<RealType>;
+  using real_type_from_ComplexType = KokkosFFT::Impl::real_type_t<ComplexType>;
+
+  static_assert(std::is_same_v<real_type_from_RealType, RealType>,
+                "Real type not deduced correctly from real type");
+  static_assert(std::is_same_v<real_type_from_ComplexType, RealType>,
+                "Real type not deduced correctly from complex type");
+}
+
+// Tests for admissible real types (float or double)
+template <typename T>
+void test_admissible_real_type() {
+  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+    static_assert(KokkosFFT::Impl::is_real_v<T>,
+                  "Real type must be float or double");
+  } else {
+    static_assert(!KokkosFFT::Impl::is_real_v<T>,
+                  "Real type must be float or double");
+  }
+}
+
+template <typename T>
+void test_admissible_complex_type() {
+  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  if constexpr (std::is_same_v<real_type, float> ||
+                std::is_same_v<real_type, double>) {
+    static_assert(KokkosFFT::Impl::is_complex_v<T>,
+                  "Complex type must be Kokkos::complex<float> or "
+                  "Kokkos::complex<double>");
+  } else {
+    static_assert(!KokkosFFT::Impl::is_complex_v<T>,
+                  "Complex type must be Kokkos::complex<float> or "
+                  "Kokkos::complex<double>");
+  }
+}
+
+TYPED_TEST(RealAndComplexTypes, get_real_type) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+
+  test_get_real_type<real_type, complex_type>();
+}
+
+TYPED_TEST(RealAndComplexTypes, admissible_real_type) {
+  using real_type = typename TestFixture::real_type;
+
+  test_admissible_real_type<real_type>();
+}
+
+TYPED_TEST(RealAndComplexTypes, admissible_complex_type) {
+  using complex_type = typename TestFixture::complex_type;
+
+  test_admissible_complex_type<complex_type>();
+}
+
+// Tests for admissible view types
+template <typename T, typename LayoutType>
+void test_admissible_value_type() {
+  using ViewType  = Kokkos::View<T*, LayoutType>;
+  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  if constexpr (std::is_same_v<real_type, float> ||
+                std::is_same_v<real_type, double>) {
+    static_assert(KokkosFFT::Impl::is_admissible_value_type_v<ViewType>,
+                  "Real type must be float or double");
+  } else {
+    static_assert(!KokkosFFT::Impl::is_admissible_value_type_v<ViewType>,
+                  "Real type must be float or double");
+  }
+}
+
+template <typename T, typename LayoutType>
+void test_admissible_layout_type() {
+  using ViewType = Kokkos::View<T*, LayoutType>;
+  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft> ||
+                std::is_same_v<LayoutType, Kokkos::LayoutRight>) {
+    static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<ViewType>,
+                  "View Layout must be either LayoutLeft or LayoutRight.");
+  } else {
+    static_assert(!KokkosFFT::Impl::is_layout_left_or_right_v<ViewType>,
+                  "View Layout must be either LayoutLeft or LayoutRight.");
+  }
+}
+
+template <typename T, typename LayoutType>
+void test_admissible_view_type() {
+  using ViewType  = Kokkos::View<T*, LayoutType>;
+  using real_type = KokkosFFT::Impl::real_type_t<T>;
+  if constexpr (
+      (std::is_same_v<real_type, float> || std::is_same_v<real_type, double>)&&(
+          std::is_same_v<LayoutType, Kokkos::LayoutLeft> ||
+          std::is_same_v<LayoutType, Kokkos::LayoutRight>)) {
+    static_assert(KokkosFFT::Impl::is_admissible_view_v<ViewType>,
+                  "View value type must be float, double, "
+                  "Kokkos::Complex<float>, Kokkos::Complex<double>. Layout "
+                  "must be either LayoutLeft or LayoutRight.");
+  } else {
+    static_assert(!KokkosFFT::Impl::is_admissible_view_v<ViewType>,
+                  "View value type must be float, double, "
+                  "Kokkos::Complex<float>, Kokkos::Complex<double>. Layout "
+                  "must be either LayoutLeft or LayoutRight.");
+  }
+}
+
+TYPED_TEST(RealAndComplexViewTypes, admissible_value_type) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+  using layout_type  = typename TestFixture::layout_type;
+
+  test_admissible_value_type<real_type, layout_type>();
+  test_admissible_value_type<complex_type, layout_type>();
+}
+
+TYPED_TEST(RealAndComplexViewTypes, admissible_layout_type) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+  using layout_type  = typename TestFixture::layout_type;
+
+  test_admissible_layout_type<real_type, layout_type>();
+  test_admissible_layout_type<complex_type, layout_type>();
+}
+
+TYPED_TEST(RealAndComplexViewTypes, admissible_view_type) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+  using layout_type  = typename TestFixture::layout_type;
+
+  test_admissible_view_type<real_type, layout_type>();
+  test_admissible_view_type<complex_type, layout_type>();
+}

--- a/common/unit_test/Test_Types.hpp
+++ b/common/unit_test/Test_Types.hpp
@@ -4,7 +4,7 @@
 
 #ifndef TEST_TYPES_HPP
 #define TEST_TYPES_HPP
-
+#include <Kokkos_Core.hpp>
 #include <Kokkos_Complex.hpp>
 using execution_space = Kokkos::DefaultExecutionSpace;
 template <typename T>

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -55,8 +55,8 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<T1>, float>, fftwf_plan,
-      fftw_plan>;
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<T1>, float>,
+      fftwf_plan, fftw_plan>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                                   cufftHandle, fftwHandle>;
 };

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -55,8 +55,8 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<T1>, float>, fftwf_plan,
-      fftw_plan>;
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<T1>, float>,
+      fftwf_plan, fftw_plan>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   hipfftHandle, fftwHandle>;
 };

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -50,7 +50,8 @@ auto create_plan(const ExecutionSpace& exec_space,
       "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
   const int rank = fft_rank;
 
-  init_threads<ExecutionSpace, KokkosFFT::Impl::real_type_t<in_value_type>>(
+  init_threads<ExecutionSpace,
+               KokkosFFT::Impl::base_floating_point_type<in_value_type>>(
       exec_space);
 
   constexpr auto type =

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -37,8 +37,8 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using type = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<T1>, float>, fftwf_plan,
-      fftw_plan>;
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<T1>, float>,
+      fftwf_plan, fftw_plan>;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -67,7 +67,7 @@ class Plan {
   using out_value_type = typename OutViewType::non_const_value_type;
 
   //! The real value type of input/output views
-  using float_type = KokkosFFT::Impl::real_type_t<in_value_type>;
+  using float_type = KokkosFFT::Impl::base_floating_point_type<in_value_type>;
 
   //! The layout type of input/output views
   using layout_type = typename InViewType::array_layout;

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -42,7 +42,8 @@ auto get_in_out_array_type(TransformType type,
 
 template <typename ValueType>
 rocfft_precision get_in_out_array_type() {
-  return std::is_same_v<KokkosFFT::Impl::real_type_t<ValueType>, float>
+  return std::is_same_v<KokkosFFT::Impl::base_floating_point_type<ValueType>,
+                        float>
              ? rocfft_precision_single
              : rocfft_precision_double;
 }

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -99,8 +99,8 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<T1>, float>, fftwf_plan,
-      fftw_plan>;
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<T1>, float>,
+      fftwf_plan, fftw_plan>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   rocfft_plan, fftwHandle>;
 };

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -114,14 +114,16 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, T1, Kokkos::complex<T2>> {
   using float_type = T1;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>,
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>,
       fftwf_plan, fftw_plan>;
 
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
@@ -134,14 +136,16 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
   using float_type = T2;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>,
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>,
       fftwf_plan, fftw_plan>;
 
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
@@ -152,16 +156,18 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>> {
-  using float_type = KokkosFFT::Impl::real_type_t<T1>;
+  using float_type = KokkosFFT::Impl::base_floating_point_type<T1>;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::COMPLEX;
 
   using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>,
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>,
       fftwf_plan, fftw_plan>;
 
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
@@ -201,7 +207,8 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, T1, Kokkos::complex<T2>> {
   using float_type = T1;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =
@@ -214,7 +221,8 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
   using float_type = T2;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =
@@ -225,9 +233,10 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>> {
-  using float_type = KokkosFFT::Impl::real_type_t<T1>;
+  using float_type = KokkosFFT::Impl::base_floating_point_type<T1>;
   static constexpr oneapi::mkl::dft::precision prec =
-      std::is_same_v<KokkosFFT::Impl::real_type_t<float_type>, float>
+      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<float_type>,
+                     float>
           ? oneapi::mkl::dft::precision::SINGLE
           : oneapi::mkl::dft::precision::DOUBLE;
   static constexpr oneapi::mkl::dft::domain dom =

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -22,7 +22,7 @@ using shape_type = KokkosFFT::shape_type<DIM>;
 template <typename ViewType>
 void fft1(ViewType& in, ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
-  using real_value_type = KokkosFFT::Impl::real_type_t<value_type>;
+  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
 
   static_assert(KokkosFFT::Impl::is_complex<value_type>::value,
                 "fft1: ViewType must be complex");
@@ -62,7 +62,7 @@ void fft1(ViewType& in, ViewType& out) {
 template <typename ViewType>
 void ifft1(ViewType& in, ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
-  using real_value_type = KokkosFFT::Impl::real_type_t<value_type>;
+  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
 
   static_assert(KokkosFFT::Impl::is_complex<value_type>::value,
                 "ifft1: ViewType must be complex");


### PR DESCRIPTION
This PR aims at moving traits into `KokkosFFT_traits.hpp` from `KokkosFFT_utils.hpp`.
This will be applied in another PR to improve error handlings as commented in #80

Following modifications are made

1. All traits are moved into `KokkosFFT_traits.hpp`
2. Traits are still included via `KokkosFFT_utils.hpp`
3. Add compile tests for traits `Test_Traits.hpp`