### PR TITLE
Remove duplicated C++17 flags

### DIFF
--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -15,7 +15,6 @@ add_executable(unit-tests-kokkos-fft-common
 )
 
 target_compile_features(unit-tests-kokkos-fft-common PUBLIC cxx_std_17)
-target_compile_options(unit-tests-kokkos-fft-common PUBLIC -std=c++17)
 
 target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common GTest::gtest)
 

--- a/fft/unit_test/CMakeLists.txt
+++ b/fft/unit_test/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(unit-tests-kokkos-fft-core
 )
 
 target_compile_features(unit-tests-kokkos-fft-core PUBLIC cxx_std_17)
-target_compile_options(unit-tests-kokkos-fft-core PUBLIC -std=c++17)
 
 target_link_libraries(unit-tests-kokkos-fft-core PUBLIC KokkosFFT::fft GTest::gtest)
 


### PR DESCRIPTION
I think these flags are redundant with the compile features above