### PR TITLE
Use clang tidy in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,5 +4,7 @@
 
 Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
 FormatStyle: file
+HeaderFileExtensions: ['h','hh','hpp','hxx']
+ImplementationFileExtensions: ['c','cc','cpp','cxx']
 HeaderFilterRegex: '(common|fft).*\.hpp'
-ExcludeHeaderFilterRegex: '(tpls).*\.hpp'
+ExcludeHeaderFilterRegex: '(tpls).*\.(h|cc|hpp)'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
+Checks: '-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
 FormatStyle: file
 HeaderFileExtensions: ['h','hh','hpp','hxx']
 ImplementationFileExtensions: ['c','cc','cpp','cxx']
 HeaderFilterRegex: '(common|fft).*\.hpp'
-ExcludeHeaderFilterRegex: '(tpls).*\.(hpp)'
+ExcludeHeaderFilterRegex: 'tpls.*\.hpp'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,4 +7,4 @@ FormatStyle: file
 HeaderFileExtensions: ['h','hh','hpp','hxx']
 ImplementationFileExtensions: ['c','cc','cpp','cxx']
 HeaderFilterRegex: '(common|fft).*\.hpp'
-ExcludeHeaderFilterRegex: '(tpls).*\.(h|cc|hpp)'
+ExcludeHeaderFilterRegex: '(tpls).*\.(hpp)'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
+FormatStyle: file
+HeaderFilterRegex: '(common|fft).*\.hpp'
+ExcludeHeaderFilterRegex: '(tpls).*\.hpp'

--- a/.github/workflows/__build_base.yaml
+++ b/.github/workflows/__build_base.yaml
@@ -37,6 +37,8 @@ jobs:
         image:
           - name: gcc
             use_singularity: false
+          - name: clang
+            use_singularity: false
           - name: nvcc
             use_singularity: true
           - name: rocm

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -83,7 +83,7 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: threads
             image: gcc
             compiler:
@@ -92,7 +92,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: serial
             image: gcc
             compiler:
@@ -101,7 +101,7 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: cuda
             image: nvcc
             compiler:
@@ -110,7 +110,7 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: hip
             image: rocm
             compiler:
@@ -119,7 +119,7 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: rocm
             image: rocm
             compiler:
@@ -128,7 +128,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
           - name: sycl
             image: intel
             compiler:
@@ -139,7 +139,7 @@ jobs:
               # device, so for now, we simply generate generic Intel GPU code
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_SYCL=ON -DKokkos_ARCH_INTEL_GEN=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DKokkosFFT_ENABLE_BENCHMARK=ON
         target:
           - name: native
             cmake_flags: ""
@@ -185,7 +185,6 @@ jobs:
             -DCMAKE_CXX_STANDARD=${{ matrix.backend.cmake_flags.cxx_standard }} \
             -DKokkosFFT_ENABLE_EXAMPLES=ON \
             -DKokkosFFT_ENABLE_TESTS=ON \
-            -DKokkosFFT_ENABLE_BENCHMARK=ON \
             -DKokkosFFT_ENABLE_INTERNAL_KOKKOS=ON \
             ${{ matrix.backend.cmake_flags.kokkos }} \
             ${{ matrix.backend.cmake_flags.kokkos_fft }} \

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -75,6 +75,7 @@ jobs:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_SERIAL=ON
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
+              benchmark: OFF
           - name: openmp
             image: gcc
             compiler:
@@ -83,7 +84,8 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              benchmark: ON
           - name: threads
             image: gcc
             compiler:
@@ -92,7 +94,8 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              benchmark: ON
           - name: serial
             image: gcc
             compiler:
@@ -101,7 +104,8 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              benchmark: ON
           - name: cuda
             image: nvcc
             compiler:
@@ -110,7 +114,8 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              benchmark: ON
           - name: hip
             image: rocm
             compiler:
@@ -119,7 +124,8 @@ jobs:
             cmake_flags:
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              benchmark: ON
           - name: rocm
             image: rocm
             compiler:
@@ -128,7 +134,8 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
+              benchmark: ON
           - name: sycl
             image: intel
             compiler:
@@ -139,7 +146,8 @@ jobs:
               # device, so for now, we simply generate generic Intel GPU code
               cxx_standard: 17
               kokkos: -DKokkos_ENABLE_SYCL=ON -DKokkos_ARCH_INTEL_GEN=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DKokkosFFT_ENABLE_BENCHMARK=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
+              benchmark: ON
         target:
           - name: native
             cmake_flags: ""
@@ -184,6 +192,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.backend.compiler.cxx }} \
             -DCMAKE_CXX_STANDARD=${{ matrix.backend.cmake_flags.cxx_standard }} \
             -DKokkosFFT_ENABLE_EXAMPLES=ON \
+            -DKokkosFFT_ENABLE_BENCHMARK=${{ matrix.backend.cmake_flags.benchmark }} \
             -DKokkosFFT_ENABLE_TESTS=ON \
             -DKokkosFFT_ENABLE_INTERNAL_KOKKOS=ON \
             ${{ matrix.backend.cmake_flags.kokkos }} \

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -73,7 +73,7 @@ jobs:
               cxx: clang++
             cmake_flags:
               cxx_standard: 17
-              kokkos: -DKokkos_ENABLE_OPENMP=ON
+              kokkos: -DKokkos_ENABLE_SERIAL=ON
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
           - name: openmp
             image: gcc

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -66,6 +66,15 @@ jobs:
     strategy:
       matrix:
         backend:
+          - name: clang-tidy
+            image: clang
+            compiler:
+              c: clang
+              cxx: clang++
+            cmake_flags:
+              cxx_standard: 17
+              kokkos: -DKokkos_ENABLE_OPENMP=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
           - name: openmp
             image: gcc
             compiler:
@@ -137,6 +146,10 @@ jobs:
           - name: host_device
             cmake_flags: -DKokkosFFT_ENABLE_HOST_AND_DEVICE=ON
         exclude:
+          - backend:
+              name: clang-tidy
+            target:
+              name: host_device
           - backend:
               name: openmp
             target:

--- a/.github/workflows/cleanup_base.yaml
+++ b/.github/workflows/cleanup_base.yaml
@@ -31,5 +31,7 @@ jobs:
             kokkos-fft/base_rocm_pr
             kokkos-fft/base_gcc_main
             kokkos-fft/base_gcc_pr
+            kokkos-fft/base_clang_main
+            kokkos-fft/base_clang_pr
             kokkos-fft/base_intel_main
             kokkos-fft/base_intel_pr

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -92,7 +92,7 @@ auto get_extents(const InViewType& in, const OutViewType& out,
     }
   }
 
-  if (std::is_same<array_layout_type, Kokkos::LayoutLeft>::value) {
+  if (std::is_same_v<array_layout_type, Kokkos::LayoutLeft>) {
     std::reverse(_in_extents.begin(), _in_extents.end());
     std::reverse(_out_extents.begin(), _out_extents.end());
     std::reverse(_fft_extents.begin(), _fft_extents.end());

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -40,7 +40,7 @@ auto get_map_axes(const ViewType& view, axis_type<DIM> _axes) {
   map.reserve(rank);
   map_inv.reserve(rank);
 
-  if (std::is_same<array_layout_type, Kokkos::LayoutRight>::value) {
+  if (std::is_same_v<array_layout_type, Kokkos::LayoutRight>) {
     // Stack axes not specified by axes (0, 1, 4)
     for (int i = 0; i < rank; i++) {
       if (!is_found(axes, i)) {

--- a/docker/clang/Dockerfile
+++ b/docker/clang/Dockerfile
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+ARG BASE=ubuntu:latest
+FROM $BASE
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        wget \
+        gnupg \
+        lsb-release \
+        software-properties-common \
+        git \
+        bc \
+        ccache \
+        libfftw3-dev \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV FFTWDIR "/usr"
+
+RUN git config --global --add safe.directory "*"
+
+# Add the official LLVM repository to install Clang and Clang-tidy version 19
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh 19
+
+# Install Clang++ version 19 and Clang-tidy version 19
+RUN apt-get update && apt-get install -y \
+    clang-19 \
+    clang-tidy-19 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN KEYDUMP_URL=https://cloud.cees.ornl.gov/download && \
+    KEYDUMP_FILE=keydump && \
+    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE} && \
+    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE}.sig && \
+    gpg --import ${KEYDUMP_FILE} && \
+    gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
+    rm ${KEYDUMP_FILE}*
+
+ARG CMAKE_VERSION=3.23.2
+ENV CMAKE_DIR=/opt/cmake
+RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
+    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    CMAKE_SHA256=cmake-${CMAKE_VERSION}-SHA-256.txt && \
+    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256} && \
+    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256}.asc && \
+    wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
+    gpg --verify ${CMAKE_SHA256}.asc ${CMAKE_SHA256} && \
+    grep -i ${CMAKE_SCRIPT} ${CMAKE_SHA256} | sed -e s/linux/Linux/ | sha256sum --check && \
+    mkdir -p ${CMAKE_DIR} && \
+    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
+    rm cmake*
+ENV PATH=${CMAKE_DIR}/bin:$PATH
+
+# Set Clang 19 as the default Clang and Clang++
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100 \
+    && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 100
+
+WORKDIR /work
+CMD ["bash"]

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -233,14 +233,14 @@ class Plan {
                   "Plan::Plan: View rank must be larger than or equal to the "
                   "Rank of FFT axes");
 
-    if (std::is_floating_point<in_value_type>::value &&
+    if (KokkosFFT::Impl::is_real_v<in_value_type> &&
         m_direction != KokkosFFT::Direction::forward) {
       throw std::runtime_error(
           "Plan::Plan: real to complex transform is constrcuted with backward "
           "direction.");
     }
 
-    if (std::is_floating_point<out_value_type>::value &&
+    if (KokkosFFT::Impl::is_real_v<out_value_type> &&
         m_direction != KokkosFFT::Direction::backward) {
       throw std::runtime_error(
           "Plan::Plan: complex to real transform is constrcuted with forward "


### PR DESCRIPTION
This PR aims at improving CI for better formatting.

Following modifications are made
- [x] Introduce `.clang-tidy`
- [x] Dockerfile for clang build (llvm 19 is needed for `ExcludeHeaderFilterRegex`)
- [x] Add built test with `.clang-tidy` in CI
