### PR TITLE
Allow coexistence of three different execution spaces

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -73,7 +73,7 @@ jobs:
               cxx: g++
             cmake_flags:
               cxx_standard: 17
-              kokkos: -DKokkos_ENABLE_OPENMP=ON
+              kokkos: -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
           - name: threads
             image: gcc
@@ -100,7 +100,7 @@ jobs:
               cxx: g++
             cmake_flags:
               cxx_standard: 17
-              kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+              kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
           - name: hip
             image: rocm
@@ -109,7 +109,7 @@ jobs:
               cxx: hipcc
             cmake_flags:
               cxx_standard: 17
-              kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
+              kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON -DKokkos_ENABLE_THREADS=ON
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
           - name: rocm
             image: rocm

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -261,14 +261,11 @@ struct complex_view_type {
   using type = Kokkos::View<complex_type*, array_layout_type, ExecutionSpace>;
 };
 
-template <typename ExecutionSpace, typename Enable = void>
-struct is_AnyHostSpace : std::false_type {};
-
 template <typename ExecutionSpace>
-struct is_AnyHostSpace<ExecutionSpace,
-                       std::enable_if_t<Kokkos::SpaceAccessibility<
-                           ExecutionSpace, Kokkos::HostSpace>::accessible>>
-    : std::true_type {};
+struct is_AnyHostSpace
+    : std::integral_constant<
+          bool, Kokkos::SpaceAccessibility<ExecutionSpace,
+                                           Kokkos::HostSpace>::accessible> {};
 
 /// \brief Helper to check if the ExecutionSpace is one of the enabled
 /// HostExecutionSpaces
@@ -279,13 +276,9 @@ inline constexpr bool is_AnyHostSpace_v =
 #if !defined(ENABLE_HOST_AND_DEVICE) &&                           \
     (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
      defined(KOKKOS_ENABLE_SYCL))
-template <typename ExecutionSpace, typename Enable = void>
-struct is_AllowedSpace : std::false_type {};
 template <typename ExecutionSpace>
-struct is_AllowedSpace<ExecutionSpace,
-                       std::enable_if_t<std::is_same_v<
-                           ExecutionSpace, Kokkos::DefaultExecutionSpace>>>
-    : std::true_type {};
+struct is_AllowedSpace
+    : std::is_same<ExecutionSpace, Kokkos::DefaultExecutionSpace> {};
 #else
 template <typename ExecutionSpace>
 struct is_AllowedSpace : std::true_type {};

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -263,21 +263,12 @@ struct complex_view_type {
 
 template <typename ExecutionSpace, typename Enable = void>
 struct is_AnyHostSpace : std::false_type {};
-#if defined(KOKKOS_ENABLE_SERIAL)
-template <typename ExecutionSpace>
-struct is_AnyHostSpace<
-    ExecutionSpace,
-    std::enable_if_t<
-        std::is_same_v<ExecutionSpace, Kokkos::Serial> ||
-        std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>>>
-    : std::true_type {};
-#else
+
 template <typename ExecutionSpace>
 struct is_AnyHostSpace<ExecutionSpace,
-                       std::enable_if_t<std::is_same_v<
-                           ExecutionSpace, Kokkos::DefaultHostExecutionSpace>>>
+                       std::enable_if_t<Kokkos::SpaceAccessibility<
+                           ExecutionSpace, Kokkos::HostSpace>::accessible>>
     : std::true_type {};
-#endif
 
 /// \brief Helper to check if the ExecutionSpace is one of the enabled
 /// HostExecutionSpaces

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -126,7 +126,7 @@ void test_is_any_host_exec_space() {
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
   static_assert(KokkosFFT::Impl::is_AnyHostSpace_v<Kokkos::Threads>,
-                "Kokkos::THREADS must be a HostSpace");
+                "Kokkos::Threads must be a HostSpace");
 #endif
 }
 

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -114,6 +114,27 @@ TYPED_TEST_SUITE(PairedValueTypes, paired_value_types);
 TYPED_TEST_SUITE(PairedLayoutTypes, paired_layout_types);
 TYPED_TEST_SUITE(PairedViewTypes, paired_view_types);
 
+// Tests for host execution space
+void test_is_any_host_exec_space() {
+#if defined(KOKKOS_ENABLE_SERIAL)
+  static_assert(KokkosFFT::Impl::is_AnyHostSpace_v<Kokkos::Serial>,
+                "Kokkos::Serial must be a HostSpace");
+#endif
+#if defined(KOKKOS_ENABLE_OPENMP)
+  static_assert(KokkosFFT::Impl::is_AnyHostSpace_v<Kokkos::OpenMP>,
+                "Kokkos::OpenMP must be a HostSpace");
+#endif
+#if defined(KOKKOS_ENABLE_THREADS)
+  static_assert(KokkosFFT::Impl::is_AnyHostSpace_v<Kokkos::Threads>,
+                "Kokkos::THREADS must be a HostSpace");
+#endif
+}
+
+TEST(ExecutionSpace, test_is_any_host_exec_space) {
+  GTEST_SKIP() << "Skipping all tests";
+  test_is_any_host_exec_space();
+}
+
 // Tests for base value type deduction
 template <typename ValueType, typename ContainerType>
 void test_get_container_value_type() {

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -32,9 +32,8 @@ void init_threads([[maybe_unused]] const ExecutionSpace& exec_space) {
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
           typename OutViewType, typename BufferViewType, typename InfoType,
           std::size_t fft_rank = 1,
-          std::enable_if_t<
-              is_HostSpace_v<ExecutionSpace>,
-              std::nullptr_t> = nullptr>
+          std::enable_if_t<is_AnyHostSpace_v<ExecutionSpace>, std::nullptr_t> =
+              nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
@@ -109,9 +108,8 @@ auto create_plan(const ExecutionSpace& exec_space,
 }
 
 template <typename ExecutionSpace, typename PlanType, typename InfoType,
-          std::enable_if_t<
-              is_HostSpace_v<ExecutionSpace>,
-              std::nullptr_t> = nullptr>
+          std::enable_if_t<is_AnyHostSpace_v<ExecutionSpace>, std::nullptr_t> =
+              nullptr>
 void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   if constexpr (std::is_same_v<PlanType, fftwf_plan>) {
     fftwf_destroy_plan(*plan);

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -8,9 +8,11 @@
 #include <numeric>
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_traits.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
+
 template <typename ExecutionSpace, typename T>
 void init_threads([[maybe_unused]] const ExecutionSpace& exec_space) {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
@@ -31,7 +33,7 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
           typename OutViewType, typename BufferViewType, typename InfoType,
           std::size_t fft_rank = 1,
           std::enable_if_t<
-              std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
+              is_HostSpace_v<ExecutionSpace>,
               std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
@@ -108,7 +110,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
 template <typename ExecutionSpace, typename PlanType, typename InfoType,
           std::enable_if_t<
-              std::is_same_v<ExecutionSpace, Kokkos::DefaultHostExecutionSpace>,
+              is_HostSpace_v<ExecutionSpace>,
               std::nullptr_t> = nullptr>
 void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
   if constexpr (std::is_same_v<PlanType, fftwf_plan>) {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -155,10 +155,11 @@ class Plan {
   /// \param axis [in] Axis over which FFT is performed
   /// \param n [in] Length of the transformed axis of the output (optional)
   //
-  explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
-                OutViewType& out, KokkosFFT::Direction direction, int axis,
-                std::optional<std::size_t> n = std::nullopt,
-                std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
+  explicit Plan(
+      const ExecutionSpace& exec_space, InViewType& in, OutViewType& out,
+      KokkosFFT::Direction direction, int axis,
+      std::optional<std::size_t> n = std::nullopt,
+      std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
       : m_exec_space(exec_space), m_axes({axis}), m_direction(direction) {
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
@@ -211,10 +212,11 @@ class Plan {
   /// \param axes [in] Axes over which FFT is performed
   /// \param s [in] Shape of the transformed axis of the output (optional)
   //
-  explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
-                OutViewType& out, KokkosFFT::Direction direction,
-                axis_type<DIM> axes, shape_type<DIM> s = {0},
-                std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
+  explicit Plan(
+      const ExecutionSpace& exec_space, InViewType& in, OutViewType& out,
+      KokkosFFT::Direction direction, axis_type<DIM> axes,
+      shape_type<DIM> s                                              = {0},
+      std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
       : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
@@ -261,7 +263,7 @@ class Plan {
                                                                         m_info);
   }
 
-  Plan() = delete;
+  Plan()            = delete;
   Plan(const Plan&) = delete;
   Plan& operator=(const Plan&) = delete;
   Plan& operator=(Plan&&) = delete;

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -155,12 +155,12 @@ class Plan {
   /// \param axis [in] Axis over which FFT is performed
   /// \param n [in] Length of the transformed axis of the output (optional)
   //
-  explicit Plan(
-      const ExecutionSpace& exec_space, InViewType& in, OutViewType& out,
-      KokkosFFT::Direction direction, int axis,
-      std::optional<std::size_t> n = std::nullopt,
-      std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
+  explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
+                OutViewType& out, KokkosFFT::Direction direction, int axis,
+                std::optional<std::size_t> n = std::nullopt)
       : m_exec_space(exec_space), m_axes({axis}), m_direction(direction) {
+    static_assert(KokkosFFT::Impl::is_AllowedSpace_v<ExecutionSpace>,
+                  "Plan::Plan: ExecutionSpace is not allowed ");
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                                 OutViewType>,
@@ -212,12 +212,12 @@ class Plan {
   /// \param axes [in] Axes over which FFT is performed
   /// \param s [in] Shape of the transformed axis of the output (optional)
   //
-  explicit Plan(
-      const ExecutionSpace& exec_space, InViewType& in, OutViewType& out,
-      KokkosFFT::Direction direction, axis_type<DIM> axes,
-      shape_type<DIM> s                                              = {0},
-      std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
+  explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
+                OutViewType& out, KokkosFFT::Direction direction,
+                axis_type<DIM> axes, shape_type<DIM> s = {0})
       : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
+    static_assert(KokkosFFT::Impl::is_AllowedSpace_v<ExecutionSpace>,
+                  "Plan::Plan: ExecutionSpace is not allowed ");
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                                 OutViewType>,

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -157,7 +157,8 @@ class Plan {
   //
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
                 OutViewType& out, KokkosFFT::Direction direction, int axis,
-                std::optional<std::size_t> n = std::nullopt)
+                std::optional<std::size_t> n = std::nullopt,
+                std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
       : m_exec_space(exec_space), m_axes({axis}), m_direction(direction) {
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
@@ -212,7 +213,8 @@ class Plan {
   //
   explicit Plan(const ExecutionSpace& exec_space, InViewType& in,
                 OutViewType& out, KokkosFFT::Direction direction,
-                axis_type<DIM> axes, shape_type<DIM> s = {0})
+                axis_type<DIM> axes, shape_type<DIM> s = {0},
+                std::enable_if_t<is_AllowedSpace_v<execSpace>, std::nullptr_t> = nullptr)
       : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
     static_assert(
         KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
@@ -259,6 +261,7 @@ class Plan {
                                                                         m_info);
   }
 
+  Plan() = delete;
   Plan(const Plan&) = delete;
   Plan& operator=(const Plan&) = delete;
   Plan& operator=(Plan&&) = delete;

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -58,6 +58,27 @@ TYPED_TEST_SUITE(Plans3D, test_types);
 
 // Tests for execution space
 template <typename ExecutionSpace>
+void test_allowed_exec_space() {
+#if !defined(ENABLE_HOST_AND_DEVICE) &&                           \
+    (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+     defined(KOKKOS_ENABLE_SYCL))
+  // For GPUs without ENABLE_HOST_AND_DEVICE, a plan can be constructible from
+  // Kokkos::DefaultExecutionSpace only
+  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>) {
+    static_assert(KokkosFFT::Impl::is_AllowedSpace_v<ExecutionSpace>);
+  } else {
+    static_assert(!KokkosFFT::Impl::is_AllowedSpace_v<ExecutionSpace>);
+  }
+#else
+  // For CPUs or GPUs with ENABLE_HOST_AND_DEVICE,
+  // a plan can be constructible from Kokkos::DefaultExecutionSpace,
+  // Kokkos::DefaultHostExecutionSpace or Kokkos::Serial (if enabled)
+  static_assert(KokkosFFT::Impl::is_AllowedSpace_v<ExecutionSpace>);
+#endif
+}
+
+// Tests for execution space
+template <typename ExecutionSpace>
 void test_plan_constructible() {
   using ValueType      = double;
   using RealView1DType = Kokkos::View<ValueType*, ExecutionSpace>;
@@ -75,10 +96,6 @@ void test_plan_constructible() {
     static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&,
                                           RealView1DType&, ComplexView1DType&,
                                           KokkosFFT::Direction, int>);
-  } else {
-    static_assert(!std::is_constructible_v<PlanType, const ExecutionSpace&,
-                                           RealView1DType&, ComplexView1DType&,
-                                           KokkosFFT::Direction, int>);
   }
 #else
   // For CPUs or GPUs with ENABLE_HOST_AND_DEVICE,
@@ -88,6 +105,12 @@ void test_plan_constructible() {
       std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&,
                               ComplexView1DType&, KokkosFFT::Direction, int>);
 #endif
+}
+
+// Tests for plan constructiblility
+TYPED_TEST(ExecutionSpaceType, is_allowed_space) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  test_allowed_exec_space<execution_space_type>();
 }
 
 // Tests for 1D FFT plan on 1D View

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -15,9 +15,9 @@ using test_types = ::testing::Types<std::pair<float, Kokkos::LayoutLeft>,
                                     std::pair<double, Kokkos::LayoutRight> >;
 
 #if defined(KOKKOS_ENABLE_SERIAL)
-using execution_spaces = ::testing::Types<Kokkos::Serial,
-                                          Kokkos::DefaultHostExecutionSpace,
-                                          Kokkos::DefaultExecutionSpace>;
+using execution_spaces =
+    ::testing::Types<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace,
+                     Kokkos::DefaultExecutionSpace>;
 #else
 using execution_spaces = ::testing::Types<Kokkos::DefaultHostExecutionSpace,
                                           Kokkos::DefaultExecutionSpace>;
@@ -59,24 +59,35 @@ TYPED_TEST_SUITE(Plans3D, test_types);
 // Tests for execution space
 template <typename ExecutionSpace>
 void test_plan_constructible() {
-  using ValueType = double;
+  using ValueType      = double;
   using RealView1DType = Kokkos::View<ValueType*, ExecutionSpace>;
   using ComplexView1DType =
       Kokkos::View<Kokkos::complex<ValueType>*, ExecutionSpace>;
-  using PlanType = KokkosFFT::Impl::Plan<ExecutionSpace, RealView1DType, ComplexView1DType>;
+  using PlanType =
+      KokkosFFT::Impl::Plan<ExecutionSpace, RealView1DType, ComplexView1DType>;
 
-  #if !defined(ENABLE_HOST_AND_DEVICE) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL))
-    // For GPUs without ENABLE_HOST_AND_DEVICE, a plan can be constructible from Kokkos::DefaultExecutionSpace only
-    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>) {
-      static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
-    } else {
-      static_assert(!std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
-    }
-  #else
-    // For CPUs or GPUs with ENABLE_HOST_AND_DEVICE, 
-    // a plan can be constructible from Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace or Kokkos::Serial (if enabled)
-    static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
-  #endif
+#if !defined(ENABLE_HOST_AND_DEVICE) &&                           \
+    (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+     defined(KOKKOS_ENABLE_SYCL))
+  // For GPUs without ENABLE_HOST_AND_DEVICE, a plan can be constructible from
+  // Kokkos::DefaultExecutionSpace only
+  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>) {
+    static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&,
+                                          RealView1DType&, ComplexView1DType&,
+                                          KokkosFFT::Direction, int>);
+  } else {
+    static_assert(!std::is_constructible_v<PlanType, const ExecutionSpace&,
+                                           RealView1DType&, ComplexView1DType&,
+                                           KokkosFFT::Direction, int>);
+  }
+#else
+  // For CPUs or GPUs with ENABLE_HOST_AND_DEVICE,
+  // a plan can be constructible from Kokkos::DefaultExecutionSpace,
+  // Kokkos::DefaultHostExecutionSpace or Kokkos::Serial (if enabled)
+  static_assert(
+      std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&,
+                              ComplexView1DType&, KokkosFFT::Direction, int>);
+#endif
 }
 
 // Tests for 1D FFT plan on 1D View

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -14,6 +14,24 @@ using test_types = ::testing::Types<std::pair<float, Kokkos::LayoutLeft>,
                                     std::pair<double, Kokkos::LayoutLeft>,
                                     std::pair<double, Kokkos::LayoutRight> >;
 
+#if defined(KOKKOS_ENABLE_SERIAL)
+using execution_spaces = ::testing::Types<Kokkos::Serial,
+                                          Kokkos::DefaultHostExecutionSpace,
+                                          Kokkos::DefaultExecutionSpace>;
+#else
+using execution_spaces = ::testing::Types<Kokkos::DefaultHostExecutionSpace,
+                                          Kokkos::DefaultExecutionSpace>;
+#endif
+
+template <typename T>
+struct ExecutionSpaceType : public ::testing::Test {
+  using execution_space_type = T;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
+};
+
 // Basically the same fixtures, used for labeling tests
 template <typename T>
 struct Plans1D : public ::testing::Test {
@@ -33,9 +51,39 @@ struct Plans3D : public ::testing::Test {
   using layout_type = typename T::second_type;
 };
 
+TYPED_TEST_SUITE(ExecutionSpaceType, execution_spaces);
 TYPED_TEST_SUITE(Plans1D, test_types);
 TYPED_TEST_SUITE(Plans2D, test_types);
 TYPED_TEST_SUITE(Plans3D, test_types);
+
+// Tests for execution space
+template <typename ExecutionSpace>
+void test_plan_constructible() {
+  using ValueType = double;
+  using RealView1DType = Kokkos::View<ValueType*, ExecutionSpace>;
+  using ComplexView1DType =
+      Kokkos::View<Kokkos::complex<ValueType>*, ExecutionSpace>;
+  using PlanType = KokkosFFT::Impl::Plan<ExecutionSpace, RealView1DType, ComplexView1DType>;
+
+  #if !defined(ENABLE_HOST_AND_DEVICE) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL))
+    // For GPUs without ENABLE_HOST_AND_DEVICE, a plan can be constructible from Kokkos::DefaultExecutionSpace only
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>) {
+      static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
+    } else {
+      static_assert(!std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
+    }
+  #else
+    // For CPUs or GPUs with ENABLE_HOST_AND_DEVICE, 
+    // a plan can be constructible from Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace or Kokkos::Serial (if enabled)
+    static_assert(std::is_constructible_v<PlanType, const ExecutionSpace&, RealView1DType&, ComplexView1DType&, KokkosFFT::Direction, int>);
+  #endif
+}
+
+// Tests for 1D FFT plan on 1D View
+TYPED_TEST(ExecutionSpaceType, is_constrcutrible) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  test_plan_constructible<execution_space_type>();
+}
 
 // Tests for 1D FFT Plans
 template <typename T, typename LayoutType>


### PR DESCRIPTION
Resolves #79

This PR aims at allowing the coexistence of three different execution spaces.

Following modifications are made
- [x] Fix bugs not to allow instantiate a `Plan` with `Serial` execution space if both `HostSerial` and `HostParallel` are enabled
- [x] Disallow the creation of a `Plan` if execution space is not appropriate
- [x] Add compile time tests for the plan creation again execution space 
- [x] Improve CI to test build with multiple host backends (Added 28/August/2024)
