### PR TITLE
More traits for unary and binary operations

### DIFF
--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -131,10 +131,10 @@ inline constexpr bool is_operatable_view_v =
 
 // Traits for binary operations
 template <typename T1, typename T2, typename Enable = void>
-struct have_same_precision : std::false_type {};
+struct have_same_base_floating_point_type : std::false_type {};
 
 template <typename T1, typename T2>
-struct have_same_precision<
+struct have_same_base_floating_point_type<
     T1, T2,
     std::enable_if_t<!Kokkos::is_view_v<T1> && !Kokkos::is_view_v<T2> &&
                      std::is_same_v<base_floating_point_type<T1>,
@@ -142,7 +142,7 @@ struct have_same_precision<
     : std::true_type {};
 
 template <typename InViewType, typename OutViewType>
-struct have_same_precision<
+struct have_same_base_floating_point_type<
     InViewType, OutViewType,
     std::enable_if_t<
         Kokkos::is_view_v<InViewType> && Kokkos::is_view_v<OutViewType> &&
@@ -152,12 +152,12 @@ struct have_same_precision<
                 typename OutViewType::non_const_value_type>>>>
     : std::true_type {};
 
-/// \brief Helper to check if two value have the same base precision type.
+/// \brief Helper to check if two value have the same base floating point type.
 /// When applied to Kokkos::View, then check if values of views have the same
-/// base precision type.
+/// base floating point type.
 template <typename T1, typename T2>
-inline constexpr bool have_same_precision_v =
-    have_same_precision<T1, T2>::value;
+inline constexpr bool have_same_base_floating_point_type_v =
+    have_same_base_floating_point_type<T1, T2>::value;
 
 template <typename InViewType, typename OutViewType, typename Enable = void>
 struct have_same_layout : std::false_type {};
@@ -199,12 +199,12 @@ struct are_operatable_views : std::false_type {};
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 struct are_operatable_views<
     ExecutionSpace, InViewType, OutViewType,
-    std::enable_if_t<is_operatable_view_v<ExecutionSpace, InViewType> &&
-                     is_operatable_view_v<ExecutionSpace, OutViewType> &&
-                     have_same_precision_v<InViewType, OutViewType> &&
-                     have_same_layout_v<InViewType, OutViewType> &&
-                     have_same_rank_v<InViewType, OutViewType>>>
-    : std::true_type {};
+    std::enable_if_t<
+        is_operatable_view_v<ExecutionSpace, InViewType> &&
+        is_operatable_view_v<ExecutionSpace, OutViewType> &&
+        have_same_base_floating_point_type_v<InViewType, OutViewType> &&
+        have_same_layout_v<InViewType, OutViewType> &&
+        have_same_rank_v<InViewType, OutViewType>>> : std::true_type {};
 
 /// \brief Helper to check if Views are acceptable View for Kokkos-FFT and
 /// memory space are accessible from the ExecutionSpace.

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -63,15 +63,15 @@ struct is_admissible_value_type<
 
 template <typename T>
 struct is_admissible_value_type<
-    T, std::enable_if_t<Kokkos::is_view<T>::value &&
+    T, std::enable_if_t<Kokkos::is_view_v<T> &&
                         (is_real_v<typename T::non_const_value_type> ||
                          is_complex_v<typename T::non_const_value_type>)>>
     : std::true_type {};
 
 /// \brief Helper to check if a type is an acceptable value type
 /// (float/double/Kokkos::complex<float>/Kokkos::complex<double>) for Kokkos-FFT
-///        When applied to Kokkos::View, then check if a value type is an
-///        acceptable real/complex type.
+/// When applied to Kokkos::View, then check if a value type is an acceptable
+/// real/complex type.
 template <typename T>
 inline constexpr bool is_admissible_value_type_v =
     is_admissible_value_type<T>::value;
@@ -83,7 +83,7 @@ template <typename ViewType>
 struct is_layout_left_or_right<
     ViewType,
     std::enable_if_t<
-        Kokkos::is_view<ViewType>::value &&
+        Kokkos::is_view_v<ViewType> &&
         (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutLeft> ||
          std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>)>>
     : std::true_type {};
@@ -99,7 +99,7 @@ struct is_admissible_view : std::false_type {};
 
 template <typename ViewType>
 struct is_admissible_view<
-    ViewType, std::enable_if_t<Kokkos::is_view<ViewType>::value &&
+    ViewType, std::enable_if_t<Kokkos::is_view_v<ViewType> &&
                                is_layout_left_or_right_v<ViewType> &&
                                is_admissible_value_type_v<ViewType>>>
     : std::true_type {};
@@ -117,14 +117,14 @@ template <typename ExecutionSpace, typename ViewType>
 struct is_operatable_view<
     ExecutionSpace, ViewType,
     std::enable_if_t<
+        Kokkos::is_execution_space_v<ExecutionSpace> &&
         is_admissible_view_v<ViewType> &&
         Kokkos::SpaceAccessibility<
             ExecutionSpace, typename ViewType::memory_space>::accessible>>
     : std::true_type {};
 
 /// \brief Helper to check if a View is an acceptable View for Kokkos-FFT and
-/// memory space
-///        is accessible from the ExecutionSpace
+/// memory space is accessible from the ExecutionSpace
 template <typename ExecutionSpace, typename ViewType>
 inline constexpr bool is_operatable_view_v =
     is_operatable_view<ExecutionSpace, ViewType>::value;
@@ -136,8 +136,7 @@ struct have_same_precision : std::false_type {};
 template <typename T1, typename T2>
 struct have_same_precision<
     T1, T2,
-    std::enable_if_t<!Kokkos::is_view<T1>::value &&
-                     !Kokkos::is_view<T2>::value &&
+    std::enable_if_t<!Kokkos::is_view_v<T1> && !Kokkos::is_view_v<T2> &&
                      std::is_same_v<base_floating_point_type<T1>,
                                     base_floating_point_type<T2>>>>
     : std::true_type {};
@@ -146,8 +145,7 @@ template <typename InViewType, typename OutViewType>
 struct have_same_precision<
     InViewType, OutViewType,
     std::enable_if_t<
-        Kokkos::is_view<InViewType>::value &&
-        Kokkos::is_view<OutViewType>::value &&
+        Kokkos::is_view_v<InViewType> && Kokkos::is_view_v<OutViewType> &&
         std::is_same_v<
             base_floating_point_type<typename InViewType::non_const_value_type>,
             base_floating_point_type<
@@ -155,8 +153,8 @@ struct have_same_precision<
     : std::true_type {};
 
 /// \brief Helper to check if two value have the same base precision type.
-///      When applied to Kokkos::View, then check if values of views have the
-///      same base precision type.
+/// When applied to Kokkos::View, then check if values of views have the same
+/// base precision type.
 template <typename T1, typename T2>
 inline constexpr bool have_same_precision_v =
     have_same_precision<T1, T2>::value;
@@ -167,8 +165,8 @@ struct have_same_layout : std::false_type {};
 template <typename InViewType, typename OutViewType>
 struct have_same_layout<
     InViewType, OutViewType,
-    std::enable_if_t<Kokkos::is_view<InViewType>::value &&
-                     Kokkos::is_view<OutViewType>::value &&
+    std::enable_if_t<Kokkos::is_view_v<InViewType> &&
+                     Kokkos::is_view_v<OutViewType> &&
                      std::is_same_v<typename InViewType::array_layout,
                                     typename OutViewType::array_layout>>>
     : std::true_type {};
@@ -184,8 +182,8 @@ struct have_same_rank : std::false_type {};
 template <typename InViewType, typename OutViewType>
 struct have_same_rank<
     InViewType, OutViewType,
-    std::enable_if_t<Kokkos::is_view<InViewType>::value &&
-                     Kokkos::is_view<OutViewType>::value &&
+    std::enable_if_t<Kokkos::is_view_v<InViewType> &&
+                     Kokkos::is_view_v<OutViewType> &&
                      InViewType::rank() == OutViewType::rank()>>
     : std::true_type {};
 

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -6,6 +6,16 @@
 #include "KokkosFFT_traits.hpp"
 #include "Test_Utils.hpp"
 
+// All the tests in this file are compile time tests, so we skip all the tests
+// by GTEST_SKIP().
+
+// Define the types to combine
+using base_real_types = std::tuple<float, double, long double>;
+
+// Define the layouts to combine
+using base_layout_types =
+    std::tuple<Kokkos::LayoutLeft, Kokkos::LayoutRight, Kokkos::LayoutStride>;
+
 using real_types = ::testing::Types<float, double, long double>;
 using view_types =
     ::testing::Types<std::pair<float, Kokkos::LayoutLeft>,
@@ -18,10 +28,19 @@ using view_types =
                      std::pair<long double, Kokkos::LayoutRight>,
                      std::pair<long double, Kokkos::LayoutStride>>;
 
+// Define all the combinations
+using paired_view_types =
+    tuple_to_types_t<cartesian_product_t<base_real_types, base_layout_types,
+                                         base_real_types, base_layout_types>>;
+
 template <typename T>
 struct RealAndComplexTypes : public ::testing::Test {
   using real_type    = T;
   using complex_type = Kokkos::complex<T>;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
 };
 
 template <typename T>
@@ -29,10 +48,26 @@ struct RealAndComplexViewTypes : public ::testing::Test {
   using real_type    = typename T::first_type;
   using complex_type = Kokkos::complex<real_type>;
   using layout_type  = typename T::second_type;
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
+};
+
+template <typename T>
+struct PairedViewTypes : public ::testing::Test {
+  using real_type1   = typename std::tuple_element_t<0, T>;
+  using layout_type1 = typename std::tuple_element_t<1, T>;
+  using real_type2   = typename std::tuple_element_t<2, T>;
+  using layout_type2 = typename std::tuple_element_t<3, T>;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
 };
 
 TYPED_TEST_SUITE(RealAndComplexTypes, real_types);
 TYPED_TEST_SUITE(RealAndComplexViewTypes, view_types);
+TYPED_TEST_SUITE(PairedViewTypes, paired_view_types);
 
 // Tests for real type deduction
 template <typename RealType, typename ComplexType>
@@ -142,6 +177,45 @@ void test_admissible_view_type() {
   }
 }
 
+// \brief Test if a View is operatable
+// \tparam ExecutionSpace1 Execution space for the device
+// \tparam ExecutionSpace2 Execution space for the View memory space
+// \tparam T Value type of the View
+// \tparam LayoutType Layout type of the View
+template <typename ExecutionSpace1, typename ExecutionSpace2, typename T,
+          typename LayoutType>
+void test_operatable_view_type() {
+  using ViewType  = Kokkos::View<T*, LayoutType, ExecutionSpace2>;
+  using real_type = KokkosFFT::Impl::base_floating_point_type<T>;
+  if constexpr (Kokkos::SpaceAccessibility<
+                    ExecutionSpace1,
+                    typename ViewType::memory_space>::accessible) {
+    if constexpr ((std::is_same_v<real_type, float> ||
+                   std::is_same_v<
+                       real_type,
+                       double>)&&(std::is_same_v<LayoutType,
+                                                 Kokkos::LayoutLeft> ||
+                                  std::is_same_v<LayoutType,
+                                                 Kokkos::LayoutRight>)) {
+      static_assert(
+          KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace1, ViewType>,
+          "View value type must be float, double, "
+          "Kokkos::Complex<float>, Kokkos::Complex<double>. Layout "
+          "must be either LayoutLeft or LayoutRight.");
+    } else {
+      static_assert(
+          !KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace1, ViewType>,
+          "View value type must be float, double, "
+          "Kokkos::Complex<float>, Kokkos::Complex<double>. Layout "
+          "must be either LayoutLeft or LayoutRight.");
+    }
+  } else {
+    static_assert(
+        !KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace1, ViewType>,
+        "execution_space cannot access data in ViewType");
+  }
+}
+
 TYPED_TEST(RealAndComplexViewTypes, admissible_value_type) {
   using real_type    = typename TestFixture::real_type;
   using complex_type = typename TestFixture::complex_type;
@@ -167,4 +241,310 @@ TYPED_TEST(RealAndComplexViewTypes, admissible_view_type) {
 
   test_admissible_view_type<real_type, layout_type>();
   test_admissible_view_type<complex_type, layout_type>();
+}
+
+TYPED_TEST(RealAndComplexViewTypes, operatable_view_type) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using host_space   = Kokkos::DefaultHostExecutionSpace;
+  using device_space = Kokkos::DefaultExecutionSpace;
+
+  test_operatable_view_type<host_space, host_space, real_type, layout_type>();
+  test_operatable_view_type<host_space, device_space, real_type, layout_type>();
+  test_operatable_view_type<device_space, host_space, real_type, layout_type>();
+  test_operatable_view_type<device_space, device_space, real_type,
+                            layout_type>();
+
+  test_operatable_view_type<host_space, host_space, complex_type,
+                            layout_type>();
+  test_operatable_view_type<host_space, device_space, complex_type,
+                            layout_type>();
+  test_operatable_view_type<device_space, host_space, complex_type,
+                            layout_type>();
+  test_operatable_view_type<device_space, device_space, complex_type,
+                            layout_type>();
+}
+
+// Tests for multiple Views
+template <typename RealType1, typename RealType2, typename LayoutType>
+void test_have_same_precision() {
+  using real_type1    = RealType1;
+  using real_type2    = RealType2;
+  using complex_type1 = Kokkos::complex<real_type1>;
+  using complex_type2 = Kokkos::complex<real_type2>;
+
+  using RealViewType1    = Kokkos::View<real_type1*, LayoutType>;
+  using ComplexViewType1 = Kokkos::View<complex_type1*, LayoutType>;
+  using RealViewType2    = Kokkos::View<real_type2*, LayoutType>;
+  using ComplexViewType2 = Kokkos::View<complex_type2*, LayoutType>;
+
+  if constexpr (std::is_same_v<real_type1, real_type2>) {
+    // Tests for values
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<real_type1, complex_type1>,
+        "Values have the same base precisions");
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<complex_type1, real_type2>,
+        "Values have the same base precisions");
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<complex_type1, complex_type2>,
+        "Values have the same base precisions");
+
+    // Tests for Views
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<RealViewType1, RealViewType2>,
+        "ViewTypes have the same base precisions");
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<RealViewType1, ComplexViewType2>,
+        "ViewTypes have the same base precisions");
+    static_assert(
+        KokkosFFT::Impl::have_same_precision_v<ComplexViewType1, RealViewType2>,
+        "ViewTypes have the same base precisions");
+    static_assert(KokkosFFT::Impl::have_same_precision_v<ComplexViewType1,
+                                                         ComplexViewType2>,
+                  "ViewTypes have the same base precisions");
+  } else {
+    // Tests for values
+    static_assert(
+        !KokkosFFT::Impl::have_same_precision_v<complex_type1, real_type2>,
+        "Values have the same base precisions");
+    static_assert(
+        !KokkosFFT::Impl::have_same_precision_v<complex_type1, complex_type2>,
+        "Values have the same base precisions");
+
+    // Tests for Views
+    static_assert(
+        !KokkosFFT::Impl::have_same_precision_v<RealViewType1, RealViewType2>,
+        "ViewTypes have the same base precisions");
+    static_assert(!KokkosFFT::Impl::have_same_precision_v<RealViewType1,
+                                                          ComplexViewType2>,
+                  "ViewTypes have the same base precisions");
+    static_assert(!KokkosFFT::Impl::have_same_precision_v<ComplexViewType1,
+                                                          RealViewType2>,
+                  "ViewTypes have the same base precisions");
+    static_assert(!KokkosFFT::Impl::have_same_precision_v<ComplexViewType1,
+                                                          ComplexViewType2>,
+                  "ViewTypes have the same base precisions");
+  }
+}
+
+template <typename RealType, typename LayoutType1, typename LayoutType2>
+void test_have_same_layout() {
+  using ViewType1 = Kokkos::View<RealType*, LayoutType1>;
+  using ViewType2 = Kokkos::View<RealType*, LayoutType2>;
+
+  if constexpr (std::is_same_v<LayoutType1, LayoutType2>) {
+    // Tests for Views
+    static_assert(KokkosFFT::Impl::have_same_layout_v<ViewType1, ViewType2>,
+                  "ViewTypes have the same layout");
+  } else {
+    // Tests for Views
+    static_assert(!KokkosFFT::Impl::have_same_layout_v<ViewType1, ViewType2>,
+                  "ViewTypes have the same layout");
+  }
+}
+
+template <typename RealType, typename LayoutType>
+void test_have_same_rank() {
+  using DynamicRank1ViewType       = Kokkos::View<RealType*, LayoutType>;
+  using DynamicRank2ViewType       = Kokkos::View<RealType**, LayoutType>;
+  using StaticRank1ViewType        = Kokkos::View<RealType[3], LayoutType>;
+  using StaticRank2ViewType        = Kokkos::View<RealType[2][5], LayoutType>;
+  using DynamicStaticRank2ViewType = Kokkos::View<RealType* [5], LayoutType>;
+  static_assert(KokkosFFT::Impl::have_same_rank_v<DynamicRank1ViewType,
+                                                  StaticRank1ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(KokkosFFT::Impl::have_same_rank_v<DynamicRank2ViewType,
+                                                  StaticRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(KokkosFFT::Impl::have_same_rank_v<DynamicRank2ViewType,
+                                                  DynamicStaticRank2ViewType>,
+                "ViewTypes have the same rank");
+
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<DynamicRank1ViewType,
+                                                   DynamicRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<DynamicRank1ViewType,
+                                                   StaticRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<DynamicRank1ViewType,
+                                                   DynamicStaticRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<StaticRank1ViewType,
+                                                   DynamicRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<StaticRank1ViewType,
+                                                   StaticRank2ViewType>,
+                "ViewTypes have the same rank");
+  static_assert(!KokkosFFT::Impl::have_same_rank_v<StaticRank1ViewType,
+                                                   DynamicStaticRank2ViewType>,
+                "ViewTypes have the same rank");
+}
+
+// \brief Test if two Views are operatable
+// \tparam ExecutionSpace1 Execution space for the device
+// \tparam ExecutionSpace2 Execution space for the View memory space
+// \tparam RealType1 Base Real Value type of the View1
+// \tparam LayoutType1 Layout type of the View1
+// \tparam RealType2 Base Real Value type of the View2
+// \tparam LayoutType2 Layout type of the View2
+template <typename ExecutionSpace1, typename ExecutionSpace2,
+          typename RealType1, typename LayoutType1, typename RealType2,
+          typename LayoutType2>
+void test_are_operatable_views() {
+  using real_type1    = RealType1;
+  using real_type2    = RealType2;
+  using complex_type1 = Kokkos::complex<real_type1>;
+  using complex_type2 = Kokkos::complex<real_type2>;
+
+  using RealViewType1 = Kokkos::View<real_type1*, LayoutType1, ExecutionSpace2>;
+  using ComplexViewType1 =
+      Kokkos::View<complex_type1*, LayoutType1, ExecutionSpace2>;
+  using RealViewType2 = Kokkos::View<real_type2*, LayoutType2, ExecutionSpace2>;
+  using ComplexViewType2 =
+      Kokkos::View<complex_type2*, LayoutType2, ExecutionSpace2>;
+  using RealViewType3 =
+      Kokkos::View<real_type2**, LayoutType2, ExecutionSpace2>;
+  using ComplexViewType3 =
+      Kokkos::View<complex_type2* [3], LayoutType2, ExecutionSpace2>;
+
+  // Tests that the Views are accessible from the ExecutionSpace
+  if constexpr (Kokkos::SpaceAccessibility<
+                    ExecutionSpace1,
+                    typename RealViewType1::memory_space>::accessible) {
+    // Tests that the Views have the same precision in float or double
+    if constexpr (std::is_same_v<RealType1, RealType2> &&
+                  (std::is_same_v<RealType1, float> ||
+                   std::is_same_v<RealType1, double>)) {
+      // Tests that the Views have the same layout in LayoutLeft or LayoutRight
+      if constexpr (std::is_same_v<LayoutType1, LayoutType2> &&
+                    (std::is_same_v<LayoutType1, Kokkos::LayoutLeft> ||
+                     std::is_same_v<LayoutType1, Kokkos::LayoutRight>)) {
+        // Tests that the Views are operatable if they have the same rank
+        static_assert(KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, RealViewType2>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, ComplexViewType2>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, RealViewType2>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, ComplexViewType2>,
+                      "InViewType and OutViewType must have the same rank");
+
+        // Tests that the Views are not operatable if the ranks are not the same
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, RealViewType3>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, ComplexViewType3>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, RealViewType3>,
+                      "InViewType and OutViewType must have the same rank");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, ComplexViewType3>,
+                      "InViewType and OutViewType must have the same rank");
+      } else {
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, RealViewType2>,
+                      "Layouts are not identical or one of them is not "
+                      "LayoutLeft or LayoutRight");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, RealViewType1, ComplexViewType2>,
+                      "Layouts are not identical or one of them is not "
+                      "LayoutLeft or LayoutRight");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, RealViewType2>,
+                      "Layouts are not identical or one of them is not "
+                      "LayoutLeft or LayoutRight");
+        static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                          ExecutionSpace1, ComplexViewType1, ComplexViewType2>,
+                      "Layouts are not identical or one of them is not "
+                      "LayoutLeft or LayoutRight");
+      }
+    } else {
+      static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                        ExecutionSpace1, RealViewType1, RealViewType2>,
+                    "Base value types are not identical or one of them is not "
+                    "float or double");
+      static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                        ExecutionSpace1, RealViewType1, ComplexViewType2>,
+                    "Base value types are not identical or one of them is not "
+                    "float or double");
+      static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                        ExecutionSpace1, ComplexViewType1, RealViewType2>,
+                    "Base value types are not identical or one of them is not "
+                    "float or double");
+      static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                        ExecutionSpace1, ComplexViewType1, ComplexViewType2>,
+                    "Base value types are not identical or one of them is not "
+                    "float or double");
+    }
+  } else {
+    // Views are not operatable because they are not accessible from
+    // ExecutionSpace
+    static_assert(
+        !KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace1, RealViewType1,
+                                                 RealViewType2>,
+        "Either InViewType or OutViewType is not accessible from "
+        "ExecutionSpace");
+    static_assert(
+        !KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace1, RealViewType1,
+                                                 ComplexViewType2>,
+        "Either InViewType or OutViewType is not accessible from "
+        "ExecutionSpace");
+    static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                      ExecutionSpace1, ComplexViewType1, RealViewType2>,
+                  "Either InViewType or OutViewType is not accessible from "
+                  "ExecutionSpace");
+    static_assert(!KokkosFFT::Impl::are_operatable_views_v<
+                      ExecutionSpace1, ComplexViewType1, ComplexViewType2>,
+                  "Either InViewType or OutViewType is not accessible from "
+                  "ExecutionSpace");
+  }
+}
+
+TYPED_TEST(PairedViewTypes, have_same_precision) {
+  using real_type1  = typename TestFixture::real_type1;
+  using real_type2  = typename TestFixture::real_type2;
+  using layout_type = typename TestFixture::layout_type1;
+
+  test_have_same_precision<real_type1, real_type2, layout_type>();
+}
+
+TYPED_TEST(PairedViewTypes, have_same_layout) {
+  using real_type    = typename TestFixture::real_type1;
+  using layout_type1 = typename TestFixture::layout_type1;
+  using layout_type2 = typename TestFixture::layout_type2;
+
+  test_have_same_layout<real_type, layout_type1, layout_type2>();
+}
+
+TYPED_TEST(PairedViewTypes, have_same_rank) {
+  using real_type   = typename TestFixture::real_type1;
+  using layout_type = typename TestFixture::layout_type1;
+
+  test_have_same_rank<real_type, layout_type>();
+}
+
+TYPED_TEST(PairedViewTypes, are_operatable_views) {
+  using real_type1   = typename TestFixture::real_type1;
+  using layout_type1 = typename TestFixture::layout_type1;
+  using real_type2   = typename TestFixture::real_type2;
+  using layout_type2 = typename TestFixture::layout_type2;
+  using host_space   = Kokkos::DefaultHostExecutionSpace;
+  using device_space = Kokkos::DefaultExecutionSpace;
+
+  test_are_operatable_views<host_space, host_space, real_type1, layout_type1,
+                            real_type2, layout_type2>();
+  test_are_operatable_views<host_space, device_space, real_type1, layout_type1,
+                            real_type2, layout_type2>();
+  test_are_operatable_views<device_space, host_space, real_type1, layout_type1,
+                            real_type2, layout_type2>();
+  test_are_operatable_views<device_space, device_space, real_type1,
+                            layout_type1, real_type2, layout_type2>();
 }

--- a/common/unit_test/Test_Utils.hpp
+++ b/common/unit_test/Test_Utils.hpp
@@ -5,6 +5,9 @@
 #ifndef TEST_UTILS_HPP
 #define TEST_UTILS_HPP
 
+#include <gtest/gtest.h>
+#include <tuple>
+#include <type_traits>
 #include "Test_Types.hpp"
 
 template <typename AViewType, typename BViewType>
@@ -53,5 +56,96 @@ void display(std::string name, std::vector<T>& values) {
     std::cout << value << std::endl;
   }
 }
+
+/// Transform a sequence S to a tuple:
+/// - a std::integer_sequence<T, Ints...> to a
+/// std::tuple<std::integral_constant<T, Ints>...>
+/// - a std::pair<T, U> to a std::tuple<T, U>
+/// - identity otherwise (std::tuple)
+template <class S>
+struct to_tuple {
+  using type = S;
+};
+
+template <class T, T... Ints>
+struct to_tuple<std::integer_sequence<T, Ints...>> {
+  using type = std::tuple<std::integral_constant<T, Ints>...>;
+};
+
+template <class T, class U>
+struct to_tuple<std::pair<T, U>> {
+  using type = std::tuple<T, U>;
+};
+
+template <class S>
+using to_tuple_t = typename to_tuple<S>::type;
+
+template <class TupleOfTuples, class Tuple>
+struct for_each_tuple_cat;
+
+template <class... Tuples, class Tuple>
+struct for_each_tuple_cat<std::tuple<Tuples...>, Tuple> {
+  using type = std::tuple<decltype(std::tuple_cat(std::declval<Tuples>(),
+                                                  std::declval<Tuple>()))...>;
+};
+
+/// Construct a tuple of tuples that is the result of the concatenation of the
+/// tuples in TupleOfTuples with Tuple.
+template <class TupleOfTuples, class Tuple>
+using for_each_tuple_cat_t =
+    typename for_each_tuple_cat<TupleOfTuples, Tuple>::type;
+
+static_assert(
+    std::is_same_v<for_each_tuple_cat_t<std::tuple<std::tuple<double, double>,
+                                                   std::tuple<int, double>>,
+                                        std::tuple<int>>,
+                   std::tuple<std::tuple<double, double, int>,
+                              std::tuple<int, double, int>>>);
+
+static_assert(
+    std::is_same_v<for_each_tuple_cat_t<std::tuple<std::tuple<double, double>>,
+                                        std::tuple<int>>,
+                   std::tuple<std::tuple<double, double, int>>>);
+
+template <class InTupleOfTuples, class OutTupleOfTuples>
+struct cartesian_product_impl;
+
+template <class... HeadArgs, class... TailTuples, class OutTupleOfTuples>
+struct cartesian_product_impl<
+    std::tuple<std::tuple<HeadArgs...>, TailTuples...>, OutTupleOfTuples>
+    : cartesian_product_impl<
+          std::tuple<TailTuples...>,
+          decltype(std::tuple_cat(
+              std::declval<for_each_tuple_cat_t<OutTupleOfTuples,
+                                                std::tuple<HeadArgs>>>()...))> {
+};
+
+template <class OutTupleOfTuples>
+struct cartesian_product_impl<std::tuple<>, OutTupleOfTuples> {
+  using type = OutTupleOfTuples;
+};
+
+/// Generate a std::tuple cartesian product from multiple tuple-like structures
+/// (std::tuple, std::integer_sequence and std::pair) Do not rely on the
+/// ordering result.
+template <class... InTuplesLike>
+using cartesian_product_t =
+    typename cartesian_product_impl<std::tuple<to_tuple_t<InTuplesLike>...>,
+                                    std::tuple<std::tuple<>>>::type;
+
+/// Transform a std::tuple<Args...> to a testing::Types<Args...>, identity
+/// otherwise
+template <class T>
+struct tuple_to_types {
+  using type = T;
+};
+
+template <class... Args>
+struct tuple_to_types<std::tuple<Args...>> {
+  using type = testing::Types<Args...>;
+};
+
+template <class T>
+using tuple_to_types_t = typename tuple_to_types<T>::type;
 
 #endif


### PR DESCRIPTION
This PR aims at adding more traits for unary and binary operations to `KokkosFFT_traits.hpp`.
This will be applied in another PR to improve error handlings as commented in #80

Following modifications are made

Static assertion to Unary (`fftshift`, `ifftshift`) and Binary (`Plan` and `fft` functions) APIs. Applications of new traits (unchecked tasks) would be done in another PR.

- [x] Introduce `is_view_operatable_v` for Unary operation (Views can be accessible from `Execspace` and the base value types are `float/double/Kokkos::complex<float>/Kokkos::complex<double>`. In addition, layout is either `Kokkos::LayoutLeft` or `Kokkos::LayoutRight`.
- [x] Introduce `are_views_operatable_v` for Binary operation (Both Views are `operatable` and have the same `precision`, `layout` and `rank`)
- [x] Introduce ~~`have_same_precision_v`~~ `have_same_base_floating_point_type_v`  for Binary operation (the values have the same ~~precision~~ base floating point type. For example, `float` and `Kokkos::complex<float>` have the same precision)
- [x] Introduce `have_same_layout_v` for Binary operation
- [x] Introduce `have_same_rank_v` for Binary operation
- [ ] Apply `are_views_operatable_v` to binary APIs. Exec space and memory space consistency, precision consistency, layout consistency and rank consistency.
- [ ] Apply `is_view_operatable_v` to unary APIs. Exec space and memory space consistency.