### PR TITLE
Fix out of range check

### DIFF
--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -75,14 +75,14 @@ bool is_out_of_range_value_included(const ContainerType& values, IntType max) {
   static_assert(std::is_same_v<value_type, IntType>,
                 "is_out_of_range_value_included: Container value type must "
                 "match IntType");
-  const auto vmax = std::max_element(values.begin(), values.end());
   if constexpr (std::is_signed_v<value_type>) {
-    const auto vmin = std::min_element(values.begin(), values.end());
     KOKKOSFFT_THROW_IF(
-        *vmin < 0,
+        std::any_of(values.begin(), values.end(),
+                    [](value_type value) { return value < 0; }),
         "is_out_of_range_value_included: values must be non-negative");
   }
-  return *vmax >= max;
+  return std::any_of(values.begin(), values.end(),
+                     [max](value_type value) { return value >= max; });
 }
 
 template <

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -75,8 +75,9 @@ bool is_out_of_range_value_included(const ContainerType& values, IntType max) {
   static_assert(std::is_same_v<value_type, IntType>,
                 "is_out_of_range_value_included: Container value type must "
                 "match IntType");
-  const auto [vmin, vmax] = std::minmax_element(values.begin(), values.end());
+  const auto vmax = std::max_element(values.begin(), values.end());
   if constexpr (std::is_signed_v<value_type>) {
+    const auto vmin = std::min_element(values.begin(), values.end());
     KOKKOSFFT_THROW_IF(
         *vmin < 0,
         "is_out_of_range_value_included: values must be non-negative");

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -75,11 +75,13 @@ bool is_out_of_range_value_included(const ContainerType& values, IntType max) {
   static_assert(std::is_same_v<value_type, IntType>,
                 "is_out_of_range_value_included: Container value type must "
                 "match IntType");
-  bool is_included = false;
-  for (auto value : values) {
-    is_included = value >= max;
+  const auto [vmin, vmax] = std::minmax_element(values.begin(), values.end());
+  if constexpr (std::is_signed_v<value_type>) {
+    KOKKOSFFT_THROW_IF(
+        *vmin < 0,
+        "is_out_of_range_value_included: values must be non-negative");
   }
-  return is_included;
+  return *vmax >= max;
 }
 
 template <

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -332,7 +332,7 @@ void test_has_duplicate_values() {
 template <typename ContainerType>
 void test_is_out_of_range_value_included() {
   using IntType   = KokkosFFT::Impl::base_container_value_type<ContainerType>;
-  ContainerType v = {0, 1, 2, 3, 4};
+  ContainerType v = {0, 1, 2, 3, 4}, v2 = {0, 4, 1};
 
   EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
       v, static_cast<IntType>(2)));
@@ -342,6 +342,26 @@ void test_is_out_of_range_value_included() {
       v, static_cast<IntType>(5)));
   EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
       v, static_cast<IntType>(6)));
+
+  EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v2, static_cast<IntType>(2)));
+  EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v2, static_cast<IntType>(3)));
+  EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v2, static_cast<IntType>(5)));
+  EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v2, static_cast<IntType>(6)));
+
+  if constexpr (std::is_signed_v<IntType>) {
+    // Since non-negative value is included, it should be invalid
+    ContainerType v3 = {0, 1, -1};
+    EXPECT_THROW(
+        {
+          KokkosFFT::Impl::is_out_of_range_value_included(
+              v3, static_cast<IntType>(2));
+        },
+        std::runtime_error);
+  }
 }
 
 template <typename IntType>

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -338,6 +338,8 @@ void test_is_out_of_range_value_included() {
       v, static_cast<IntType>(2)));
   EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
       v, static_cast<IntType>(3)));
+  EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v, static_cast<IntType>(4)));
   EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
       v, static_cast<IntType>(5)));
   EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
@@ -347,6 +349,8 @@ void test_is_out_of_range_value_included() {
       v2, static_cast<IntType>(2)));
   EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
       v2, static_cast<IntType>(3)));
+  EXPECT_TRUE(KokkosFFT::Impl::is_out_of_range_value_included(
+      v2, static_cast<IntType>(4)));
   EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(
       v2, static_cast<IntType>(5)));
   EXPECT_FALSE(KokkosFFT::Impl::is_out_of_range_value_included(


### PR DESCRIPTION
This PR aims at fixing a bug in `is_out_of_range_value_included` function.
Previous implementation would give a wrong result if `axes` variable is not sorted.

For example, it returns `false` (now returns `true`) in the previous implementation.
```C++
std::array<int> v2 = {0, 4, 1};
KokkosFFT::Impl::is_out_of_range_value_included(
      v2, static_cast<IntType>(2));
```

Following changes are made
- [x] Fix `is_out_of_range_value_included` function with `std::max_element`
- [x] Gives a `runtime_error` if a negative number is included
- [x] Add an unit_test for these cases