### PR TITLE
Discover the test right before running the tests

### DIFF
--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common GTest::gtest)
 
 # Enable GoogleTest
 include(GoogleTest)
-gtest_discover_tests(unit-tests-kokkos-fft-common PROPERTIES DISCOVERY_TIMEOUT 600)
+gtest_discover_tests(unit-tests-kokkos-fft-common PROPERTIES DISCOVERY_TIMEOUT 600 DISCOVERY_MODE PRE_TEST)

--- a/fft/unit_test/CMakeLists.txt
+++ b/fft/unit_test/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(unit-tests-kokkos-fft-core PUBLIC KokkosFFT::fft GTest::gt
 
 # Enable GoogleTest
 include(GoogleTest)
-gtest_discover_tests(unit-tests-kokkos-fft-core PROPERTIES DISCOVERY_TIMEOUT 600)
+gtest_discover_tests(unit-tests-kokkos-fft-core PROPERTIES DISCOVERY_TIMEOUT 600 DISCOVERY_MODE PRE_TEST)


### PR DESCRIPTION
This allows to compile the tests with a GPU backend while not having any GPU on the system. Otherwise we see errors like:
```
/local/home/tpadiole/Codes/kokkos-fft/build-cuda/common/unit_test/unit-tests-kokkos-fft-common: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory
CMake Error at /local/home/tpadiole/spack-0.22.2/opt/spack/linux-ubuntu20.04-icelake/gcc-10.5.0/cmake-3.27.9-6wmnwemkvfflvaks6uiznf4lwwgykneb/share/cmake-3.27/Modules/GoogleTestAddTests.cmake:112 (message):
  Error running test executable.

    Path: '/local/home/tpadiole/Codes/kokkos-fft/build-cuda/common/unit_test/unit-tests-kokkos-fft-common'
    Result: 127
    Output:
      

Call Stack (most recent call first):
  /local/home/tpadiole/spack-0.22.2/opt/spack/linux-ubuntu20.04-icelake/gcc-10.5.0/cmake-3.27.9-6wmnwemkvfflvaks6uiznf4lwwgykneb/share/cmake-3.27/Modules/GoogleTestAddTests.cmake:225 (gtest_discover_tests_impl)


gmake[2]: *** [common/unit_test/CMakeFiles/unit-tests-kokkos-fft-common.dir/build.make:235: common/unit_test/unit-tests-kokkos-fft-common] Error 1
gmake[2]: *** Deleting file 'common/unit_test/unit-tests-kokkos-fft-common'
gmake[1]: *** [CMakeFiles/Makefile2:938: common/unit_test/CMakeFiles/unit-tests-kokkos-fft-common.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```