### PR TITLE
Only allow float and double to represent real values

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -181,7 +181,7 @@ namespace KokkosFFT {
 template <typename ExecutionSpace, typename RealType>
 auto fftfreq(const ExecutionSpace&, const std::size_t n,
              const RealType d = 1.0) {
-  static_assert(std::is_floating_point<RealType>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<RealType>,
                 "fftfreq: d must be float or double");
   using ViewType = Kokkos::View<RealType*, ExecutionSpace>;
   ViewType freq("freq", n);
@@ -216,7 +216,7 @@ auto fftfreq(const ExecutionSpace&, const std::size_t n,
 template <typename ExecutionSpace, typename RealType>
 auto rfftfreq(const ExecutionSpace&, const std::size_t n,
               const RealType d = 1.0) {
-  static_assert(std::is_floating_point<RealType>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<RealType>,
                 "fftfreq: d must be float or double");
   using ViewType = Kokkos::View<RealType*, ExecutionSpace>;
 

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -64,9 +64,9 @@ auto get_extents(const InViewType& in, const OutViewType& out,
     _fft_extents.push_back(fft_extent);
   }
 
-  if (std::is_floating_point<in_value_type>::value) {
+  if (is_real_v<in_value_type>) {
     // Then R2C
-    if (is_complex<out_value_type>::value) {
+    if (is_complex_v<out_value_type>) {
       assert(_out_extents.at(inner_most_axis) ==
              _in_extents.at(inner_most_axis) / 2 + 1);
     } else {
@@ -75,9 +75,9 @@ auto get_extents(const InViewType& in, const OutViewType& out,
     }
   }
 
-  if (std::is_floating_point<out_value_type>::value) {
+  if (is_real_v<out_value_type>) {
     // Then C2R
-    if (is_complex<in_value_type>::value) {
+    if (is_complex_v<in_value_type>) {
       assert(_in_extents.at(inner_most_axis) ==
              _out_extents.at(inner_most_axis) / 2 + 1);
     } else {

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -70,8 +70,7 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  bool is_C2R = is_complex<in_value_type>::value &&
-                std::is_floating_point_v<out_value_type>;
+  bool is_C2R = is_complex_v<in_value_type> && is_real_v<out_value_type>;
 
   if (is_C2R) {
     int reshaped_axis                = positive_axes.back();

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -186,14 +186,14 @@ class Plan {
             ExecutionSpace, typename OutViewType::memory_space>::accessible,
         "Plan::Plan: execution_space cannot access data in OutViewType");
 
-    if (std::is_floating_point<in_value_type>::value &&
+    if (KokkosFFT::Impl::is_real_v<in_value_type> &&
         m_direction != KokkosFFT::Direction::forward) {
       throw std::runtime_error(
           "Plan::Plan: real to complex transform is constrcuted with backward "
           "direction.");
     }
 
-    if (std::is_floating_point<out_value_type>::value &&
+    if (KokkosFFT::Impl::is_real_v<out_value_type> &&
         m_direction != KokkosFFT::Direction::backward) {
       throw std::runtime_error(
           "Plan::Plan: complex to real transform is constrcuted with forward "

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -292,9 +292,9 @@ void rfft(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(std::is_floating_point<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<in_value_type>,
                 "rfft: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfft: OutViewType must be complex");
 
   fft(exec_space, in, out, norm, axis, n);
@@ -341,9 +341,9 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<in_value_type>,
                 "irfft: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfft: OutViewType must be real");
   ifft(exec_space, in, out, norm, axis, n);
 }
@@ -391,9 +391,9 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
   // type
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<in_value_type>,
                 "hfft: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "hfft: OutViewType must be real");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
   // using ComplexViewType = typename
@@ -444,9 +444,9 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(std::is_floating_point<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<in_value_type>,
                 "ihfft: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "ihfft: OutViewType must be complex");
 
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
@@ -585,9 +585,9 @@ void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(std::is_floating_point<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<in_value_type>,
                 "rfft2: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfft2: OutViewType must be complex");
 
   fft2(exec_space, in, out, norm, axes, s);
@@ -635,9 +635,9 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<in_value_type>,
                 "irfft2: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfft2: OutViewType must be real");
 
   ifft2(exec_space, in, out, norm, axes, s);
@@ -775,9 +775,9 @@ void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(std::is_floating_point<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<in_value_type>,
                 "rfftn: InViewType must be real");
-  static_assert(KokkosFFT::Impl::is_complex<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfftn: OutViewType must be complex");
 
   fftn(exec_space, in, out, axes, norm, s);
@@ -826,9 +826,9 @@ void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  static_assert(KokkosFFT::Impl::is_complex<in_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_complex_v<in_value_type>,
                 "irfftn: InViewType must be complex");
-  static_assert(std::is_floating_point<out_value_type>::value,
+  static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfftn: OutViewType must be real");
 
   ifftn(exec_space, in, out, axes, norm, s);


### PR DESCRIPTION
This PR aims at improving the checks of precisions to be strictly in `float` or `double`.
We have replaced `std::is_floating_point_v<RealType>` with `is_real_v<RealType>`.
The previous one accepts `float`, `double`, `long double` (, `std::float16_t` and more in c++23) but the latter accepts `float` and `double` only.
Because of the limitation of backend libraries, we can only use `float` and `double` to represent values.