### PR TITLE
Fix unresolved doxygen for N-dimensional FFT APIs

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2177,7 +2177,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = DOXY
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/api/standard/fftn.rst
+++ b/docs/api/standard/fftn.rst
@@ -5,4 +5,4 @@
 KokkosFFT::fftn
 ---------------
 
-.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)
+.. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization norm, shape_type<DIM> s)

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -469,12 +469,12 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed (optional)
+/// \param axes [in] Axes over which FFT is performed (default, all axes)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
 #if defined(DOXY)
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
-          std::size_t DIM = 1>
+          std::size_t DIM>
 #else
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = InViewType::rank()>
@@ -509,11 +509,16 @@ void fftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed (optional)
+/// \param axes [in] Axes over which FFT is performed (default, all axes)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
+#if defined(DOXY)
+template <typename ExecutionSpace, typename InViewType, typename OutViewType,
+          std::size_t DIM>
+#else
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = InViewType::rank()>
+#endif
 void ifftn(
     const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
     axis_type<DIM> axes =
@@ -546,11 +551,16 @@ void ifftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (real)
 /// \param out [out] Ouput data (complex)
-/// \param axes [in] Axes over which FFT is performed (optional)
+/// \param axes [in] Axes over which FFT is performed (default, all axes)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
+#if defined(DOXY)
+template <typename ExecutionSpace, typename InViewType, typename OutViewType,
+          std::size_t DIM>
+#else
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = InViewType::rank()>
+#endif
 void rfftn(
     const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
     axis_type<DIM> axes =
@@ -589,11 +599,16 @@ void rfftn(
 /// \param exec_space [in] Kokkos execution space
 /// \param in [in] Input data (complex)
 /// \param out [out] Ouput data (real)
-/// \param axes [in] Axes over which FFT is performed (optional)
+/// \param axes [in] Axes over which FFT is performed (default, all axes)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
+#if defined(DOXY)
+template <typename ExecutionSpace, typename InViewType, typename OutViewType,
+          std::size_t DIM>
+#else
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = InViewType::rank()>
+#endif
 void irfftn(
     const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
     axis_type<DIM> axes =

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -472,8 +472,13 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
 /// \param axes [in] Axes over which FFT is performed (optional)
 /// \param norm [in] How the normalization is applied (optional)
 /// \param s [in] Shape of the transformed axis of the output (optional)
+#if defined(DOXY)
+template <typename ExecutionSpace, typename InViewType, typename OutViewType,
+          std::size_t DIM = 1>
+#else
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = InViewType::rank()>
+#endif
 void fftn(
     const ExecutionSpace& exec_space, const InViewType& in, OutViewType& out,
     axis_type<DIM> axes =


### PR DESCRIPTION
This PR aims at fixing docstrings bugs from #141 
As a temporary solution, we introduce a macro for doxygen which can be resolved. See https://github.com/kokkos/kokkos-kernels/pull/1319 for detail.