### PR TITLE
Improve check functions

### DIFF
--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -215,6 +215,31 @@ inline constexpr bool are_operatable_views_v =
 
 // Other traits
 
+template <typename ContainerType>
+struct base_container_value;
+
+template <template <typename, typename...> class ContainerType,
+          typename ValueType, typename... Args>
+struct base_container_value<ContainerType<ValueType, Args...>> {
+  using value_type = ValueType;
+};
+
+// Specialization for std::array
+template <typename ValueType, std::size_t N>
+struct base_container_value<std::array<ValueType, N>> {
+  using value_type = ValueType;
+};
+
+// Specialization for Kokkos::Array
+template <typename ValueType, std::size_t N>
+struct base_container_value<Kokkos::Array<ValueType, N>> {
+  using value_type = ValueType;
+};
+
+/// \brief Helper to extract the base value type from a container
+template <typename T>
+using base_container_value_type = typename base_container_value<T>::value_type;
+
 /// \brief Helper to define a managable View type from the original view type
 template <typename T>
 struct managable_view_type {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -127,11 +127,9 @@ bool are_valid_axes(const ViewType& view, const ArrayType<IntType, DIM>& axes) {
                 "are_valid_axes: View rank must be larger than or equal to the "
                 "Rank of FFT axes");
 
+  // Convert the input axes to be in the range of [0, rank-1]
   // int type is choosen for consistency with the rest of the code
   // the axes are defined with int type
-  constexpr int rank = ViewType::rank();
-
-  // Convert the input axes to be in the range of [0, rank-1]
   std::array<int, DIM> non_negative_axes;
 
   // In case axis is out of range, 'convert_negative_axis' will throw an

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -130,9 +130,16 @@ bool are_valid_axes(const ViewType& view, const ArrayType<IntType, DIM>& axes) {
 
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> non_negative_axes;
-  for (std::size_t i = 0; i < DIM; i++) {
-    int axis = KokkosFFT::Impl::convert_negative_axis(view, axes[i]);
-    non_negative_axes.push_back(axis);
+
+  // In case of exception, we capture it and return false,
+  // since we do not want to throw an exception here
+  try {
+    for (std::size_t i = 0; i < DIM; i++) {
+      int axis = KokkosFFT::Impl::convert_negative_axis(view, axes[i]);
+      non_negative_axes.push_back(axis);
+    }
+  } catch (std::exception& e) {
+    return false;
   }
 
   bool is_valid = (!KokkosFFT::Impl::has_duplicate_values(non_negative_axes)) &&

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -87,11 +87,11 @@ auto convert_negative_shift(const ViewType& view, int _shift, int _axis) {
 }
 
 template <typename ContainerType, typename ValueType>
-bool is_found(ContainerType& values, const ValueType& key) {
+bool is_found(ContainerType& values, const ValueType& value) {
   using value_type = KokkosFFT::Impl::base_container_value_type<ContainerType>;
   static_assert(std::is_same_v<value_type, ValueType>,
                 "Container value type must match ValueType");
-  return std::find(values.begin(), values.end(), key) != values.end();
+  return std::find(values.begin(), values.end(), value) != values.end();
 }
 
 template <typename ContainerType>
@@ -158,16 +158,16 @@ bool is_transpose_needed(std::array<int, DIM> map) {
 }
 
 template <typename ContainerType, typename ValueType>
-std::size_t get_index(ContainerType& values, const ValueType& key) {
+std::size_t get_index(ContainerType& values, const ValueType& value) {
   using value_type = KokkosFFT::Impl::base_container_value_type<ContainerType>;
   static_assert(std::is_same_v<value_type, ValueType>,
                 "Container value type must match ValueType");
-  auto it           = std::find(values.begin(), values.end(), key);
+  auto it           = std::find(values.begin(), values.end(), value);
   std::size_t index = 0;
   if (it != values.end()) {
     index = it - values.begin();
   } else {
-    throw std::runtime_error("key is not included in values");
+    throw std::runtime_error("value is not included in values");
   }
 
   return index;

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -379,9 +379,8 @@ void test_are_valid_axes() {
   EXPECT_TRUE(KokkosFFT::Impl::are_valid_axes(view4, axes2));
   EXPECT_TRUE(KokkosFFT::Impl::are_valid_axes(view4, axes4));
 
-  // 3D axes on 3D Views with out of range -> should throw
-  EXPECT_THROW(KokkosFFT::Impl::are_valid_axes(view3, axes4),
-               std::runtime_error);
+  // 3D axes on 3D Views with out of range -> should fail
+  EXPECT_FALSE(KokkosFFT::Impl::are_valid_axes(view3, axes4));
 
   // axes include overlap -> should fail
   EXPECT_FALSE(KokkosFFT::Impl::are_valid_axes(view3, axes3));

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -385,6 +385,18 @@ void test_are_valid_axes() {
   // axes include overlap -> should fail
   EXPECT_FALSE(KokkosFFT::Impl::are_valid_axes(view3, axes3));
   EXPECT_FALSE(KokkosFFT::Impl::are_valid_axes(view4, axes3));
+
+  if constexpr (std::is_signed_v<IntType>) {
+    // {0, 1, -2} is converted to {0, 1, 1} for 3D View and {0, 1, 2}
+    // for 4D View. Invalid for 3D View but valid for 4D View
+    std::array<IntType, 3> axes5 = {0, 1, -2};
+
+    // axes include overlap -> should fail
+    EXPECT_FALSE(KokkosFFT::Impl::are_valid_axes(view3, axes5));
+
+    // axes do not include overlap -> OK
+    EXPECT_TRUE(KokkosFFT::Impl::are_valid_axes(view4, axes5));
+  }
 }
 
 TYPED_TEST(ContainerTypes, is_found_from_vector) {


### PR DESCRIPTION
Improves #80

This PR aims at extending some check functions to work on `std::array` or `std::vector`. A check function `are_valid_axes` has been introduced. For this purpose, a new trait to extract the base value type has been added.

Following modifications are made
- [x] Add a trait `base_container_value_type` to extract the base value type of a container
- [x] Update existing check functions to work on `std::array` or `std::vector`.
- [x] Introduce a new check function `are_valid_axes` to check if the axes are valid for input Views