### PR TITLE
Set default axes for N-dimensional fft APIs

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -233,7 +233,7 @@ void fftshift(const ExecutionSpace& exec_space, ViewType& inout,
   } else {
     constexpr std::size_t rank = ViewType::rank();
     constexpr int start        = -static_cast<int>(rank);
-    axis_type<rank> _axes      = KokkosFFT::Impl::index_sequence<rank>(start);
+    auto _axes = KokkosFFT::Impl::index_sequence<int, rank, start>();
     KokkosFFT::Impl::fftshift_impl(exec_space, inout, _axes);
   }
 }
@@ -281,7 +281,7 @@ void ifftshift(const ExecutionSpace& exec_space, ViewType& inout,
   } else {
     constexpr std::size_t rank = ViewType::rank();
     constexpr int start        = -static_cast<int>(rank);
-    axis_type<rank> _axes      = KokkosFFT::Impl::index_sequence<rank>(start);
+    auto _axes = KokkosFFT::Impl::index_sequence<int, rank, start>();
     KokkosFFT::Impl::ifftshift_impl(exec_space, inout, _axes);
   }
 }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -135,15 +135,19 @@ std::size_t get_index(ContainerType& values, const ValueType& value) {
 }
 
 template <typename T, std::size_t... I>
-std::array<T, sizeof...(I)> make_sequence_array(std::index_sequence<I...>) {
+constexpr std::array<T, sizeof...(I)> make_sequence_array(
+    std::index_sequence<I...>) {
   return std::array<T, sizeof...(I)>{{I...}};
 }
 
-template <int N, typename T>
-std::array<T, N> index_sequence(T const& start) {
-  auto sequence = make_sequence_array<T>(std::make_index_sequence<N>());
-  std::transform(sequence.begin(), sequence.end(), sequence.begin(),
-                 [=](const T sequence) -> T { return start + sequence; });
+template <typename IntType, std::size_t N, int start>
+constexpr std::array<IntType, N> index_sequence() {
+  static_assert(std::is_integral_v<IntType> && std::is_signed_v<IntType>,
+                "index_sequence: IntType must be a signed integer type.");
+  std::array<IntType, N> sequence{};
+  for (std::size_t i = 0; i < N; ++i) {
+    sequence[i] = static_cast<IntType>(start) + static_cast<IntType>(i);
+  }
   return sequence;
 }
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -134,19 +134,13 @@ std::size_t get_index(ContainerType& values, const ValueType& value) {
   return it - values.begin();
 }
 
-template <typename T, std::size_t... I>
-constexpr std::array<T, sizeof...(I)> make_sequence_array(
-    std::index_sequence<I...>) {
-  return std::array<T, sizeof...(I)>{{I...}};
-}
-
-template <typename IntType, std::size_t N, int start>
+template <typename IntType, std::size_t N, IntType start>
 constexpr std::array<IntType, N> index_sequence() {
   static_assert(std::is_integral_v<IntType> && std::is_signed_v<IntType>,
                 "index_sequence: IntType must be a signed integer type.");
   std::array<IntType, N> sequence{};
   for (std::size_t i = 0; i < N; ++i) {
-    sequence[i] = static_cast<IntType>(start) + static_cast<IntType>(i);
+    sequence[i] = start + static_cast<IntType>(i);
   }
   return sequence;
 }

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -487,3 +487,22 @@ TEST(ExtractExtents, 1Dto8D) {
   EXPECT_EQ(KokkosFFT::Impl::extract_extents(view7D), ref_extents7D);
   EXPECT_EQ(KokkosFFT::Impl::extract_extents(view8D), ref_extents8D);
 }
+
+TEST(IndexSequence, 3Dto5D) {
+  constexpr std::size_t DIM = 3;
+  constexpr int rank0 = 3, rank1 = 4, rank2 = 5;
+  constexpr auto default_axes0 =
+      KokkosFFT::Impl::index_sequence<int, DIM, -rank0>();
+  constexpr auto default_axes1 =
+      KokkosFFT::Impl::index_sequence<int, DIM, -rank1>();
+  constexpr auto default_axes2 =
+      KokkosFFT::Impl::index_sequence<int, DIM, -rank2>();
+
+  std::array<int, DIM> ref_axes0 = {-3, -2, -1};
+  std::array<int, DIM> ref_axes1 = {-4, -3, -2};
+  std::array<int, DIM> ref_axes2 = {-5, -4, -3};
+
+  EXPECT_EQ(default_axes0, ref_axes0);
+  EXPECT_EQ(default_axes1, ref_axes1);
+  EXPECT_EQ(default_axes2, ref_axes2);
+}

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -489,14 +489,25 @@ TEST(ExtractExtents, 1Dto8D) {
 }
 
 TEST(IndexSequence, 3Dto5D) {
+  using View3Dtype = Kokkos::View<double***, execution_space>;
+  using View4Dtype = Kokkos::View<double****, execution_space>;
+  using View5Dtype = Kokkos::View<double*****, execution_space>;
+
   constexpr std::size_t DIM = 3;
-  constexpr int rank0 = 3, rank1 = 4, rank2 = 5;
+  std::size_t n1 = 1, n2 = 1, n3 = 2, n4 = 3, n5 = 5;
+  View3Dtype view3D("view3D", n1, n2, n3);
+  View4Dtype view4D("view4D", n1, n2, n3, n4);
+  View5Dtype view5D("view5D", n1, n2, n3, n4, n5);
+  constexpr int start0 = -static_cast<int>(View3Dtype::rank());
+  constexpr int start1 = -static_cast<int>(View4Dtype::rank());
+  constexpr int start2 = -static_cast<int>(View5Dtype::rank());
+
   constexpr auto default_axes0 =
-      KokkosFFT::Impl::index_sequence<int, DIM, -rank0>();
+      KokkosFFT::Impl::index_sequence<int, DIM, start0>();
   constexpr auto default_axes1 =
-      KokkosFFT::Impl::index_sequence<int, DIM, -rank1>();
+      KokkosFFT::Impl::index_sequence<int, DIM, start1>();
   constexpr auto default_axes2 =
-      KokkosFFT::Impl::index_sequence<int, DIM, -rank2>();
+      KokkosFFT::Impl::index_sequence<int, DIM, start2>();
 
   std::array<int, DIM> ref_axes0 = {-3, -2, -1};
   std::array<int, DIM> ref_axes1 = {-4, -3, -2};

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -470,7 +470,7 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed
+/// \param axes [in] Axes over which FFT is performed (optional)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
@@ -505,7 +505,7 @@ void fftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed
+/// \param axes [in] Axes over which FFT is performed (optional)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
@@ -542,7 +542,7 @@ void ifftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (real)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed
+/// \param axes [in] Axes over which FFT is performed (optional)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
@@ -585,7 +585,7 @@ void rfftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (real)
-/// \param axes [in] Axes over which FFT is performed
+/// \param axes [in] Axes over which FFT is performed (optional)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -474,11 +474,13 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void fftn(const ExecutionSpace& exec_space, const InViewType& in,
-          OutViewType& out, axis_type<DIM> axes,
-          KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-          shape_type<DIM> s             = {0}) {
+          std::size_t DIM = InViewType::rank()>
+void fftn(
+    const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
+    axis_type<DIM> axes =
+        KokkosFFT::Impl::index_sequence<int, DIM, -static_cast<int>(DIM)>(),
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
+    shape_type<DIM> s             = {}) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -507,11 +509,13 @@ void fftn(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, axis_type<DIM> axes,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
+          std::size_t DIM = InViewType::rank()>
+void ifftn(
+    const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
+    axis_type<DIM> axes =
+        KokkosFFT::Impl::index_sequence<int, DIM, -static_cast<int>(DIM)>(),
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
+    shape_type<DIM> s             = {}) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -542,11 +546,13 @@ void ifftn(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
-           OutViewType& out, axis_type<DIM> axes,
-           KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-           shape_type<DIM> s             = {0}) {
+          std::size_t DIM = InViewType::rank()>
+void rfftn(
+    const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
+    axis_type<DIM> axes =
+        KokkosFFT::Impl::index_sequence<int, DIM, -static_cast<int>(DIM)>(),
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
+    shape_type<DIM> s             = {}) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -583,11 +589,13 @@ void rfftn(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
-void irfftn(const ExecutionSpace& exec_space, const InViewType& in,
-            OutViewType& out, axis_type<DIM> axes,
-            KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
-            shape_type<DIM> s             = {0}) {
+          std::size_t DIM = InViewType::rank()>
+void irfftn(
+    const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
+    axis_type<DIM> axes =
+        KokkosFFT::Impl::index_sequence<int, DIM, -static_cast<int>(DIM)>(),
+    KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward,
+    shape_type<DIM> s             = {}) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -2322,8 +2322,8 @@ void test_fftn_2dfft_2dview() {
 
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
-  KokkosFFT::fftn(execution_space(), x, out,
-                  axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::fftn(execution_space(), x,
+                  out);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::fftn(execution_space(), x, out_b, axes,
                   KokkosFFT::Normalization::backward);
   KokkosFFT::fftn(execution_space(), x, out_o, axes,
@@ -2387,8 +2387,8 @@ void test_ifftn_2dfft_2dview() {
   KokkosFFT::ifft(execution_space(), out1, out2,
                   KokkosFFT::Normalization::backward, /*axis=*/0);
 
-  KokkosFFT::ifftn(execution_space(), x, out,
-                   axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::ifftn(execution_space(), x,
+                   out);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::ifftn(execution_space(), x, out_b, axes,
                    KokkosFFT::Normalization::backward);
   KokkosFFT::ifftn(execution_space(), x, out_o, axes,
@@ -2452,8 +2452,8 @@ void test_rfftn_2dfft_2dview() {
                  KokkosFFT::Normalization::backward, /*axis=*/0);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::rfftn(execution_space(), x, out,
-                   axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::rfftn(execution_space(), x,
+                   out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x, out_b, axes,
@@ -2531,8 +2531,8 @@ void test_irfftn_2dfft_2dview() {
                    KokkosFFT::Normalization::backward, /*axis=*/1);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::irfftn(execution_space(), x, out,
-                    axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::irfftn(execution_space(), x,
+                    out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::irfftn(execution_space(), x, out_b, axes,
@@ -2698,8 +2698,8 @@ void test_fftn_3dfft_3dview(T atol = 1.0e-6) {
   KokkosFFT::fft(execution_space(), out2, out3,
                  KokkosFFT::Normalization::backward, /*axis=*/0);
 
-  KokkosFFT::fftn(execution_space(), x, out,
-                  axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::fftn(execution_space(), x,
+                  out);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::fftn(execution_space(), x, out_b, axes,
                   KokkosFFT::Normalization::backward);
   KokkosFFT::fftn(execution_space(), x, out_o, axes,
@@ -2746,8 +2746,8 @@ void test_ifftn_3dfft_3dview() {
   KokkosFFT::ifft(execution_space(), out2, out3,
                   KokkosFFT::Normalization::backward, /*axis=*/0);
 
-  KokkosFFT::ifftn(execution_space(), x, out,
-                   axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::ifftn(execution_space(), x,
+                   out);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::ifftn(execution_space(), x, out_b, axes,
                    KokkosFFT::Normalization::backward);
   KokkosFFT::ifftn(execution_space(), x, out_o, axes,
@@ -2796,8 +2796,8 @@ void test_rfftn_3dfft_3dview() {
                  KokkosFFT::Normalization::backward, /*axis=*/0);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::rfftn(execution_space(), x, out,
-                   axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::rfftn(execution_space(), x,
+                   out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x, out_b, axes,
@@ -2853,8 +2853,8 @@ void test_irfftn_3dfft_3dview() {
                    KokkosFFT::Normalization::backward, /*axis=*/2);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::irfftn(execution_space(), x, out,
-                    axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::irfftn(execution_space(), x,
+                    out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::irfftn(execution_space(), x, out_b, axes,

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -2304,7 +2304,7 @@ void test_fftn_2dfft_2dview() {
 
   ComplexView2DType x("x", n0, n1);
   ComplexView2DType out("out", n0, n1), out1("out1", n0, n1),
-      out2("out2", n0, n1);
+      out2("out2", n0, n1), out_no_axes("out_no_axes", n0, n1);
   ComplexView2DType out_b("out_b", n0, n1), out_o("out_o", n0, n1),
       out_f("out_f", n0, n1);
 
@@ -2323,7 +2323,9 @@ void test_fftn_2dfft_2dview() {
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
   KokkosFFT::fftn(execution_space(), x,
-                  out);  // default: KokkosFFT::Normalization::backward
+                  out_no_axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::fftn(execution_space(), x, out,
+                  axes);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::fftn(execution_space(), x, out_b, axes,
                   KokkosFFT::Normalization::backward);
   KokkosFFT::fftn(execution_space(), x, out_o, axes,
@@ -2335,6 +2337,7 @@ void test_fftn_2dfft_2dview() {
   multiply(out_f, static_cast<T>(n0 * n1));
 
   EXPECT_TRUE(allclose(out, out2, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
@@ -2368,7 +2371,7 @@ void test_ifftn_2dfft_2dview() {
 
   ComplexView2DType x("x", n0, n1);
   ComplexView2DType out("out", n0, n1), out1("out1", n0, n1),
-      out2("out2", n0, n1);
+      out2("out2", n0, n1), out_no_axes("out_no_axes", n0, n1);
   ComplexView2DType out_b("out_b", n0, n1), out_o("out_o", n0, n1),
       out_f("out_f", n0, n1);
 
@@ -2388,7 +2391,9 @@ void test_ifftn_2dfft_2dview() {
                   KokkosFFT::Normalization::backward, /*axis=*/0);
 
   KokkosFFT::ifftn(execution_space(), x,
-                   out);  // default: KokkosFFT::Normalization::backward
+                   out_no_axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::ifftn(execution_space(), x, out,
+                   axes);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::ifftn(execution_space(), x, out_b, axes,
                    KokkosFFT::Normalization::backward);
   KokkosFFT::ifftn(execution_space(), x, out_o, axes,
@@ -2400,6 +2405,7 @@ void test_ifftn_2dfft_2dview() {
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
 
   EXPECT_TRUE(allclose(out, out2, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
@@ -2434,7 +2440,7 @@ void test_rfftn_2dfft_2dview() {
 
   RealView2DType x("x", n0, n1), x_ref("x_ref", n0, n1);
   ComplexView2DType out("out", n0, n1 / 2 + 1), out1("out1", n0, n1 / 2 + 1),
-      out2("out2", n0, n1 / 2 + 1);
+      out2("out2", n0, n1 / 2 + 1), out_no_axes("out_no_axes", n0, n1 / 2 + 1);
   ComplexView2DType out_b("out_b", n0, n1 / 2 + 1),
       out_o("out_o", n0, n1 / 2 + 1), out_f("out_f", n0, n1 / 2 + 1);
 
@@ -2453,7 +2459,11 @@ void test_rfftn_2dfft_2dview() {
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x,
-                   out);  // default: KokkosFFT::Normalization::backward
+                   out_no_axes);  // default: KokkosFFT::Normalization::backward
+
+  Kokkos::deep_copy(x, x_ref);
+  KokkosFFT::rfftn(execution_space(), x, out,
+                   axes);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x, out_b, axes,
@@ -2471,6 +2481,7 @@ void test_rfftn_2dfft_2dview() {
   multiply(out_f, static_cast<T>(n0 * n1));
 
   EXPECT_TRUE(allclose(out, out2, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
@@ -2514,7 +2525,7 @@ void test_irfftn_2dfft_2dview() {
   ComplexView2DType out1("out1", n0, n1 / 2 + 1);
   RealView2DType out2("out2", n0, n1), out("out", n0, n1);
   RealView2DType out_b("out_b", n0, n1), out_o("out_o", n0, n1),
-      out_f("out_f", n0, n1);
+      out_f("out_f", n0, n1), out_no_axes("out_no_axes", n0, n1);
 
   const Kokkos::complex<T> I(1.0, 1.0);
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
@@ -2531,8 +2542,13 @@ void test_irfftn_2dfft_2dview() {
                    KokkosFFT::Normalization::backward, /*axis=*/1);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::irfftn(execution_space(), x,
-                    out);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::irfftn(
+      execution_space(), x,
+      out_no_axes);  // default: KokkosFFT::Normalization::backward
+
+  Kokkos::deep_copy(x, x_ref);
+  KokkosFFT::irfftn(execution_space(), x, out,
+                    axes);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::irfftn(execution_space(), x, out_b, axes,
@@ -2550,6 +2566,7 @@ void test_irfftn_2dfft_2dview() {
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
 
   EXPECT_TRUE(allclose(out, out2, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
@@ -2678,7 +2695,7 @@ void test_fftn_3dfft_3dview(T atol = 1.0e-6) {
   ComplexView3DType out("out", n0, n1, n2), out1("out1", n0, n1, n2),
       out2("out2", n0, n1, n2), out3("out3", n0, n1, n2);
   ComplexView3DType out_b("out_b", n0, n1, n2), out_o("out_o", n0, n1, n2),
-      out_f("out_f", n0, n1, n2);
+      out_f("out_f", n0, n1, n2), out_no_axes("out_no_axes", n0, n1, n2);
 
   const Kokkos::complex<T> I(1.0, 1.0);
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
@@ -2699,7 +2716,9 @@ void test_fftn_3dfft_3dview(T atol = 1.0e-6) {
                  KokkosFFT::Normalization::backward, /*axis=*/0);
 
   KokkosFFT::fftn(execution_space(), x,
-                  out);  // default: KokkosFFT::Normalization::backward
+                  out_no_axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::fftn(execution_space(), x, out,
+                  axes);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::fftn(execution_space(), x, out_b, axes,
                   KokkosFFT::Normalization::backward);
   KokkosFFT::fftn(execution_space(), x, out_o, axes,
@@ -2711,6 +2730,7 @@ void test_fftn_3dfft_3dview(T atol = 1.0e-6) {
   multiply(out_f, static_cast<T>(n0 * n1 * n2));
 
   EXPECT_TRUE(allclose(out, out3, 1.e-5, atol));
+  EXPECT_TRUE(allclose(out_no_axes, out3, 1.e-5, atol));
   EXPECT_TRUE(allclose(out_b, out3, 1.e-5, atol));
   EXPECT_TRUE(allclose(out_o, out3, 1.e-5, atol));
   EXPECT_TRUE(allclose(out_f, out3, 1.e-5, atol));
@@ -2726,7 +2746,7 @@ void test_ifftn_3dfft_3dview() {
   ComplexView3DType out("out", n0, n1, n2), out1("out1", n0, n1, n2),
       out2("out2", n0, n1, n2), out3("out3", n0, n1, n2);
   ComplexView3DType out_b("out_b", n0, n1, n2), out_o("out_o", n0, n1, n2),
-      out_f("out_f", n0, n1, n2);
+      out_f("out_f", n0, n1, n2), out_no_axes("out_no_axes", n0, n1, n2);
 
   const Kokkos::complex<T> I(1.0, 1.0);
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
@@ -2747,7 +2767,9 @@ void test_ifftn_3dfft_3dview() {
                   KokkosFFT::Normalization::backward, /*axis=*/0);
 
   KokkosFFT::ifftn(execution_space(), x,
-                   out);  // default: KokkosFFT::Normalization::backward
+                   out_no_axes);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::ifftn(execution_space(), x, out,
+                   axes);  // default: KokkosFFT::Normalization::backward
   KokkosFFT::ifftn(execution_space(), x, out_b, axes,
                    KokkosFFT::Normalization::backward);
   KokkosFFT::ifftn(execution_space(), x, out_o, axes,
@@ -2759,6 +2781,7 @@ void test_ifftn_3dfft_3dview() {
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1 * n2));
 
   EXPECT_TRUE(allclose(out, out3, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out3, 1.e-5, 1.e-6));
@@ -2776,7 +2799,8 @@ void test_rfftn_3dfft_3dview() {
       out1("out1", n0, n1, n2 / 2 + 1), out2("out2", n0, n1, n2 / 2 + 1),
       out3("out3", n0, n1, n2 / 2 + 1);
   ComplexView3DType out_b("out_b", n0, n1, n2 / 2 + 1),
-      out_o("out_o", n0, n1, n2 / 2 + 1), out_f("out_f", n0, n1, n2 / 2 + 1);
+      out_o("out_o", n0, n1, n2 / 2 + 1), out_f("out_f", n0, n1, n2 / 2 + 1),
+      out_no_axes("out_no_axes", n0, n1, n2 / 2 + 1);
 
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
   Kokkos::fill_random(x, random_pool, 1);
@@ -2797,7 +2821,11 @@ void test_rfftn_3dfft_3dview() {
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x,
-                   out);  // default: KokkosFFT::Normalization::backward
+                   out_no_axes);  // default: KokkosFFT::Normalization::backward
+
+  Kokkos::deep_copy(x, x_ref);
+  KokkosFFT::rfftn(execution_space(), x, out,
+                   axes);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::rfftn(execution_space(), x, out_b, axes,
@@ -2815,6 +2843,7 @@ void test_rfftn_3dfft_3dview() {
   multiply(out_f, static_cast<T>(n0 * n1 * n2));
 
   EXPECT_TRUE(allclose(out, out3, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out3, 1.e-5, 1.e-6));
@@ -2833,7 +2862,7 @@ void test_irfftn_3dfft_3dview() {
       out2("out2", n0, n1, n2 / 2 + 1);
   RealView3DType out("out", n0, n1, n2), out3("out3", n0, n1, n2);
   RealView3DType out_b("out_b", n0, n1, n2), out_o("out_o", n0, n1, n2),
-      out_f("out_f", n0, n1, n2);
+      out_f("out_f", n0, n1, n2), out_no_axes("out_no_axes", n0, n1, n2);
 
   const Kokkos::complex<T> I(1.0, 1.0);
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
@@ -2853,8 +2882,13 @@ void test_irfftn_3dfft_3dview() {
                    KokkosFFT::Normalization::backward, /*axis=*/2);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::irfftn(execution_space(), x,
-                    out);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::irfftn(
+      execution_space(), x,
+      out_no_axes);  // default: KokkosFFT::Normalization::backward
+
+  Kokkos::deep_copy(x, x_ref);
+  KokkosFFT::irfftn(execution_space(), x, out,
+                    axes);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
   KokkosFFT::irfftn(execution_space(), x, out_b, axes,
@@ -2872,6 +2906,7 @@ void test_irfftn_3dfft_3dview() {
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1 * n2));
 
   EXPECT_TRUE(allclose(out, out3, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(out_no_axes, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_b, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_o, out3, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out3, 1.e-5, 1.e-6));


### PR DESCRIPTION
In this PR, we set default axes for ND fft APIs. 
For example, for 2D Views, default `axes = {-2, -1}`.

```C++
using axes_type = KokkosFFT::axis_type<2>;
axes_type axes  = {-2, -1};
KokkosFFT::fftn(execution_space(), x, out);
KokkosFFT::fftn(execution_space(), x, out, axes);
```