### PR TITLE
Replace KOKKOSFFT_EXPECTS with KOKKOSFFT_THROW_IF

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -23,10 +23,10 @@ auto get_shift(const ViewType& inout, axis_type<DIM> _axes, int direction = 1) {
 
   // Assert if the elements are overlapped
   constexpr int rank = ViewType::rank();
-  KOKKOSFFT_EXPECTS(!KokkosFFT::Impl::has_duplicate_values(axes),
-                    "Axes overlap");
-  KOKKOSFFT_EXPECTS(
-      !KokkosFFT::Impl::is_out_of_range_value_included(axes, rank),
+  KOKKOSFFT_THROW_IF(KokkosFFT::Impl::has_duplicate_values(axes),
+                     "Axes overlap");
+  KOKKOSFFT_THROW_IF(
+      KokkosFFT::Impl::is_out_of_range_value_included(axes, rank),
       "Axes include an out-of-range index."
       "Axes must be in the range of [-rank, rank-1].");
 

--- a/common/src/KokkosFFT_asserts.hpp
+++ b/common/src/KokkosFFT_asserts.hpp
@@ -11,7 +11,7 @@
 
 #if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
 #include <source_location>
-#define KOKKOSFFT_EXPECTS(expression, msg)                            \
+#define KOKKOSFFT_THROW_IF(expression, msg)                           \
   KokkosFFT::Impl::check_precondition(                                \
       (expression), msg, std::source_location::current().file_name(), \
       std::source_location::current().line(),                         \
@@ -19,7 +19,7 @@
       std::source_location::current().column())
 #else
 #include <cstdlib>
-#define KOKKOSFFT_EXPECTS(expression, msg)                                   \
+#define KOKKOSFFT_THROW_IF(expression, msg)                                  \
   KokkosFFT::Impl::check_precondition((expression), msg, __FILE__, __LINE__, \
                                       __FUNCTION__)
 #endif
@@ -33,7 +33,7 @@ inline void check_precondition(const bool expression,
                                const char* function_name,
                                const int column = -1) {
   // Quick return if possible
-  if (expression) return;
+  if (!expression) return;
 
   std::stringstream ss("file: ");
   if (column == -1) {

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -26,8 +26,8 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   using out_value_type    = typename OutViewType::non_const_value_type;
   using array_layout_type = typename InViewType::array_layout;
 
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "input axes are not valid for the view");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "input axes are not valid for the view");
 
   constexpr std::size_t rank = InViewType::rank;
   [[maybe_unused]] int inner_most_axis =
@@ -65,8 +65,8 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   if (is_real_v<in_value_type>) {
     // Then R2C
-    KOKKOSFFT_EXPECTS(
-        _out_extents.at(inner_most_axis) ==
+    KOKKOSFFT_THROW_IF(
+        _out_extents.at(inner_most_axis) !=
             _in_extents.at(inner_most_axis) / 2 + 1,
         "For R2C, the 'output extent' of transform must be equal to "
         "'input extent'/2 + 1");
@@ -74,8 +74,8 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   if (is_real_v<out_value_type>) {
     // Then C2R
-    KOKKOSFFT_EXPECTS(
-        _in_extents.at(inner_most_axis) ==
+    KOKKOSFFT_THROW_IF(
+        _in_extents.at(inner_most_axis) !=
             _out_extents.at(inner_most_axis) / 2 + 1,
         "For C2R, the 'input extent' of transform must be equal to "
         "'output extent' / 2 + 1");

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -30,8 +30,8 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   static_assert(
       KokkosFFT::Impl::have_same_rank_v<InViewType, OutViewType>,
       "get_modified_shape: Input View and Output View must have the same rank");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "input axes are not valid for the view");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "input axes are not valid for the view");
 
   shape_type<DIM> zeros = {0};  // default shape means no crop or pad
   if (shape == zeros) {

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -14,8 +14,8 @@ namespace KokkosFFT {
 namespace Impl {
 template <typename ViewType, std::size_t DIM>
 auto get_map_axes(const ViewType& view, axis_type<DIM> _axes) {
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(view, _axes),
-                    "get_map_axes: input axes are not valid for the view");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(view, _axes),
+                     "get_map_axes: input axes are not valid for the view");
 
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> axes;
@@ -400,8 +400,8 @@ void transpose(const ExecutionSpace& exec_space, InViewType& in,
                 "transpose: Rank of View must be equal to Rank of "
                 "transpose axes.");
 
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::is_transpose_needed(map),
-                    "transpose: transpose not necessary");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::is_transpose_needed(map),
+                     "transpose: transpose not necessary");
 
   // in order not to call transpose_impl for 1D case
   if constexpr (DIM > 1) {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -23,8 +23,8 @@ auto convert_negative_axis(ViewType, int _axis = -1) {
                 "convert_negative_axis: ViewType must be a Kokkos::View.");
   int rank = static_cast<int>(ViewType::rank());
 
-  KOKKOSFFT_EXPECTS(_axis >= -rank && _axis < rank,
-                    "Axis must be in [-rank, rank-1]");
+  KOKKOSFFT_THROW_IF(_axis < -rank || _axis >= rank,
+                     "Axis must be in [-rank, rank-1]");
 
   int axis = _axis < 0 ? rank + _axis : _axis;
   return axis;
@@ -130,7 +130,7 @@ std::size_t get_index(ContainerType& values, const ValueType& value) {
   static_assert(std::is_same_v<value_type, ValueType>,
                 "get_index: Container value type must match ValueType");
   auto it = std::find(values.begin(), values.end(), value);
-  KOKKOSFFT_EXPECTS(it != values.end(), "value is not included in values");
+  KOKKOSFFT_THROW_IF(it == values.end(), "value is not included in values");
   return it - values.begin();
 }
 
@@ -256,16 +256,16 @@ void create_view(ViewType& out, const Label& label,
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 1>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(extents[0]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(extents[0]),
+                     "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0]);
 }
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 2>& extents) {
-  KOKKOSFFT_EXPECTS(
-      ViewType::required_allocation_size(out.layout()) >=
+  KOKKOSFFT_THROW_IF(
+      ViewType::required_allocation_size(out.layout()) <
           ViewType::required_allocation_size(extents[0], extents[1]),
       "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0], extents[1]);
@@ -273,27 +273,27 @@ void reshape_view(ViewType& out, const std::array<int, 2>& extents) {
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 3>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(
-                            extents[0], extents[1], extents[2]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(
+                             extents[0], extents[1], extents[2]),
+                     "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0], extents[1], extents[2]);
 }
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 4>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(
-                            extents[0], extents[1], extents[2], extents[3]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(
+                             extents[0], extents[1], extents[2], extents[3]),
+                     "reshape_view: insufficient memory");
 
   out = ViewType(out.data(), extents[0], extents[1], extents[2], extents[3]);
 }
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 5>& extents) {
-  KOKKOSFFT_EXPECTS(
-      ViewType::required_allocation_size(out.layout()) >=
+  KOKKOSFFT_THROW_IF(
+      ViewType::required_allocation_size(out.layout()) <
           ViewType::required_allocation_size(extents[0], extents[1], extents[2],
                                              extents[3], extents[4]),
       "reshape_view: insufficient memory");
@@ -303,33 +303,33 @@ void reshape_view(ViewType& out, const std::array<int, 5>& extents) {
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 6>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(
-                            extents[0], extents[1], extents[2], extents[3],
-                            extents[4], extents[5]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(
+                             extents[0], extents[1], extents[2], extents[3],
+                             extents[4], extents[5]),
+                     "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0], extents[1], extents[2], extents[3],
                  extents[4], extents[5]);
 }
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 7>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(
-                            extents[0], extents[1], extents[2], extents[3],
-                            extents[4], extents[5], extents[6]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(
+                             extents[0], extents[1], extents[2], extents[3],
+                             extents[4], extents[5], extents[6]),
+                     "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0], extents[1], extents[2], extents[3],
                  extents[4], extents[5], extents[6]);
 }
 
 template <typename ViewType>
 void reshape_view(ViewType& out, const std::array<int, 8>& extents) {
-  KOKKOSFFT_EXPECTS(ViewType::required_allocation_size(out.layout()) >=
-                        ViewType::required_allocation_size(
-                            extents[0], extents[1], extents[2], extents[3],
-                            extents[4], extents[5], extents[6], extents[7]),
-                    "reshape_view: insufficient memory");
+  KOKKOSFFT_THROW_IF(ViewType::required_allocation_size(out.layout()) <
+                         ViewType::required_allocation_size(
+                             extents[0], extents[1], extents[2], extents[3],
+                             extents[4], extents[5], extents[6], extents[7]),
+                     "reshape_view: insufficient memory");
   out = ViewType(out.data(), extents[0], extents[1], extents[2], extents[3],
                  extents[4], extents[5], extents[6], extents[7]);
 }

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -31,7 +31,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                 = std::make_unique<PlanType>();
   cufftResult cufft_rt = cufftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftCreate failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftCreate failed");
 
   cudaStream_t stream = exec_space.cuda_stream();
   cufftSetStream((*plan), stream);
@@ -45,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   cufft_rt = cufftPlan1d(&(*plan), nx, type, howmany);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftPlan1d failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan1d failed");
 
   return fft_size;
 }
@@ -69,7 +69,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                 = std::make_unique<PlanType>();
   cufftResult cufft_rt = cufftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftCreate failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftCreate failed");
 
   cudaStream_t stream = exec_space.cuda_stream();
   cufftSetStream((*plan), stream);
@@ -83,7 +83,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   cufft_rt = cufftPlan2d(&(*plan), nx, ny, type);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftPlan2d failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan2d failed");
 
   return fft_size;
 }
@@ -107,7 +107,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                 = std::make_unique<PlanType>();
   cufftResult cufft_rt = cufftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftCreate failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftCreate failed");
 
   cudaStream_t stream = exec_space.cuda_stream();
   cufftSetStream((*plan), stream);
@@ -123,7 +123,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   cufft_rt = cufftPlan3d(&(*plan), nx, ny, nz, type);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftPlan3d failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan3d failed");
 
   return fft_size;
 }
@@ -167,7 +167,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                 = std::make_unique<PlanType>();
   cufftResult cufft_rt = cufftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftCreate failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftCreate failed");
 
   cudaStream_t stream = exec_space.cuda_stream();
   cufftSetStream((*plan), stream);
@@ -176,7 +176,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                            in_extents.data(), istride, idist,
                            out_extents.data(), ostride, odist, type, howmany);
 
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftPlanMany failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlanMany failed");
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -14,42 +14,42 @@ template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
                       int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecR2C(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecR2C failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecR2C failed");
 }
 
 template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftDoubleReal* idata,
                       cufftDoubleComplex* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecD2Z(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecD2Z failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecD2Z failed");
 }
 
 template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
                       int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecC2R(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecC2R failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2R failed");
 }
 
 template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
                       cufftDoubleReal* odata, int /*direction*/, Args...) {
   cufftResult cufft_rt = cufftExecZ2D(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecZ2D failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2D failed");
 }
 
 template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftComplex* idata,
                       cufftComplex* odata, int direction, Args...) {
   cufftResult cufft_rt = cufftExecC2C(plan, idata, odata, direction);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecC2C failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2C failed");
 }
 
 template <typename... Args>
 inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
                       cufftDoubleComplex* odata, int direction, Args...) {
   cufftResult cufft_rt = cufftExecZ2Z(plan, idata, odata, direction);
-  KOKKOSFFT_EXPECTS(cufft_rt == CUFFT_SUCCESS, "cufftExecZ2Z failed");
+  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2Z failed");
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -31,7 +31,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                   = std::make_unique<PlanType>();
   hipfftResult hipfft_rt = hipfftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftCreate failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftCreate failed");
 
   hipStream_t stream = exec_space.hip_stream();
   hipfftSetStream((*plan), stream);
@@ -45,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   hipfft_rt = hipfftPlan1d(&(*plan), nx, type, howmany);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftPlan1d failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan1d failed");
 
   return fft_size;
 }
@@ -69,7 +69,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                   = std::make_unique<PlanType>();
   hipfftResult hipfft_rt = hipfftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftCreate failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftCreate failed");
 
   hipStream_t stream = exec_space.hip_stream();
   hipfftSetStream((*plan), stream);
@@ -83,7 +83,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   hipfft_rt = hipfftPlan2d(&(*plan), nx, ny, type);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftPlan2d failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan2d failed");
 
   return fft_size;
 }
@@ -107,7 +107,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                   = std::make_unique<PlanType>();
   hipfftResult hipfft_rt = hipfftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftCreate failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftCreate failed");
 
   hipStream_t stream = exec_space.hip_stream();
   hipfftSetStream((*plan), stream);
@@ -123,7 +123,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   hipfft_rt = hipfftPlan3d(&(*plan), nx, ny, nz, type);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftPlan3d failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan3d failed");
 
   return fft_size;
 }
@@ -167,7 +167,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   plan                   = std::make_unique<PlanType>();
   hipfftResult hipfft_rt = hipfftCreate(&(*plan));
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftCreate failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftCreate failed");
 
   hipStream_t stream = exec_space.hip_stream();
   hipfftSetStream((*plan), stream);
@@ -176,7 +176,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                              in_extents.data(), istride, idist,
                              out_extents.data(), ostride, odist, type, howmany);
 
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftPlanMany failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -14,42 +14,42 @@ template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftReal* idata,
                       hipfftComplex* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecR2C(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecR2C failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecR2C failed");
 }
 
 template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftDoubleReal* idata,
                       hipfftDoubleComplex* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecD2Z(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecD2Z failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecD2Z failed");
 }
 
 template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
                       hipfftReal* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2R(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecC2R failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2R failed");
 }
 
 template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
                       hipfftDoubleReal* odata, int /*direction*/, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2D(plan, idata, odata);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecZ2D failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2D failed");
 }
 
 template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
                       hipfftComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecC2C(plan, idata, odata, direction);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecC2C failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2C failed");
 }
 
 template <typename... Args>
 inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
                       hipfftDoubleComplex* odata, int direction, Args...) {
   hipfftResult hipfft_rt = hipfftExecZ2Z(plan, idata, odata, direction);
-  KOKKOSFFT_EXPECTS(hipfft_rt == HIPFFT_SUCCESS, "hipfftExecZ2Z failed");
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2Z failed");
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -172,18 +172,18 @@ class Plan {
     static_assert(InViewType::rank() >= 1,
                   "Plan::Plan: View rank must be larger than or equal to 1");
 
-    KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, m_axes),
-                      "axes are invalid for in/out views");
+    KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, m_axes),
+                       "axes are invalid for in/out views");
 
     if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
-      KOKKOSFFT_EXPECTS(
-          m_direction == KokkosFFT::Direction::forward,
+      KOKKOSFFT_THROW_IF(
+          m_direction != KokkosFFT::Direction::forward,
           "real to complex transform is constructed with backward direction.");
     }
 
     if constexpr (KokkosFFT::Impl::is_real_v<out_value_type>) {
-      KOKKOSFFT_EXPECTS(
-          m_direction == KokkosFFT::Direction::backward,
+      KOKKOSFFT_THROW_IF(
+          m_direction != KokkosFFT::Direction::backward,
           "complex to real transform is constructed with forward direction.");
     }
 
@@ -234,17 +234,17 @@ class Plan {
                   "Plan::Plan: View rank must be larger than or equal to the "
                   "Rank of FFT axes");
 
-    KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, m_axes),
-                      "axes are invalid for in/out views");
+    KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, m_axes),
+                       "axes are invalid for in/out views");
     if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
-      KOKKOSFFT_EXPECTS(
-          m_direction == KokkosFFT::Direction::forward,
+      KOKKOSFFT_THROW_IF(
+          m_direction != KokkosFFT::Direction::forward,
           "real to complex transform is constructed with backward direction.");
     }
 
     if constexpr (KokkosFFT::Impl::is_real_v<out_value_type>) {
-      KOKKOSFFT_EXPECTS(
-          m_direction == KokkosFFT::Direction::backward,
+      KOKKOSFFT_THROW_IF(
+          m_direction != KokkosFFT::Direction::backward,
           "complex to real transform is constructed with forward direction.");
     }
 
@@ -290,12 +290,12 @@ class Plan {
     auto in_extents  = KokkosFFT::Impl::extract_extents(in);
     auto out_extents = KokkosFFT::Impl::extract_extents(out);
 
-    KOKKOSFFT_EXPECTS(
-        in_extents == m_in_extents,
+    KOKKOSFFT_THROW_IF(
+        in_extents != m_in_extents,
         "extents of input View for plan and execution are not identical.");
 
-    KOKKOSFFT_EXPECTS(
-        out_extents == m_out_extents,
+    KOKKOSFFT_THROW_IF(
+        out_extents != m_out_extents,
         "extents of output View for plan and execution are not identical.");
   }
 

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -125,8 +125,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   // Create the description
   rocfft_plan_description description;
   rocfft_status status = rocfft_plan_description_create(&description);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_plan_description_create failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_plan_description_create failed");
 
   auto [in_array_type, out_array_type, fft_direction] =
       get_in_out_array_type(type, direction);
@@ -144,8 +144,8 @@ auto create_plan(const ExecutionSpace& exec_space,
       out_strides.size(),  // output stride length
       out_strides.data(),  // output stride data
       odist);              // output batch distance
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_plan_description_set_data_layout failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_plan_description_set_data_layout failed");
 
   // Out-of-place transform
   const rocfft_result_placement place = rocfft_placement_notinplace;
@@ -158,38 +158,38 @@ auto create_plan(const ExecutionSpace& exec_space,
                               howmany,              // Number of transforms
                               description           // Description
   );
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_plan_create failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_plan_create failed");
 
   // Prepare workbuffer and set execution information
   status = rocfft_execution_info_create(&execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execution_info_create failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execution_info_create failed");
 
   // set stream
   // NOTE: The stream must be of type hipStream_t.
   // It is an error to pass the address of a hipStream_t object.
   hipStream_t stream = exec_space.hip_stream();
   status             = rocfft_execution_info_set_stream(execution_info, stream);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execution_info_set_stream failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execution_info_set_stream failed");
 
   std::size_t workbuffersize = 0;
   status = rocfft_plan_get_work_buffer_size(*plan, &workbuffersize);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_plan_get_work_buffer_size failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_plan_get_work_buffer_size failed");
 
   if (workbuffersize > 0) {
     buffer = BufferViewType("work_buffer", workbuffersize);
     status = rocfft_execution_info_set_work_buffer(
         execution_info, (void*)buffer.data(), workbuffersize);
-    KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                      "rocfft_execution_info_set_work_buffer failed");
+    KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                       "rocfft_execution_info_set_work_buffer failed");
   }
 
   status = rocfft_plan_description_destroy(description);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_plan_description_destroy failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_plan_description_destroy failed");
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -16,8 +16,8 @@ inline void exec_plan(rocfft_plan& plan, float* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for R2C failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for R2C failed");
 }
 
 inline void exec_plan(rocfft_plan& plan, double* idata,
@@ -25,8 +25,8 @@ inline void exec_plan(rocfft_plan& plan, double* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for D2Z failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for D2Z failed");
 }
 
 inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
@@ -34,8 +34,8 @@ inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for C2R failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for C2R failed");
 }
 
 inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
@@ -43,8 +43,8 @@ inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for Z2D failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for Z2D failed");
 }
 
 inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
@@ -52,8 +52,8 @@ inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for C2C failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for C2C failed");
 }
 
 inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
@@ -61,8 +61,8 @@ inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
                       const rocfft_execution_info& execution_info) {
   rocfft_status status =
       rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
-  KOKKOSFFT_EXPECTS(status == rocfft_status_success,
-                    "rocfft_execute for Z2Z failed");
+  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
+                     "rocfft_execute for Z2Z failed");
 }
 
 }  // namespace Impl

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -141,8 +141,8 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 1,
                 "fft: View rank must be larger than or equal to 1");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axis, n);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -170,8 +170,8 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 1,
                 "ifft: View rank must be larger than or equal to 1");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axis, n);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -207,8 +207,8 @@ void rfft(const ExecutionSpace& exec_space, const InViewType& in,
                 "rfft: InViewType must be real");
   static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfft: OutViewType must be complex");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   fft(exec_space, in, out, norm, axis, n);
 }
 
@@ -243,8 +243,8 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
                 "irfft: InViewType must be complex");
   static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfft: OutViewType must be real");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   ifft(exec_space, in, out, norm, axis, n);
 }
 
@@ -280,8 +280,8 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
                 "hfft: InViewType must be complex");
   static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "hfft: OutViewType must be real");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
   // using ComplexViewType = typename
   // KokkosFFT::Impl::complex_view_type<ExecutionSpace, InViewType>::type;
@@ -321,8 +321,8 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
                 "ihfft: InViewType must be real");
   static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "ihfft: OutViewType must be complex");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
+                     "axes are invalid for in/out views");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
   OutViewType out_conj;
   rfft(exec_space, in, out, new_norm, axis, n);
@@ -354,8 +354,8 @@ void fft2(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 2,
                 "fft2: View rank must be larger than or equal to 2");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -384,8 +384,8 @@ void ifft2(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 2,
                 "ifft2: View rank must be larger than or equal to 2");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -422,8 +422,8 @@ void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
                 "rfft2: InViewType must be real");
   static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfft2: OutViewType must be complex");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   fft2(exec_space, in, out, norm, axes, s);
 }
 
@@ -458,8 +458,8 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
                 "irfft2: InViewType must be complex");
   static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfft2: OutViewType must be real");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   ifft2(exec_space, in, out, norm, axes, s);
 }
 
@@ -491,8 +491,8 @@ void fftn(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(
       InViewType::rank() >= DIM,
       "fftn: View rank must be larger than or equal to the Rank of FFT axes");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
                              axes, s);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -526,8 +526,8 @@ void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(
       InViewType::rank() >= DIM,
       "ifftn: View rank must be larger than or equal to the Rank of FFT axes");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   KokkosFFT::Impl::Plan plan(exec_space, in, out,
                              KokkosFFT::Direction::backward, axes, s);
   KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
@@ -569,8 +569,8 @@ void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
                 "rfftn: InViewType must be real");
   static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
                 "rfftn: OutViewType must be complex");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   fftn(exec_space, in, out, axes, norm, s);
 }
 
@@ -610,8 +610,8 @@ void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
                 "irfftn: InViewType must be complex");
   static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "irfftn: OutViewType must be real");
-  KOKKOSFFT_EXPECTS(KokkosFFT::Impl::are_valid_axes(in, axes),
-                    "axes are invalid for in/out views");
+  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
+                     "axes are invalid for in/out views");
   ifftn(exec_space, in, out, axes, norm, s);
 }
 


### PR DESCRIPTION
Improves #80 

This PR aims at replacing runtime `KOKKOSFFT_EXPECTS` with `KOKKOSFFT_THROW_IF`. See discussions in #130 for detail.
             
