### PR TITLE
Apply traits to operations

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -7,6 +7,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
@@ -131,16 +132,6 @@ void roll(const ExecutionSpace& exec_space, ViewType& inout, axis_type<2> shift,
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
 void fftshift_impl(const ExecutionSpace& exec_space, ViewType& inout,
                    axis_type<DIM> axes) {
-  static_assert(Kokkos::is_view<ViewType>::value,
-                "fftshift_impl: ViewType is not a Kokkos::View.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<ViewType>,
-      "fftshift_impl: ViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename ViewType::memory_space>::accessible,
-      "fftshift_impl: execution_space cannot access data in ViewType");
-
   static_assert(ViewType::rank() >= DIM,
                 "fftshift_impl: Rank of View must be larger thane "
                 "or equal to the Rank of shift axes.");
@@ -151,16 +142,6 @@ void fftshift_impl(const ExecutionSpace& exec_space, ViewType& inout,
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
 void ifftshift_impl(const ExecutionSpace& exec_space, ViewType& inout,
                     axis_type<DIM> axes) {
-  static_assert(Kokkos::is_view<ViewType>::value,
-                "ifftshift_impl: ViewType is not a Kokkos::View.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<ViewType>,
-      "ifftshift_impl: ViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename ViewType::memory_space>::accessible,
-      "ifftshift_impl: execution_space cannot access data in ViewType");
-
   static_assert(ViewType::rank() >= DIM,
                 "ifftshift_impl: Rank of View must be larger "
                 "thane or equal to the Rank of shift axes.");
@@ -243,6 +224,11 @@ auto rfftfreq(const ExecutionSpace&, const std::size_t n,
 template <typename ExecutionSpace, typename ViewType>
 void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
               std::optional<int> axes = std::nullopt) {
+  static_assert(KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace, ViewType>,
+                "fftshift: View value type must be float, double, "
+                "Kokkos::Complex<float>, or Kokkos::Complex<double>. "
+                "Layout must be either LayoutLeft or LayoutRight. "
+                "ExecutionSpace must be able to access data in ViewType");
   if (axes) {
     axis_type<1> _axes{axes.value()};
     KokkosFFT::Impl::fftshift_impl(exec_space, inout, _axes);
@@ -262,6 +248,11 @@ void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
 void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
               axis_type<DIM> axes) {
+  static_assert(KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace, ViewType>,
+                "fftshift: View value type must be float, double, "
+                "Kokkos::Complex<float>, or Kokkos::Complex<double>. "
+                "Layout must be either LayoutLeft or LayoutRight. "
+                "ExecutionSpace must be able to access data in ViewType");
   KokkosFFT::Impl::fftshift_impl(exec_space, inout, axes);
 }
 
@@ -273,6 +264,11 @@ void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
 template <typename ExecutionSpace, typename ViewType>
 void ifftshift(const ExecutionSpace& exec_space, ViewType& inout,
                std::optional<int> axes = std::nullopt) {
+  static_assert(KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace, ViewType>,
+                "ifftshift: View value type must be float, double, "
+                "Kokkos::Complex<float>, or Kokkos::Complex<double>. "
+                "Layout must be either LayoutLeft or LayoutRight. "
+                "ExecutionSpace must be able to access data in ViewType");
   if (axes) {
     axis_type<1> _axes{axes.value()};
     KokkosFFT::Impl::ifftshift_impl(exec_space, inout, _axes);
@@ -292,6 +288,11 @@ void ifftshift(const ExecutionSpace& exec_space, ViewType& inout,
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
 void ifftshift(const ExecutionSpace& exec_space, ViewType& inout,
                axis_type<DIM> axes) {
+  static_assert(KokkosFFT::Impl::is_operatable_view_v<ExecutionSpace, ViewType>,
+                "ifftshift: View value type must be float, double, "
+                "Kokkos::Complex<float>, or Kokkos::Complex<double>. "
+                "Layout must be either LayoutLeft or LayoutRight. "
+                "ExecutionSpace must be able to access data in ViewType");
   KokkosFFT::Impl::ifftshift_impl(exec_space, inout, axes);
 }
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -13,6 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
+#include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_transpose.hpp"
 #include "KokkosFFT_padding.hpp"
 #include "KokkosFFT_utils.hpp"
@@ -158,33 +159,14 @@ class Plan {
                 OutViewType& out, KokkosFFT::Direction direction, int axis,
                 std::optional<std::size_t> n = std::nullopt)
       : m_exec_space(exec_space), m_axes({axis}), m_direction(direction) {
-    static_assert(Kokkos::is_view<InViewType>::value,
-                  "Plan::Plan: InViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<OutViewType>::value,
-                  "Plan::Plan: OutViewType is not a Kokkos::View.");
     static_assert(
-        KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-        "Plan::Plan: InViewType must be either LayoutLeft or LayoutRight.");
-    static_assert(
-        KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-        "Plan::Plan: OutViewType must be either LayoutLeft or LayoutRight.");
-
-    static_assert(InViewType::rank() == OutViewType::rank(),
-                  "Plan::Plan: InViewType and OutViewType must have "
-                  "the same rank.");
-    static_assert(std::is_same_v<typename InViewType::array_layout,
-                                 typename OutViewType::array_layout>,
-                  "Plan::Plan: InViewType and OutViewType must have "
-                  "the same Layout.");
-
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename InViewType::memory_space>::accessible,
-        "Plan::Plan: execution_space cannot access data in InViewType");
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename OutViewType::memory_space>::accessible,
-        "Plan::Plan: execution_space cannot access data in OutViewType");
+        KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                                OutViewType>,
+        "Plan::Plan: InViewType and OutViewType must have the same base "
+        "floating point type (float/double), the same layout "
+        "(LayoutLeft/LayoutRight), "
+        "and the same rank. ExecutionSpace must be accessible to the data in "
+        "InViewType and OutViewType.");
 
     if (KokkosFFT::Impl::is_real_v<in_value_type> &&
         m_direction != KokkosFFT::Direction::forward) {
@@ -230,34 +212,14 @@ class Plan {
                 OutViewType& out, KokkosFFT::Direction direction,
                 axis_type<DIM> axes, shape_type<DIM> s = {0})
       : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
-    static_assert(Kokkos::is_view<InViewType>::value,
-                  "Plan::Plan: InViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<OutViewType>::value,
-                  "Plan::Plan: OutViewType is not a Kokkos::View.");
     static_assert(
-        KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-        "Plan::Plan: InViewType must be either LayoutLeft or LayoutRight.");
-    static_assert(
-        KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-        "Plan::Plan: OutViewType must be either LayoutLeft or LayoutRight.");
-
-    static_assert(InViewType::rank() == OutViewType::rank(),
-                  "Plan::Plan: InViewType and OutViewType must have "
-                  "the same rank.");
-
-    static_assert(std::is_same_v<typename InViewType::array_layout,
-                                 typename OutViewType::array_layout>,
-                  "Plan::Plan: InViewType and OutViewType must have "
-                  "the same Layout.");
-
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename InViewType::memory_space>::accessible,
-        "Plan::Plan: execution_space cannot access data in InViewType");
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename OutViewType::memory_space>::accessible,
-        "Plan::Plan: execution_space cannot access data in OutViewType");
+        KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                                OutViewType>,
+        "Plan::Plan: InViewType and OutViewType must have the same base "
+        "floating point type (float/double), the same layout "
+        "(LayoutLeft/LayoutRight), "
+        "and the same rank. ExecutionSpace must be accessible to the data in "
+        "InViewType and OutViewType.");
 
     if (std::is_floating_point<in_value_type>::value &&
         m_direction != KokkosFFT::Direction::forward) {
@@ -302,15 +264,6 @@ class Plan {
   /// \param out [in] Ouput data
   template <typename InViewType2, typename OutViewType2>
   void good(const InViewType2& in, const OutViewType2& out) const {
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename InViewType2::memory_space>::accessible,
-        "Plan::good: execution_space cannot access data in InViewType");
-    static_assert(
-        Kokkos::SpaceAccessibility<
-            ExecutionSpace, typename OutViewType2::memory_space>::accessible,
-        "Plan::good: execution_space cannot access data in OutViewType");
-
     using nonConstInViewType2  = std::remove_cv_t<InViewType2>;
     using nonConstOutViewType2 = std::remove_cv_t<OutViewType2>;
     static_assert(std::is_same_v<nonConstInViewType2, nonConstInViewType>,

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -7,6 +7,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
+#include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_normalization.hpp"
 #include "KokkosFFT_transpose.hpp"
@@ -50,35 +51,6 @@ template <typename PlanType, typename InViewType, typename OutViewType>
 void exec_impl(
     const PlanType& plan, const InViewType& in, OutViewType& out,
     KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "exec_impl: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "exec_impl: OutViewType is not a Kokkos::View.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-      "exec_impl: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "exec_impl: OutViewType must be either LayoutLeft or LayoutRight.");
-
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "exec_impl: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "exec_impl: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  using ExecutionSpace = typename PlanType::execSpace;
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "exec_impl: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "exec_impl: execution_space cannot access data in OutViewType");
-
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -99,34 +71,14 @@ void fft_exec_impl(
     const PlanType& plan, const InViewType& in, OutViewType& out,
     // KokkosFFT::Direction direction,
     KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fft_exec_impl: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fft_exec_impl: OutViewType is not a Kokkos::View.");
   static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-      "fft_exec_impl: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "fft_exec_impl: OutViewType must be either LayoutLeft or LayoutRight.");
-
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fft_exec_impl: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fft_exec_impl: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  using ExecutionSpace = typename PlanType::execSpace;
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fft_exec_impl: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fft_exec_impl: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "fft_exec_impl: InViewType and OutViewType must have the same base "
+      "floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   plan.template good<InViewType, OutViewType>(in, out);
 
@@ -178,30 +130,13 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
          OutViewType& out,
          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
          int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "fft: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axis, n);
@@ -221,30 +156,13 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
           OutViewType& out,
           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
           int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "ifft: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axis, n);
@@ -264,30 +182,13 @@ void rfft(const ExecutionSpace& exec_space, const InViewType& in,
           OutViewType& out,
           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
           int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "rfft: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -313,30 +214,14 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rifft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "irfft: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -361,30 +246,13 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
           OutViewType& out,
           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
           int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "hfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "hfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "hfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "hfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "hfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "hfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "hfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "hfft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "hfft: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   // [TO DO]
   // allow real type as input, need to obtain complex view type from in view
@@ -417,30 +285,14 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            int axis = -1, std::optional<std::size_t> n = std::nullopt) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ihfft: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ihfft: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ihfft: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ihfft: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ihfft: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ihfft: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ihfft: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ihfft: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "ihfft: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -471,30 +323,13 @@ void fft2(const ExecutionSpace& exec_space, const InViewType& in,
           OutViewType& out,
           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
           axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fft2: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "fft2: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
@@ -514,30 +349,14 @@ void ifft2(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifft2: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "ifft2: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
@@ -557,31 +376,14 @@ void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfft2: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfft2: execution_space cannot access data in OutViewType");
-
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "rfft2: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
@@ -606,31 +408,14 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
             OutViewType& out,
             KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
             axis_type<2> axes = {-2, -1}, shape_type<2> s = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfft2: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfft2: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfft2: InViewType must be either LayoutLeft or LayoutRight.");
   static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "irfft2: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfft2: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfft2: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfft2: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfft2: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "irfft2: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -659,30 +444,13 @@ void fftn(const ExecutionSpace& exec_space, const InViewType& in,
           OutViewType& out, axis_type<DIM> axes,
           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
           shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "fftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "fftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "fftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "fftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "fftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "fftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "fftn: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "fftn: InViewType and OutViewType must have the same base floating point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
@@ -703,30 +471,14 @@ void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out, axis_type<DIM> axes,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "ifftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "ifftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "ifftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "ifftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "ifftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "ifftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "ifftn: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "ifftn: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
@@ -747,30 +499,14 @@ void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
            OutViewType& out, axis_type<DIM> axes,
            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
            shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "rfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "rfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "rfftn: InViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-                "rfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "rfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "rfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
   static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "rfftn: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "rfftn: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
@@ -797,31 +533,14 @@ void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
             OutViewType& out, axis_type<DIM> axes,
             KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
             shape_type<DIM> s             = {0}) {
-  static_assert(Kokkos::is_view<InViewType>::value,
-                "irfftn: InViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<OutViewType>::value,
-                "irfftn: OutViewType is not a Kokkos::View.");
-  static_assert(KokkosFFT::Impl::is_layout_left_or_right_v<InViewType>,
-                "irfftn: InViewType must be either LayoutLeft or LayoutRight.");
   static_assert(
-      KokkosFFT::Impl::is_layout_left_or_right_v<OutViewType>,
-      "irfftn: OutViewType must be either LayoutLeft or LayoutRight.");
-  static_assert(InViewType::rank() == OutViewType::rank(),
-                "irfftn: InViewType and OutViewType must have "
-                "the same rank.");
-  static_assert(std::is_same_v<typename InViewType::array_layout,
-                               typename OutViewType::array_layout>,
-                "irfftn: InViewType and OutViewType must have "
-                "the same Layout.");
-
-  static_assert(
-      Kokkos::SpaceAccessibility<ExecutionSpace,
-                                 typename InViewType::memory_space>::accessible,
-      "irfftn: execution_space cannot access data in InViewType");
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          ExecutionSpace, typename OutViewType::memory_space>::accessible,
-      "irfftn: execution_space cannot access data in OutViewType");
+      KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
+                                              OutViewType>,
+      "irfftn: InViewType and OutViewType must have the same base floating "
+      "point "
+      "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
+      "same rank. ExecutionSpace must be accessible to the data in InViewType "
+      "and OutViewType.");
 
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;


### PR DESCRIPTION
Improves #80

This PR aims at applying new traits from `KokkosFFT_traits.hpp` to unary (`fftshift`, `ifftshift`) and binary  (`Plan` and `fft` functions) operations.

Static assertions are applied to Unary  and Binary APIs.

- [x] Introduce `is_view_operatable_v` for Unary operation (Views can be accessible from `Execspace` and the base value types are `float/double/Kokkos::complex<float>/Kokkos::complex<double>`. In addition, layout is either `Kokkos::LayoutLeft` or `Kokkos::LayoutRight`.
- [x] Introduce `are_views_operatable_v` for Binary operation (Both Views are `operatable` and have the same `precision`, `layout` and `rank`)
- [x] Introduce `have_same_base_floating_point_type_v`  for Binary operation (the values have the same base floating point type. For example, `float` and `Kokkos::complex<float>` have the same base floating point type)
- [x] Introduce `have_same_layout_v` for Binary operation
- [x] Introduce `have_same_rank_v` for Binary operation
- [x] Apply `are_views_operatable_v` to binary APIs. Exec space and memory space consistency, precision consistency, layout consistency and rank consistency.
- [x] Apply `is_view_operatable_v` to unary APIs. Exec space and memory space consistency.