### PR TITLE
Allow user to work on const output View

### DIFF
--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -91,9 +91,10 @@ void prep_transpose_view(InViewType& in, OutViewType& out,
   }
 
   if constexpr (std::is_const_v<OutViewType>) {
-    KOKKOSFFT_THROW_IF(!is_out_view_ready,
-                       "prep_transpose_view: OutViewType is const, but do not "
-                       "have the required extents");
+    KOKKOSFFT_THROW_IF(
+        !is_out_view_ready,
+        "prep_transpose_view: OutViewType is const, but does not "
+        "have the required extents");
   } else {
     if (!is_out_view_ready) {
       if constexpr (!OutViewType::memory_traits::is_unmanaged) {

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -92,7 +92,8 @@ void prep_transpose_view(InViewType& in, OutViewType& out,
 
   if constexpr (std::is_const_v<OutViewType>) {
     KOKKOSFFT_THROW_IF(!is_out_view_ready,
-                       "prep_transpose_view: OutViewType is const, but do not have the required extents");
+                       "prep_transpose_view: OutViewType is const, but do not "
+                       "have the required extents");
   } else {
     if (!is_out_view_ready) {
       if constexpr (!OutViewType::memory_traits::is_unmanaged) {

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -90,12 +90,17 @@ void prep_transpose_view(InViewType& in, OutViewType& out,
     }
   }
 
-  if (!is_out_view_ready) {
-    if constexpr (!OutViewType::memory_traits::is_unmanaged) {
-      KokkosFFT::Impl::create_view(out, "out", out_extents);
-    } else {
-      // try to reshape out if it currently has enough memory available
-      KokkosFFT::Impl::reshape_view(out, out_extents);
+  if constexpr (std::is_const_v<OutViewType>) {
+    KOKKOSFFT_THROW_IF(!is_out_view_ready,
+                       "prep_transpose_view: OutViewType is const, but do not have the required extents");
+  } else {
+    if (!is_out_view_ready) {
+      if constexpr (!OutViewType::memory_traits::is_unmanaged) {
+        KokkosFFT::Impl::create_view(out, "out", out_extents);
+      } else {
+        // try to reshape out if it currently has enough memory available
+        KokkosFFT::Impl::reshape_view(out, out_extents);
+      }
     }
   }
 }

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -1283,8 +1283,8 @@ void test_fft2_2dfft_2dview() {
       Kokkos::View<Kokkos::complex<T>**, LayoutType, execution_space>;
 
   ComplexView2DType x("x", n0, n1);
-  ComplexView2DType out("out", n0, n1), out1("out1", n0, n1),
-      out2("out2", n0, n1);
+  ComplexView2DType out("out", n0, n1);
+  const ComplexView2DType out1("out1", n0, n1), out2("out2", n0, n1);
   ComplexView2DType out_b("out_b", n0, n1), out_o("out_o", n0, n1),
       out_f("out_f", n0, n1);
 


### PR DESCRIPTION
This PR aims at allowing users to work on const output View type.

For example,

```C++
#include <KokkosFFT.hpp>
#include <Kokkos_Core.hpp>

int main() {
  Kokkos::ScopeGuard scope;
  Kokkos::View<Kokkos::complex<double> **> const in_view("in", 10, 10);
  Kokkos::View<Kokkos::complex<double> **> const out_view("out", 10, 10);
  KokkosFFT::fft2(Kokkos::DefaultExecutionSpace(), in_view, out_view);
  return 0;
}
```