### PR TITLE
Do not install CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ install(
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/common/src/ ${CMAKE_CURRENT_SOURCE_DIR}/fft/src/
     DESTINATION ${INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
 )
 
 install(


### PR DESCRIPTION
Fixes #134 

In the installed directory `include`, `CMakeLists.txt` should not be installed