### PR TITLE
Replace assert with runtime error

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -23,12 +23,12 @@ auto get_shift(const ViewType& inout, axis_type<DIM> _axes, int direction = 1) {
 
   // Assert if the elements are overlapped
   constexpr int rank = ViewType::rank();
-  check_precondition(!KokkosFFT::Impl::has_duplicate_values(axes),
-                     "axes are overlapped");
-  check_precondition(
+  KOKKOSFFT_EXPECTS(!KokkosFFT::Impl::has_duplicate_values(axes),
+                    "Axes overlap");
+  KOKKOSFFT_EXPECTS(
       !KokkosFFT::Impl::is_out_of_range_value_included(axes, rank),
-      "axes include out of range index."
-      "axes should be in the range of [-rank, rank-1].");
+      "Axes include an out-of-range index."
+      "Axes must be in the range of [-rank, rank-1].");
 
   axis_type<rank> shift = {0};
   for (int i = 0; i < static_cast<int>(DIM); i++) {

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -23,8 +23,14 @@ auto get_shift(const ViewType& inout, axis_type<DIM> _axes, int direction = 1) {
 
   // Assert if the elements are overlapped
   constexpr int rank = ViewType::rank();
-  assert(!KokkosFFT::Impl::has_duplicate_values(axes));
-  assert(!KokkosFFT::Impl::is_out_of_range_value_included(axes, rank));
+  if (KokkosFFT::Impl::has_duplicate_values(axes)) {
+    throw std::runtime_error("get_shift: axes are overlapped.");
+  }
+  if (KokkosFFT::Impl::is_out_of_range_value_included(axes, rank)) {
+    throw std::runtime_error(
+        "get_shift: axes include out of range index."
+        "axes should be in the range of [-rank, rank-1].");
+  }
 
   axis_type<rank> shift = {0};
   for (int i = 0; i < static_cast<int>(DIM); i++) {

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -23,14 +23,12 @@ auto get_shift(const ViewType& inout, axis_type<DIM> _axes, int direction = 1) {
 
   // Assert if the elements are overlapped
   constexpr int rank = ViewType::rank();
-  if (KokkosFFT::Impl::has_duplicate_values(axes)) {
-    throw std::runtime_error("get_shift: axes are overlapped.");
-  }
-  if (KokkosFFT::Impl::is_out_of_range_value_included(axes, rank)) {
-    throw std::runtime_error(
-        "get_shift: axes include out of range index."
-        "axes should be in the range of [-rank, rank-1].");
-  }
+  check_precondition(!KokkosFFT::Impl::has_duplicate_values(axes),
+                     "axes are overlapped");
+  check_precondition(
+      !KokkosFFT::Impl::is_out_of_range_value_included(axes, rank),
+      "axes include out of range index."
+      "axes should be in the range of [-rank, rank-1].");
 
   axis_type<rank> shift = {0};
   for (int i = 0; i < static_cast<int>(DIM); i++) {

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -67,12 +67,11 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   if (is_real_v<in_value_type>) {
     // Then R2C
     if (is_complex_v<out_value_type>) {
-      if (_out_extents.at(inner_most_axis) !=
-          _in_extents.at(inner_most_axis) / 2 + 1) {
-        throw std::runtime_error(
-            "For R2C, the output extent of transform should be input extent / "
-            "2 + 1");
-      }
+      KOKKOSFFT_EXPECTS(
+          _out_extents.at(inner_most_axis) ==
+              _in_extents.at(inner_most_axis) / 2 + 1,
+          "For R2C, the 'output extent' of transform must be equal to "
+          "'input extent'/2 + 1");
     } else {
       throw std::runtime_error(
           "If the input type is real, the output type should be complex");
@@ -82,12 +81,11 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   if (is_real_v<out_value_type>) {
     // Then C2R
     if (is_complex_v<in_value_type>) {
-      if (_in_extents.at(inner_most_axis) !=
-          _out_extents.at(inner_most_axis) / 2 + 1) {
-        throw std::runtime_error(
-            "For C2R, the input extent of transform should be output extent / "
-            "2 + 1");
-      }
+      KOKKOSFFT_EXPECTS(
+          _in_extents.at(inner_most_axis) ==
+              _out_extents.at(inner_most_axis) / 2 + 1,
+          "For C2R, the 'input extent' of transform must be equal to "
+          "'output extent' / 2 + 1");
     } else {
       throw std::runtime_error(
           "If the output type is real, the input type should be complex");

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -67,8 +67,12 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   if (is_real_v<in_value_type>) {
     // Then R2C
     if (is_complex_v<out_value_type>) {
-      assert(_out_extents.at(inner_most_axis) ==
-             _in_extents.at(inner_most_axis) / 2 + 1);
+      if (_out_extents.at(inner_most_axis) !=
+          _in_extents.at(inner_most_axis) / 2 + 1) {
+        throw std::runtime_error(
+            "For R2C, the output extent of transform should be input extent / "
+            "2 + 1");
+      }
     } else {
       throw std::runtime_error(
           "If the input type is real, the output type should be complex");
@@ -78,8 +82,12 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   if (is_real_v<out_value_type>) {
     // Then C2R
     if (is_complex_v<in_value_type>) {
-      assert(_in_extents.at(inner_most_axis) ==
-             _out_extents.at(inner_most_axis) / 2 + 1);
+      if (_in_extents.at(inner_most_axis) !=
+          _out_extents.at(inner_most_axis) / 2 + 1) {
+        throw std::runtime_error(
+            "For C2R, the input extent of transform should be output extent / "
+            "2 + 1");
+      }
     } else {
       throw std::runtime_error(
           "If the output type is real, the input type should be complex");

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -51,14 +51,12 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   }
 
   // Assert if the elements are overlapped
-  if (KokkosFFT::Impl::has_duplicate_values(positive_axes)) {
-    throw std::runtime_error("get_modified_shape: axes are overlapped.");
-  }
-  if (KokkosFFT::Impl::is_out_of_range_value_included(positive_axes, rank)) {
-    throw std::runtime_error(
-        "get_modified_shape: axes include out of range index."
-        "axes should be in the range of [-rank, rank-1].");
-  }
+  KOKKOSFFT_EXPECTS(!KokkosFFT::Impl::has_duplicate_values(positive_axes),
+                    "Axes overlap");
+  KOKKOSFFT_EXPECTS(
+      !KokkosFFT::Impl::is_out_of_range_value_included(positive_axes, rank),
+      "Axes include an out-of-range index."
+      "Axes must be in the range of [-rank, rank-1].");
 
   using full_shape_type = shape_type<rank>;
   full_shape_type modified_shape;

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -51,8 +51,14 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   }
 
   // Assert if the elements are overlapped
-  assert(!KokkosFFT::Impl::has_duplicate_values(positive_axes));
-  assert(!KokkosFFT::Impl::is_out_of_range_value_included(positive_axes, rank));
+  if (KokkosFFT::Impl::has_duplicate_values(positive_axes)) {
+    throw std::runtime_error("get_modified_shape: axes are overlapped.");
+  }
+  if (KokkosFFT::Impl::is_out_of_range_value_included(positive_axes, rank)) {
+    throw std::runtime_error(
+        "get_modified_shape: axes include out of range index."
+        "axes should be in the range of [-rank, rank-1].");
+  }
 
   using full_shape_type = shape_type<rank>;
   full_shape_type modified_shape;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -26,7 +26,10 @@ auto convert_negative_axis(ViewType, int _axis = -1) {
   static_assert(Kokkos::is_view<ViewType>::value,
                 "convert_negative_axis: ViewType is not a Kokkos::View.");
   int rank = static_cast<int>(ViewType::rank());
-  assert(_axis >= -rank && _axis < rank);  // axis should be in [-rank, rank-1]
+  if (_axis < -rank || _axis >= rank) {
+    throw std::runtime_error("axis should be in [-rank, rank-1]");
+  }
+
   int axis = _axis < 0 ? rank + _axis : _axis;
   return axis;
 }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -50,26 +50,21 @@ inline void check_precondition(const bool expression,
   }
   throw std::runtime_error(ss.str());
 }
-inline void check_precondition(const bool expression, const std::string& msg,
-                               const char* file_name, int line,
-                               const char* function_name) {
-  std::stringstream ss("file: ");
-  ss << file_name << '(' << line << ") `" << function_name << "`: " << msg
-     << '\n';
-  if (!expression) {
-    throw std::runtime_error(ss.str());
-  }
-}
-#endif
 
 template <typename ViewType>
 auto convert_negative_axis(ViewType, int _axis = -1) {
   static_assert(Kokkos::is_view<ViewType>::value,
                 "convert_negative_axis: ViewType is not a Kokkos::View.");
   int rank = static_cast<int>(ViewType::rank());
+<<<<<<< HEAD
   if (_axis < -rank || _axis >= rank) {
     throw std::runtime_error("axis should be in [-rank, rank-1]");
   }
+=======
+
+  KOKKOSFFT_EXPECTS(_axis >= -rank && _axis < rank,
+                    "Axis must be in [-rank, rank-1]");
+>>>>>>> a786585 (improve assertion)
 
   int axis = _axis < 0 ? rank + _axis : _axis;
   return axis;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -56,15 +56,9 @@ auto convert_negative_axis(ViewType, int _axis = -1) {
   static_assert(Kokkos::is_view<ViewType>::value,
                 "convert_negative_axis: ViewType is not a Kokkos::View.");
   int rank = static_cast<int>(ViewType::rank());
-<<<<<<< HEAD
-  if (_axis < -rank || _axis >= rank) {
-    throw std::runtime_error("axis should be in [-rank, rank-1]");
-  }
-=======
 
   KOKKOSFFT_EXPECTS(_axis >= -rank && _axis < rank,
                     "Axis must be in [-rank, rank-1]");
->>>>>>> a786585 (improve assertion)
 
   int axis = _axis < 0 ? rank + _axis : _axis;
   return axis;

--- a/common/unit_test/Test_Layouts.cpp
+++ b/common/unit_test/Test_Layouts.cpp
@@ -52,6 +52,10 @@ void test_layouts_1d() {
   EXPECT_TRUE(fft_extents_r2c == ref_fft_extents_r2c);
   EXPECT_EQ(howmany_r2c, 1);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr, xcout, axes_type({0})); },
+               std::runtime_error);
+
   // C2R
   std::vector<int> ref_in_extents_c2r(1), ref_out_extents_c2r(1),
       ref_fft_extents_c2r(1);
@@ -65,6 +69,10 @@ void test_layouts_1d() {
   EXPECT_TRUE(out_extents_c2r == ref_out_extents_c2r);
   EXPECT_TRUE(fft_extents_c2r == ref_fft_extents_c2r);
   EXPECT_EQ(howmany_c2r, 1);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin, xr, axes_type({0})); },
+               std::runtime_error);
 
   // C2C
   std::vector<int> ref_in_extents_c2c(1), ref_out_extents_c2c(1),
@@ -111,6 +119,10 @@ void test_layouts_1d_batched_FFT_2d() {
   EXPECT_TRUE(out_extents_r2c_axis0 == ref_out_extents_r2c_axis0);
   EXPECT_EQ(howmany_r2c_axis0, ref_howmany_r2c_axis0);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr2, xcout2, axes_type({0})); },
+               std::runtime_error);
+
   auto [in_extents_r2c_axis1, out_extents_r2c_axis1, fft_extents_r2c_axis1,
         howmany_r2c_axis1] =
       KokkosFFT::Impl::get_extents(xr2, xc2_axis1, axes_type({1}));
@@ -118,6 +130,10 @@ void test_layouts_1d_batched_FFT_2d() {
   EXPECT_TRUE(fft_extents_r2c_axis1 == ref_fft_extents_r2c_axis1);
   EXPECT_TRUE(out_extents_r2c_axis1 == ref_out_extents_r2c_axis1);
   EXPECT_EQ(howmany_r2c_axis1, ref_howmany_r2c_axis1);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr2, xcout2, axes_type({1})); },
+               std::runtime_error);
 
   // C2R
   auto [in_extents_c2r_axis0, out_extents_c2r_axis0, fft_extents_c2r_axis0,
@@ -128,6 +144,10 @@ void test_layouts_1d_batched_FFT_2d() {
   EXPECT_TRUE(out_extents_c2r_axis0 == ref_in_extents_r2c_axis0);
   EXPECT_EQ(howmany_c2r_axis0, ref_howmany_r2c_axis0);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin2, xr2, axes_type({0})); },
+               std::runtime_error);
+
   auto [in_extents_c2r_axis1, out_extents_c2r_axis1, fft_extents_c2r_axis1,
         howmany_c2r_axis1] =
       KokkosFFT::Impl::get_extents(xc2_axis1, xr2, axes_type({1}));
@@ -135,6 +155,10 @@ void test_layouts_1d_batched_FFT_2d() {
   EXPECT_TRUE(fft_extents_c2r_axis1 == ref_fft_extents_r2c_axis1);
   EXPECT_TRUE(out_extents_c2r_axis1 == ref_in_extents_r2c_axis1);
   EXPECT_EQ(howmany_c2r_axis1, ref_howmany_r2c_axis1);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin2, xr2, axes_type({1})); },
+               std::runtime_error);
 
   // C2C
   auto [in_extents_c2c_axis0, out_extents_c2c_axis0, fft_extents_c2c_axis0,
@@ -193,6 +217,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_r2c_axis0 == ref_out_extents_r2c_axis0);
   EXPECT_EQ(howmany_r2c_axis0, ref_howmany_r2c_axis0);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({0})); },
+               std::runtime_error);
+
   auto [in_extents_r2c_axis1, out_extents_r2c_axis1, fft_extents_r2c_axis1,
         howmany_r2c_axis1] =
       KokkosFFT::Impl::get_extents(xr3, xc3_axis1, axes_type({1}));
@@ -201,6 +229,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_r2c_axis1 == ref_out_extents_r2c_axis1);
   EXPECT_EQ(howmany_r2c_axis1, ref_howmany_r2c_axis1);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({1})); },
+               std::runtime_error);
+
   auto [in_extents_r2c_axis2, out_extents_r2c_axis2, fft_extents_r2c_axis2,
         howmany_r2c_axis2] =
       KokkosFFT::Impl::get_extents(xr3, xc3_axis2, axes_type({2}));
@@ -208,6 +240,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_r2c_axis2 == ref_fft_extents_r2c_axis2);
   EXPECT_TRUE(out_extents_r2c_axis2 == ref_out_extents_r2c_axis2);
   EXPECT_EQ(howmany_r2c_axis2, ref_howmany_r2c_axis2);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({2})); },
+               std::runtime_error);
 
   // C2R
   auto [in_extents_c2r_axis0, out_extents_c2r_axis0, fft_extents_c2r_axis0,
@@ -218,6 +254,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_c2r_axis0 == ref_in_extents_r2c_axis0);
   EXPECT_EQ(howmany_c2r_axis0, ref_howmany_r2c_axis0);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({0})); },
+               std::runtime_error);
+
   auto [in_extents_c2r_axis1, out_extents_c2r_axis1, fft_extents_c2r_axis1,
         howmany_c2r_axis1] =
       KokkosFFT::Impl::get_extents(xc3_axis1, xr3, axes_type({1}));
@@ -226,6 +266,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_c2r_axis1 == ref_in_extents_r2c_axis1);
   EXPECT_EQ(howmany_c2r_axis1, ref_howmany_r2c_axis1);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({1})); },
+               std::runtime_error);
+
   auto [in_extents_c2r_axis2, out_extents_c2r_axis2, fft_extents_c2r_axis2,
         howmany_c2r_axis2] =
       KokkosFFT::Impl::get_extents(xc3_axis2, xr3, axes_type({2}));
@@ -233,6 +277,10 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_c2r_axis2 == ref_fft_extents_r2c_axis2);
   EXPECT_TRUE(out_extents_c2r_axis2 == ref_in_extents_r2c_axis2);
   EXPECT_EQ(howmany_c2r_axis2, ref_howmany_r2c_axis2);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW({ KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({2})); },
+               std::runtime_error);
 
   // C2C
   auto [in_extents_c2c_axis0, out_extents_c2c_axis0, fft_extents_c2c_axis0,
@@ -318,6 +366,19 @@ void test_layouts_2d() {
   EXPECT_EQ(howmany_r2c_axis01, 1);
   EXPECT_EQ(howmany_r2c_axis10, 1);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr2, xcout2, axes_type({0, 1}));
+      },
+      std::runtime_error);
+
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr2, xcout2, axes_type({1, 0}));
+      },
+      std::runtime_error);
+
   // C2R
   auto [in_extents_c2r_axis01, out_extents_c2r_axis01, fft_extents_c2r_axis01,
         howmany_c2r_axis01] =
@@ -336,6 +397,19 @@ void test_layouts_2d() {
 
   EXPECT_EQ(howmany_c2r_axis01, 1);
   EXPECT_EQ(howmany_c2r_axis10, 1);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin2, xr2, axes_type({0, 1}));
+      },
+      std::runtime_error);
+
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin2, xr2, axes_type({1, 0}));
+      },
+      std::runtime_error);
 
   // C2C
   auto [in_extents_c2c_axis01, out_extents_c2c_axis01, fft_extents_c2c_axis01,
@@ -414,6 +488,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_r2c_axis_01 == ref_out_extents_r2c_axis_01);
   EXPECT_EQ(howmany_r2c_axis_01, ref_howmany_r2c_axis_01);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({0, 1}));
+      },
+      std::runtime_error);
+
   auto [in_extents_r2c_axis_02, out_extents_r2c_axis_02,
         fft_extents_r2c_axis_02, howmany_r2c_axis_02] =
       KokkosFFT::Impl::get_extents(xr3, xc3_axis_02, axes_type({0, 2}));
@@ -421,6 +502,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_r2c_axis_02 == ref_fft_extents_r2c_axis_02);
   EXPECT_TRUE(out_extents_r2c_axis_02 == ref_out_extents_r2c_axis_02);
   EXPECT_EQ(howmany_r2c_axis_02, ref_howmany_r2c_axis_02);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({0, 2}));
+      },
+      std::runtime_error);
 
   auto [in_extents_r2c_axis_10, out_extents_r2c_axis_10,
         fft_extents_r2c_axis_10, howmany_r2c_axis_10] =
@@ -430,6 +518,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_r2c_axis_10 == ref_out_extents_r2c_axis_10);
   EXPECT_EQ(howmany_r2c_axis_10, ref_howmany_r2c_axis_10);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({1, 0}));
+      },
+      std::runtime_error);
+
   auto [in_extents_r2c_axis_12, out_extents_r2c_axis_12,
         fft_extents_r2c_axis_12, howmany_r2c_axis_12] =
       KokkosFFT::Impl::get_extents(xr3, xc3_axis_12, axes_type({1, 2}));
@@ -437,6 +532,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_r2c_axis_12 == ref_fft_extents_r2c_axis_12);
   EXPECT_TRUE(out_extents_r2c_axis_12 == ref_out_extents_r2c_axis_12);
   EXPECT_EQ(howmany_r2c_axis_12, ref_howmany_r2c_axis_12);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({1, 2}));
+      },
+      std::runtime_error);
 
   auto [in_extents_r2c_axis_20, out_extents_r2c_axis_20,
         fft_extents_r2c_axis_20, howmany_r2c_axis_20] =
@@ -446,6 +548,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_r2c_axis_20 == ref_out_extents_r2c_axis_20);
   EXPECT_EQ(howmany_r2c_axis_20, ref_howmany_r2c_axis_20);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({2, 0}));
+      },
+      std::runtime_error);
+
   auto [in_extents_r2c_axis_21, out_extents_r2c_axis_21,
         fft_extents_r2c_axis_21, howmany_r2c_axis_21] =
       KokkosFFT::Impl::get_extents(xr3, xc3_axis_21, axes_type({2, 1}));
@@ -453,6 +562,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_r2c_axis_21 == ref_fft_extents_r2c_axis_21);
   EXPECT_TRUE(out_extents_r2c_axis_21 == ref_out_extents_r2c_axis_21);
   EXPECT_EQ(howmany_r2c_axis_21, ref_howmany_r2c_axis_21);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xr3, xcout3, axes_type({2, 1}));
+      },
+      std::runtime_error);
 
   // C2R
   auto [in_extents_c2r_axis_01, out_extents_c2r_axis_01,
@@ -463,6 +579,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_c2r_axis_01 == ref_in_extents_r2c_axis_01);
   EXPECT_EQ(howmany_c2r_axis_01, ref_howmany_r2c_axis_01);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({0, 1}));
+      },
+      std::runtime_error);
+
   auto [in_extents_c2r_axis_02, out_extents_c2r_axis_02,
         fft_extents_c2r_axis_02, howmany_c2r_axis_02] =
       KokkosFFT::Impl::get_extents(xc3_axis_02, xr3, axes_type({0, 2}));
@@ -470,6 +593,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_c2r_axis_02 == ref_fft_extents_r2c_axis_02);
   EXPECT_TRUE(out_extents_c2r_axis_02 == ref_in_extents_r2c_axis_02);
   EXPECT_EQ(howmany_c2r_axis_02, ref_howmany_r2c_axis_02);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({0, 2}));
+      },
+      std::runtime_error);
 
   auto [in_extents_c2r_axis_10, out_extents_c2r_axis_10,
         fft_extents_c2r_axis_10, howmany_c2r_axis_10] =
@@ -479,6 +609,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_c2r_axis_10 == ref_in_extents_r2c_axis_10);
   EXPECT_EQ(howmany_c2r_axis_10, ref_howmany_r2c_axis_10);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({1, 0}));
+      },
+      std::runtime_error);
+
   auto [in_extents_c2r_axis_12, out_extents_c2r_axis_12,
         fft_extents_c2r_axis_12, howmany_c2r_axis_12] =
       KokkosFFT::Impl::get_extents(xc3_axis_12, xr3, axes_type({1, 2}));
@@ -486,6 +623,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_c2r_axis_12 == ref_fft_extents_r2c_axis_12);
   EXPECT_TRUE(out_extents_c2r_axis_12 == ref_in_extents_r2c_axis_12);
   EXPECT_EQ(howmany_c2r_axis_12, ref_howmany_r2c_axis_12);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({1, 2}));
+      },
+      std::runtime_error);
 
   auto [in_extents_c2r_axis_20, out_extents_c2r_axis_20,
         fft_extents_c2r_axis_20, howmany_c2r_axis_20] =
@@ -495,6 +639,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(out_extents_c2r_axis_20 == ref_in_extents_r2c_axis_20);
   EXPECT_EQ(howmany_c2r_axis_20, ref_howmany_r2c_axis_20);
 
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({2, 0}));
+      },
+      std::runtime_error);
+
   auto [in_extents_c2r_axis_21, out_extents_c2r_axis_21,
         fft_extents_c2r_axis_21, howmany_c2r_axis_21] =
       KokkosFFT::Impl::get_extents(xc3_axis_21, xr3, axes_type({2, 1}));
@@ -502,6 +653,13 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_TRUE(fft_extents_c2r_axis_21 == ref_fft_extents_r2c_axis_21);
   EXPECT_TRUE(out_extents_c2r_axis_21 == ref_in_extents_r2c_axis_21);
   EXPECT_EQ(howmany_c2r_axis_21, ref_howmany_r2c_axis_21);
+
+  // Check if errors are correctly raised aginst invalid extents
+  EXPECT_THROW(
+      {
+        KokkosFFT::Impl::get_extents(xcin3, xr3, axes_type({2, 1}));
+      },
+      std::runtime_error);
 
   // C2C
   auto [in_extents_c2c_axis_01, out_extents_c2c_axis_01,

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -38,6 +38,14 @@ void test_convert_negative_axes_1d() {
 
   EXPECT_EQ(converted_axis_0, ref_converted_axis_0);
   EXPECT_EQ(converted_axis_minus1, ref_converted_axis_minus1);
+
+  // Check if errors are correctly raised aginst invalid axis
+  // axis must be in [-1, 1)
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/1); },
+               std::runtime_error);
+
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-2); },
+               std::runtime_error);
 }
 
 template <typename LayoutType>
@@ -58,6 +66,14 @@ void test_convert_negative_axes_2d() {
   EXPECT_EQ(converted_axis_0, ref_converted_axis_0);
   EXPECT_EQ(converted_axis_1, ref_converted_axis_1);
   EXPECT_EQ(converted_axis_minus1, ref_converted_axis_minus1);
+
+  // Check if errors are correctly raised aginst invalid axis
+  // axis must be in [-2, 2)
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/2); },
+               std::runtime_error);
+
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-3); },
+               std::runtime_error);
 }
 
 template <typename LayoutType>
@@ -85,6 +101,14 @@ void test_convert_negative_axes_3d() {
   EXPECT_EQ(converted_axis_2, ref_converted_axis_2);
   EXPECT_EQ(converted_axis_minus1, ref_converted_axis_minus1);
   EXPECT_EQ(converted_axis_minus2, ref_converted_axis_minus2);
+
+  // Check if errors are correctly raised aginst invalid axis
+  // axis must be in [-3, 3)
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/3); },
+               std::runtime_error);
+
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-4); },
+               std::runtime_error);
 }
 
 template <typename LayoutType>
@@ -119,6 +143,14 @@ void test_convert_negative_axes_4d() {
   EXPECT_EQ(converted_axis_minus1, ref_converted_axis_minus1);
   EXPECT_EQ(converted_axis_minus2, ref_converted_axis_minus2);
   EXPECT_EQ(converted_axis_minus3, ref_converted_axis_minus3);
+
+  // Check if errors are correctly raised aginst invalid axis
+  // axis must be in [-4, 4)
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/4); },
+               std::runtime_error);
+
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-5); },
+               std::runtime_error);
 }
 
 // Tests for 1D View
@@ -247,6 +279,18 @@ TEST(GetIndex, Vectors) {
   EXPECT_THROW(KokkosFFT::Impl::get_index(v, -1), std::runtime_error);
 
   EXPECT_THROW(KokkosFFT::Impl::get_index(v, 5), std::runtime_error);
+}
+
+TEST(HasDuplicateValues, Array) {
+  std::vector<int> v0 = {0, 1, 1};
+  std::vector<int> v1 = {0, 1, 1, 1};
+  std::vector<int> v2 = {0, 1, 2, 3};
+  std::vector<int> v3 = {0};
+
+  EXPECT_TRUE(KokkosFFT::Impl::has_duplicate_values(v0));
+  EXPECT_TRUE(KokkosFFT::Impl::has_duplicate_values(v1));
+  EXPECT_FALSE(KokkosFFT::Impl::has_duplicate_values(v2));
+  EXPECT_FALSE(KokkosFFT::Impl::has_duplicate_values(v3));
 }
 
 TEST(IsOutOfRangeValueIncluded, Array) {


### PR DESCRIPTION
Improves #80

This PR aims at replacing runtime `assert` with `std::runtime_error` with appropriate messages.
If there is inconsistency in extents, we cannot operate FFT.

Modifications are applied to `get_shift`, `get_extents`, `get_modified_shape` and `convert_negative_axis`. For example, in `get_shift`, we replaced `assert` with `std::runtime_error` in the following way.

```C++
// Previous check
assert(!KokkosFFT::Impl::has_duplicate_values(axes));

// Current check
//if (KokkosFFT::Impl::has_duplicate_values(axes)) {
//    throw std::runtime_error("get_shift: axes are overlapped.");
//}
//check_precondition(!KokkosFFT::Impl::has_duplicate_values(axes),
//                   "axes are overlapped");
KOKKOSFFT_EXPECTS(!KokkosFFT::Impl::has_duplicate_values(axes),
                  "axes are overlapped");
```

Following modifications are made
- [x] Replacing runtime `assert` with `std::runtime_error`
- [x] Add corresponding tests to check `std::runtime_error` is correctly thrown.
- [x] Add missing test for `has_duplicate_values`
- [x] Introduce ~~`check_precondition(expression, message)` function~~ `KOKKOSFFT_EXPECTS(expression, message)`macro