### PR TITLE
Support in place transform

### DIFF
--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -22,7 +22,7 @@ namespace Impl {
 template <typename InViewType, typename OutViewType, std::size_t DIM = 1>
 auto get_extents(const InViewType& in, const OutViewType& out,
                  axis_type<DIM> axes, shape_type<DIM> shape = {},
-                 bool is_in_place = false) {
+                 bool is_inplace = false) {
   using in_value_type     = typename InViewType::non_const_value_type;
   using out_value_type    = typename OutViewType::non_const_value_type;
   using array_layout_type = typename InViewType::array_layout;
@@ -66,7 +66,7 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   if constexpr (is_real_v<in_value_type>) {
     // Then R2C
-    if (is_in_place) {
+    if (is_inplace) {
       _in_extents.at(inner_most_axis) = _out_extents.at(inner_most_axis) * 2;
     } else {
       KOKKOSFFT_THROW_IF(
@@ -79,7 +79,7 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   if constexpr (is_real_v<out_value_type>) {
     // Then C2R
-    if (is_in_place) {
+    if (is_inplace) {
       _out_extents.at(inner_most_axis) = _in_extents.at(inner_most_axis) * 2;
     } else {
       KOKKOSFFT_THROW_IF(

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -21,7 +21,8 @@ namespace Impl {
 */
 template <typename InViewType, typename OutViewType, std::size_t DIM = 1>
 auto get_extents(const InViewType& in, const OutViewType& out,
-                 axis_type<DIM> axes, shape_type<DIM> shape = {0}) {
+                 axis_type<DIM> axes, shape_type<DIM> shape = {},
+                 bool is_in_place = false) {
   using in_value_type     = typename InViewType::non_const_value_type;
   using out_value_type    = typename OutViewType::non_const_value_type;
   using array_layout_type = typename InViewType::array_layout;
@@ -65,20 +66,28 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   if constexpr (is_real_v<in_value_type>) {
     // Then R2C
-    KOKKOSFFT_THROW_IF(
-        _out_extents.at(inner_most_axis) !=
-            _in_extents.at(inner_most_axis) / 2 + 1,
-        "For R2C, the 'output extent' of transform must be equal to "
-        "'input extent'/2 + 1");
+    if (is_in_place) {
+      _in_extents.at(inner_most_axis) = _out_extents.at(inner_most_axis) * 2;
+    } else {
+      KOKKOSFFT_THROW_IF(
+          _out_extents.at(inner_most_axis) !=
+              _in_extents.at(inner_most_axis) / 2 + 1,
+          "For R2C, the 'output extent' of transform must be equal to "
+          "'input extent'/2 + 1");
+    }
   }
 
   if constexpr (is_real_v<out_value_type>) {
     // Then C2R
-    KOKKOSFFT_THROW_IF(
-        _in_extents.at(inner_most_axis) !=
-            _out_extents.at(inner_most_axis) / 2 + 1,
-        "For C2R, the 'input extent' of transform must be equal to "
-        "'output extent' / 2 + 1");
+    if (is_in_place) {
+      _out_extents.at(inner_most_axis) = _in_extents.at(inner_most_axis) * 2;
+    } else {
+      KOKKOSFFT_THROW_IF(
+          _in_extents.at(inner_most_axis) !=
+              _out_extents.at(inner_most_axis) / 2 + 1,
+          "For C2R, the 'input extent' of transform must be equal to "
+          "'output extent' / 2 + 1");
+    }
   }
 
   if constexpr (std::is_same_v<array_layout_type, Kokkos::LayoutLeft>) {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -17,6 +17,12 @@
 namespace KokkosFFT {
 namespace Impl {
 
+template <typename ScalarType1, typename ScalarType2>
+bool are_aliasing(const ScalarType1* ptr1, const ScalarType2* ptr2) {
+  return (reinterpret_cast<const void*>(ptr1) ==
+          reinterpret_cast<const void*>(ptr2));
+}
+
 template <typename ViewType>
 auto convert_negative_axis(ViewType, int _axis = -1) {
   static_assert(Kokkos::is_view_v<ViewType>,

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -19,8 +19,7 @@ namespace Impl {
 
 template <typename ScalarType1, typename ScalarType2>
 bool are_aliasing(const ScalarType1* ptr1, const ScalarType2* ptr2) {
-  return (reinterpret_cast<const void*>(ptr1) ==
-          reinterpret_cast<const void*>(ptr2));
+  return (static_cast<const void*>(ptr1) == static_cast<const void*>(ptr2));
 }
 
 template <typename ViewType>

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -12,7 +12,7 @@ using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 using base_int_types = ::testing::Types<int, std::size_t>;
 
 // value type combinations that are tested
-using paired_value_types = ::testing::Types<
+using paired_scalar_types = ::testing::Types<
     std::pair<float, float>, std::pair<float, Kokkos::complex<float>>,
     std::pair<Kokkos::complex<float>, Kokkos::complex<float>>,
     std::pair<double, double>, std::pair<double, Kokkos::complex<double>>,
@@ -38,7 +38,7 @@ struct ContainerTypes : public ::testing::Test {
 };
 
 template <typename T>
-struct PairedValueTypes : public ::testing::Test {
+struct PairedScalarTypes : public ::testing::Test {
   using value_type1 = typename T::first_type;
   using value_type2 = typename T::second_type;
 };
@@ -46,7 +46,7 @@ struct PairedValueTypes : public ::testing::Test {
 TYPED_TEST_SUITE(ConvertNegativeAxis, test_types);
 TYPED_TEST_SUITE(ConvertNegativeShift, test_types);
 TYPED_TEST_SUITE(ContainerTypes, base_int_types);
-TYPED_TEST_SUITE(PairedValueTypes, paired_value_types);
+TYPED_TEST_SUITE(PairedScalarTypes, paired_scalar_types);
 
 // Tests for convert_negative_axes over ND views
 template <typename LayoutType>
@@ -582,7 +582,7 @@ void test_are_pointers_aliasing() {
   EXPECT_FALSE(KokkosFFT::Impl::are_aliasing(view1.data(), view2.data()));
 }
 
-TYPED_TEST(PairedValueTypes, are_pointers_aliasing) {
+TYPED_TEST(PairedScalarTypes, are_pointers_aliasing) {
   using value_type1 = typename TestFixture::value_type1;
   using value_type2 = typename TestFixture::value_type2;
   test_are_pointers_aliasing<value_type1, value_type2>();

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -11,6 +11,13 @@ using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 // Int like types
 using base_int_types = ::testing::Types<int, std::size_t>;
 
+// value type combinations that are tested
+using paired_value_types = ::testing::Types<
+    std::pair<float, float>, std::pair<float, Kokkos::complex<float>>,
+    std::pair<Kokkos::complex<float>, Kokkos::complex<float>>,
+    std::pair<double, double>, std::pair<double, Kokkos::complex<double>>,
+    std::pair<Kokkos::complex<double>, Kokkos::complex<double>>>;
+
 // Basically the same fixtures, used for labeling tests
 template <typename T>
 struct ConvertNegativeAxis : public ::testing::Test {
@@ -30,9 +37,16 @@ struct ContainerTypes : public ::testing::Test {
   using array_type                  = std::array<T, rank>;
 };
 
+template <typename T>
+struct PairedValueTypes : public ::testing::Test {
+  using value_type1 = typename T::first_type;
+  using value_type2 = typename T::second_type;
+};
+
 TYPED_TEST_SUITE(ConvertNegativeAxis, test_types);
 TYPED_TEST_SUITE(ConvertNegativeShift, test_types);
 TYPED_TEST_SUITE(ContainerTypes, base_int_types);
+TYPED_TEST_SUITE(PairedValueTypes, paired_value_types);
 
 // Tests for convert_negative_axes over ND views
 template <typename LayoutType>
@@ -549,4 +563,27 @@ TEST(ToArray, lvalue) {
 
 TEST(ToArray, rvalue) {
   ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
+
+template <typename ValueType1, typename ValueType2>
+void test_are_pointers_aliasing() {
+  using View1  = Kokkos::View<ValueType1*, execution_space>;
+  using View2  = Kokkos::View<ValueType2*, execution_space>;
+  using UView2 = Kokkos::View<ValueType2*, execution_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+  const int n1 = 10;
+  // sizeof ValeuType2 is larger or equal to ValueType1
+  const int n2 = sizeof(ValueType1) == sizeof(ValueType2) ? n1 : n1 / 2 + 1;
+  View1 view1("view1", n1);
+  View2 view2("view2", n1);
+  UView2 uview2(reinterpret_cast<ValueType2*>(view1.data()), n2);
+
+  EXPECT_TRUE(KokkosFFT::Impl::are_aliasing(view1.data(), uview2.data()));
+  EXPECT_FALSE(KokkosFFT::Impl::are_aliasing(view1.data(), view2.data()));
+}
+
+TYPED_TEST(PairedValueTypes, are_pointers_aliasing) {
+  using value_type1 = typename TestFixture::value_type1;
+  using value_type2 = typename TestFixture::value_type2;
+  test_are_pointers_aliasing<value_type1, value_type2>();
 }

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -567,8 +567,8 @@ TEST(ToArray, rvalue) {
 
 template <typename ValueType1, typename ValueType2>
 void test_are_pointers_aliasing() {
-  using View1  = Kokkos::View<ValueType1*, execution_space>;
-  using View2  = Kokkos::View<ValueType2*, execution_space>;
+  using View1 = Kokkos::View<ValueType1*, execution_space>;
+  using View2 = Kokkos::View<ValueType2*, execution_space>;
 
   const int n1 = 10;
   // sizeof ValeuType2 is larger or equal to ValueType1

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -569,15 +569,13 @@ template <typename ValueType1, typename ValueType2>
 void test_are_pointers_aliasing() {
   using View1  = Kokkos::View<ValueType1*, execution_space>;
   using View2  = Kokkos::View<ValueType2*, execution_space>;
-  using UView2 = Kokkos::View<ValueType2*, execution_space,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   const int n1 = 10;
   // sizeof ValeuType2 is larger or equal to ValueType1
   const int n2 = sizeof(ValueType1) == sizeof(ValueType2) ? n1 : n1 / 2 + 1;
   View1 view1("view1", n1);
   View2 view2("view2", n1);
-  UView2 uview2(reinterpret_cast<ValueType2*>(view1.data()), n2);
+  View2 uview2(reinterpret_cast<ValueType2*>(view1.data()), n2);
 
   EXPECT_TRUE(KokkosFFT::Impl::are_aliasing(view1.data(), uview2.data()));
   EXPECT_FALSE(KokkosFFT::Impl::are_aliasing(view1.data(), view2.data()));

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -563,6 +563,7 @@ TEST(ToArray, lvalue) {
 
 TEST(ToArray, rvalue) {
   ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
+}
 
 template <typename ValueType1, typename ValueType2>
 void test_are_pointers_aliasing() {

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -22,7 +22,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s) {
+                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -44,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -64,7 +65,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s) {
+                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -86,7 +88,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -106,7 +108,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s) {
+                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -128,7 +131,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -151,7 +154,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s) {
+                 shape_type<fft_rank> s, bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -172,7 +175,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -23,7 +23,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -45,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -66,7 +66,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -88,7 +88,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -109,7 +109,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -131,7 +131,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -154,7 +154,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_in_place) {
+                 shape_type<fft_rank> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -175,7 +175,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -22,7 +22,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s) {
+                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -44,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -64,7 +65,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s) {
+                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -86,7 +88,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -106,7 +108,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s) {
+                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -128,7 +131,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -151,7 +154,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s) {
+                 shape_type<fft_rank> s, bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -172,7 +175,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -23,7 +23,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -45,7 +45,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -66,7 +66,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -88,7 +88,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
@@ -109,7 +109,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -131,7 +131,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
 
   const int nx = fft_extents.at(0), ny = fft_extents.at(1),
             nz = fft_extents.at(2);
@@ -154,7 +154,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_in_place) {
+                 shape_type<fft_rank> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -175,7 +175,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -38,7 +38,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction direction, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s) {
+                 shape_type<fft_rank> s, bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -64,7 +64,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -64,7 +64,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -38,7 +38,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction direction, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_in_place) {
+                 shape_type<fft_rank> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -127,7 +127,7 @@ class Plan {
   bool m_is_crop_or_pad_needed = false;
 
   //! in-place transform or not
-  bool m_is_in_place = false;
+  bool m_is_inplace = false;
 
   //! axes for fft
   axis_type<DIM> m_axes;
@@ -202,16 +202,16 @@ class Plan {
     m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
-    m_is_in_place = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
-    KOKKOSFFT_THROW_IF(m_is_in_place && m_is_transpose_needed,
+    m_is_inplace = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
+    KOKKOSFFT_THROW_IF(m_is_inplace && m_is_transpose_needed,
                        "In-place transform is not supported with transpose. "
                        "Please use out-of-place transform.");
-    KOKKOSFFT_THROW_IF(m_is_in_place && m_is_crop_or_pad_needed,
+    KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
     m_fft_size = KokkosFFT::Impl::create_plan(exec_space, m_plan, in, out,
                                               m_buffer, m_info, direction,
-                                              m_axes, s, m_is_in_place);
+                                              m_axes, s, m_is_inplace);
   }
 
   /// \brief Constructor for multidimensional FFT
@@ -265,16 +265,16 @@ class Plan {
     m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
     m_is_crop_or_pad_needed =
         KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
-    m_is_in_place = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
-    KOKKOSFFT_THROW_IF(m_is_in_place && m_is_transpose_needed,
+    m_is_inplace = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
+    KOKKOSFFT_THROW_IF(m_is_inplace && m_is_transpose_needed,
                        "In-place transform is not supported with transpose. "
                        "Please use out-of-place transform.");
-    KOKKOSFFT_THROW_IF(m_is_in_place && m_is_crop_or_pad_needed,
+    KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
     m_fft_size =
         KokkosFFT::Impl::create_plan(exec_space, m_plan, in, out, m_buffer,
-                                     m_info, direction, axes, s, m_is_in_place);
+                                     m_info, direction, axes, s, m_is_inplace);
   }
 
   ~Plan() {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -362,7 +362,8 @@ class Plan {
         // For the in-place Complex to Real transform, the output must be
         // reshaped to fit the original size (in.size() * 2) for correct
         // normalization
-        Kokkos::View<out_value_type*, execSpace> out_tmp(out.data(), in.size() * 2);
+        Kokkos::View<out_value_type*, execSpace> out_tmp(out.data(),
+                                                         in.size() * 2);
         KokkosFFT::Impl::normalize(m_exec_space, out_tmp, m_direction, norm,
                                    m_fft_size);
         return;

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -362,10 +362,7 @@ class Plan {
         // For the in-place Complex to Real transform, the output must be
         // reshaped to fit the original size (in.size() * 2) for correct
         // normalization
-        using UnmanagedOutViewType =
-            Kokkos::View<out_value_type*, execSpace,
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-        UnmanagedOutViewType out_tmp(out.data(), in.size() * 2);
+        Kokkos::View<out_value_type*, execSpace> out_tmp(out.data(), in.size() * 2);
         KokkosFFT::Impl::normalize(m_exec_space, out_tmp, m_direction, norm,
                                    m_fft_size);
         return;

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -93,7 +93,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  const OutViewType& out, BufferViewType& buffer,
                  InfoType& execution_info, Direction direction,
                  axis_type<fft_rank> axes, shape_type<fft_rank> s,
-                 bool is_in_place) {
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -113,7 +113,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
@@ -155,7 +155,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // Out-of-place transform
   const rocfft_result_placement place =
-      is_in_place ? rocfft_placement_inplace : rocfft_placement_notinplace;
+      is_inplace ? rocfft_placement_inplace : rocfft_placement_notinplace;
 
   // Create a plan
   plan   = std::make_unique<PlanType>();

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -92,7 +92,8 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType& buffer,
                  InfoType& execution_info, Direction direction,
-                 axis_type<fft_rank> axes, shape_type<fft_rank> s) {
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -112,7 +113,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
@@ -154,9 +155,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // Out-of-place transform
   const rocfft_result_placement place =
-      KokkosFFT::Impl::are_aliasing(in.data(), out.data())
-          ? rocfft_placement_inplace
-          : rocfft_placement_notinplace;
+      is_in_place ? rocfft_placement_inplace : rocfft_placement_notinplace;
 
   // Create a plan
   plan   = std::make_unique<PlanType>();

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -11,6 +11,7 @@
 #include "KokkosFFT_layouts.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
@@ -152,7 +153,10 @@ auto create_plan(const ExecutionSpace& exec_space,
                      "rocfft_plan_description_set_data_layout failed");
 
   // Out-of-place transform
-  const rocfft_result_placement place = rocfft_placement_notinplace;
+  const rocfft_result_placement place =
+      KokkosFFT::Impl::are_aliasing(in.data(), out.data())
+          ? rocfft_placement_inplace
+          : rocfft_placement_notinplace;
 
   // Create a plan
   plan   = std::make_unique<PlanType>();

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -10,6 +10,7 @@
 #include "KokkosFFT_SYCL_types.hpp"
 #include "KokkosFFT_layouts.hpp"
 #include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
@@ -98,7 +99,10 @@ auto create_plan(const ExecutionSpace& exec_space,
                   static_cast<std::int64_t>(howmany));
 
   // Data layout in conjugate-even domain
-  plan->set_value(oneapi::mkl::dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
+  int placement = KokkosFFT::Impl::are_aliasing(in.data(), out.data())
+                      ? DFTI_INPLACE
+                      : DFTI_NOT_INPLACE;
+  plan->set_value(oneapi::mkl::dft::config_param::PLACEMENT, placement);
   plan->set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
                   DFTI_COMPLEX_COMPLEX);
 

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -54,7 +54,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_in_place) {
+                 shape_type<fft_rank> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -69,7 +69,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
 
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
@@ -99,7 +99,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                   static_cast<std::int64_t>(howmany));
 
   // Data layout in conjugate-even domain
-  int placement = is_in_place ? DFTI_INPLACE : DFTI_NOT_INPLACE;
+  int placement = is_inplace ? DFTI_INPLACE : DFTI_NOT_INPLACE;
   plan->set_value(oneapi::mkl::dft::config_param::PLACEMENT, placement);
   plan->set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
                   DFTI_COMPLEX_COMPLEX);

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -54,7 +54,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
                  const OutViewType& out, BufferViewType&, InfoType&,
                  Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s) {
+                 shape_type<fft_rank> s, bool is_in_place) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -69,7 +69,7 @@ auto create_plan(const ExecutionSpace& exec_space,
       "KokkosFFT::create_plan: Rank of View must be larger than Rank of FFT.");
 
   auto [in_extents, out_extents, fft_extents, howmany] =
-      KokkosFFT::Impl::get_extents(in, out, axes, s);
+      KokkosFFT::Impl::get_extents(in, out, axes, s, is_in_place);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
                                  std::multiplies<>());
   int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
@@ -99,9 +99,7 @@ auto create_plan(const ExecutionSpace& exec_space,
                   static_cast<std::int64_t>(howmany));
 
   // Data layout in conjugate-even domain
-  int placement = KokkosFFT::Impl::are_aliasing(in.data(), out.data())
-                      ? DFTI_INPLACE
-                      : DFTI_NOT_INPLACE;
+  int placement = is_in_place ? DFTI_INPLACE : DFTI_NOT_INPLACE;
   plan->set_value(oneapi::mkl::dft::config_param::PLACEMENT, placement);
   plan->set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
                   DFTI_COMPLEX_COMPLEX);

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -75,7 +75,7 @@ void test_fft1_identity(T atol = 1.0e-12) {
 }
 
 template <typename T, typename LayoutType>
-void test_fft1_identity_in_place(T atol = 1.0e-12) {
+void test_fft1_identity_inplace(T atol = 1.0e-12) {
   const int maxlen      = 32;
   using RealView1DType  = Kokkos::View<T*, LayoutType, execution_space>;
   using RealUView1DType = Kokkos::View<T*, LayoutType, execution_space,
@@ -1118,12 +1118,12 @@ TYPED_TEST(FFT1D, Identity_1DView) {
 }
 
 // Identity tests on 1D Views for in-place transform
-TYPED_TEST(FFT1D, Identity_1DView_in_place) {
+TYPED_TEST(FFT1D, Identity_1DView_inplace) {
   using float_type  = typename TestFixture::float_type;
   using layout_type = typename TestFixture::layout_type;
 
   float_type atol = std::is_same_v<float_type, float> ? 1.0e-6 : 1.0e-12;
-  test_fft1_identity_in_place<float_type, layout_type>(atol);
+  test_fft1_identity_inplace<float_type, layout_type>(atol);
 }
 
 // Identity tests on 1D Views with plan reuse
@@ -1671,7 +1671,7 @@ void test_fft2_2dfft_2dview_shape(T atol = 1.0e-12) {
 }
 
 template <typename T, typename LayoutType>
-void test_fft2_2dfft_2dview_in_place(T atol = 1.0e-12) {
+void test_fft2_2dfft_2dview_inplace([[maybe_unused]] T atol = 1.0e-12) {
   const int n0 = 4, n1 = 6;
   using RealView2DType  = Kokkos::View<T**, LayoutType, execution_space>;
   using RealUView2DType = Kokkos::View<T**, LayoutType, execution_space,
@@ -2276,11 +2276,11 @@ TYPED_TEST(FFT2D, 2DFFT_2DView_shape) {
 }
 
 // fft2 on 2D Views with in-place transform
-TYPED_TEST(FFT2D, 2DFFT_2DView_in_place) {
+TYPED_TEST(FFT2D, 2DFFT_2DView_inplace) {
   using float_type  = typename TestFixture::float_type;
   using layout_type = typename TestFixture::layout_type;
 
-  test_fft2_2dfft_2dview_in_place<float_type, layout_type>();
+  test_fft2_2dfft_2dview_inplace<float_type, layout_type>();
 }
 
 // batced fft2 on 3D Views

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -91,9 +91,9 @@ void test_fft1_identity_inplace(T atol = 1.0e-12) {
         inv_ar_hat(reinterpret_cast<T*>(ar_hat.data()), i);
     RealView1DType ar_ref("ar_ref", i);
 
-    const Kokkos::complex<T> I(1.0, 1.0);
+    const Kokkos::complex<T> z(1.0, 1.0);
     Kokkos::Random_XorShift64_Pool<> random_pool(/*seed=*/12345);
-    Kokkos::fill_random(a, random_pool, I);
+    Kokkos::fill_random(a, random_pool, z);
     Kokkos::fill_random(ar, random_pool, 1.0);
 
     Kokkos::deep_copy(a_ref, a);

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -112,6 +112,8 @@ void test_fft1_identity_inplace(T atol = 1.0e-12) {
     KokkosFFT::rfft(execution_space(), ar, ar_hat);
     KokkosFFT::irfft(execution_space(), ar_hat, inv_ar_hat);
 
+    Kokkos::fence();
+
     EXPECT_TRUE(allclose(inv_a_hat, a_ref, 1.e-5, atol));
     EXPECT_TRUE(allclose(inv_ar_hat, ar_ref, 1.e-5, atol));
   }

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -13,92 +13,10 @@
 template <std::size_t DIM>
 using shape_type = KokkosFFT::shape_type<DIM>;
 
-/// Kokkos equivalent of fft1 with numpy
-/// def fft1(x):
-///    L = len(x)
-///    phase = -2j * np.pi * (np.arange(L) / L)
-///    phase = np.arange(L).reshape(-1, 1) * phase
-///    return np.sum(x*np.exp(phase), axis=1)
-template <typename ViewType>
-void fft1(ViewType& in, ViewType& out) {
-  using value_type      = typename ViewType::non_const_value_type;
-  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
-
-  static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
-                "fft1: ViewType must be complex");
-
-  const value_type I(0.0, 1.0);
-  std::size_t L = in.size();
-
-  Kokkos::parallel_for(
-      "KokkosFFT::Test::fft1",
-      Kokkos::TeamPolicy<execution_space>(L, Kokkos::AUTO),
-      KOKKOS_LAMBDA(
-          const Kokkos::TeamPolicy<execution_space>::member_type& team_member) {
-        const int j = team_member.league_rank();
-
-        value_type sum = 0;
-        Kokkos::parallel_reduce(
-            Kokkos::TeamThreadRange(team_member, L),
-            [&](const int i, value_type& lsum) {
-              auto phase = -2 * I * M_PI * static_cast<real_value_type>(i) /
-                           static_cast<real_value_type>(L);
-
-              auto tmp_in = in(i);
-              lsum +=
-                  tmp_in * Kokkos::exp(static_cast<real_value_type>(j) * phase);
-            },
-            sum);
-
-        out(j) = sum;
-      });
-}
-
-/// Kokkos equivalent of ifft1 with numpy
-/// def ifft1(x):
-///    L = len(x)
-///    phase = 2j * np.pi * (np.arange(L) / L)
-///    phase = np.arange(L).reshape(-1, 1) * phase
-///    return np.sum(x*np.exp(phase), axis=1)
-template <typename ViewType>
-void ifft1(ViewType& in, ViewType& out) {
-  using value_type      = typename ViewType::non_const_value_type;
-  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
-
-  static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
-                "ifft1: ViewType must be complex");
-
-  const value_type I(0.0, 1.0);
-  std::size_t L = in.size();
-
-  Kokkos::parallel_for(
-      "KokkosFFT::Test::ifft1",
-      Kokkos::TeamPolicy<execution_space>(L, Kokkos::AUTO),
-      KOKKOS_LAMBDA(
-          const Kokkos::TeamPolicy<execution_space>::member_type& team_member) {
-        const int j = team_member.league_rank();
-
-        value_type sum = 0;
-        Kokkos::parallel_reduce(
-            Kokkos::TeamThreadRange(team_member, L),
-            [&](const int i, value_type& lsum) {
-              auto phase = 2 * I * M_PI * static_cast<real_value_type>(i) /
-                           static_cast<real_value_type>(L);
-
-              auto tmp_in = in(i);
-              lsum +=
-                  tmp_in * Kokkos::exp(static_cast<real_value_type>(j) * phase);
-            },
-            sum);
-
-        out(j) = sum;
-      });
-}
-
 using test_types = ::testing::Types<std::pair<float, Kokkos::LayoutLeft>,
                                     std::pair<float, Kokkos::LayoutRight>,
                                     std::pair<double, Kokkos::LayoutLeft>,
-                                    std::pair<double, Kokkos::LayoutRight> >;
+                                    std::pair<double, Kokkos::LayoutRight>>;
 
 // Basically the same fixtures, used for labeling tests
 template <typename T>
@@ -140,6 +58,49 @@ void test_fft1_identity(T atol = 1.0e-12) {
     Kokkos::Random_XorShift64_Pool<> random_pool(/*seed=*/12345);
     Kokkos::fill_random(a, random_pool, z);
     Kokkos::fill_random(ar, random_pool, 1.0);
+    Kokkos::deep_copy(a_ref, a);
+    Kokkos::deep_copy(ar_ref, ar);
+
+    Kokkos::fence();
+
+    KokkosFFT::fft(execution_space(), a, out);
+    KokkosFFT::ifft(execution_space(), out, _a);
+
+    KokkosFFT::rfft(execution_space(), ar, outr);
+    KokkosFFT::irfft(execution_space(), outr, _ar);
+
+    EXPECT_TRUE(allclose(_a, a_ref, 1.e-5, atol));
+    EXPECT_TRUE(allclose(_ar, ar_ref, 1.e-5, atol));
+  }
+}
+
+template <typename T, typename LayoutType>
+void test_fft1_identity_in_place(T atol = 1.0e-12) {
+  const int maxlen      = 32;
+  using RealView1DType  = Kokkos::View<T*, LayoutType, execution_space>;
+  using RealUView1DType = Kokkos::View<T*, LayoutType, execution_space,
+                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ComplexView1DType =
+      Kokkos::View<Kokkos::complex<T>*, LayoutType, execution_space>;
+  using ComplexUView1DType =
+      Kokkos::View<Kokkos::complex<T>*, LayoutType, execution_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+  for (int i = 1; i < maxlen; i++) {
+    ComplexView1DType a("a", i), a_ref("a_ref", i);
+    ComplexUView1DType out(a.data(), i), _a(a.data(), i);
+
+    // Used for Real transforms
+    ComplexView1DType outr("outr", i / 2 + 1);
+    RealUView1DType ar(reinterpret_cast<T*>(outr.data()), i),
+        _ar(reinterpret_cast<T*>(outr.data()), i);
+    RealView1DType ar_ref("ar_ref", i);
+
+    const Kokkos::complex<T> I(1.0, 1.0);
+    Kokkos::Random_XorShift64_Pool<> random_pool(/*seed=*/12345);
+    Kokkos::fill_random(a, random_pool, I);
+    Kokkos::fill_random(ar, random_pool, 1.0);
+
     Kokkos::deep_copy(a_ref, a);
     Kokkos::deep_copy(ar_ref, ar);
 
@@ -1156,6 +1117,15 @@ TYPED_TEST(FFT1D, Identity_1DView) {
   test_fft1_identity<float_type, layout_type>(atol);
 }
 
+// Identity tests on 1D Views for in-place transform
+TYPED_TEST(FFT1D, Identity_1DView_in_place) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  float_type atol = std::is_same_v<float_type, float> ? 1.0e-6 : 1.0e-12;
+  test_fft1_identity_in_place<float_type, layout_type>(atol);
+}
+
 // Identity tests on 1D Views with plan reuse
 TYPED_TEST(FFT1D, Identity_1DView_reuse_plans) {
   using float_type  = typename TestFixture::float_type;
@@ -1701,6 +1671,94 @@ void test_fft2_2dfft_2dview_shape(T atol = 1.0e-12) {
 }
 
 template <typename T, typename LayoutType>
+void test_fft2_2dfft_2dview_in_place(T atol = 1.0e-12) {
+  const int n0 = 4, n1 = 6;
+  using RealView2DType  = Kokkos::View<T**, LayoutType, execution_space>;
+  using RealUView2DType = Kokkos::View<T**, LayoutType, execution_space,
+                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ComplexView2DType =
+      Kokkos::View<Kokkos::complex<T>**, LayoutType, execution_space>;
+  using ComplexUView2DType =
+      Kokkos::View<Kokkos::complex<T>**, LayoutType, execution_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+  ComplexView2DType x("x", n0, n1), x_ref("x_ref", n0, n1);
+  ComplexUView2DType xout(x.data(), n0, n1), _x(x.data(), n0, n1);
+
+  // Used for real transforms
+  ComplexView2DType xr_out("xr_out", n0, n1 / 2 + 1),
+      xr_out_ref("xr_out_ref", n0, n1 / 2 + 1), xhat("xhat", n0, n1 / 2 + 1),
+      xhat_ref("xhat_ref", n0, n1 / 2 + 1);
+  RealView2DType xr_ref("xr_ref", n0, n1), _xr_unpadded("_xr_unpadded", n0, n1),
+      _xr_ref("_xr_ref", n0, n1);
+  RealUView2DType xr(reinterpret_cast<T*>(xr_out.data()), n0, n1),
+      xr_correct(reinterpret_cast<T*>(xr_out.data()), n0, (n1 / 2 + 1) * 2),
+      _xr(reinterpret_cast<T*>(xhat.data()), n0, n1),
+      _xr_correct(reinterpret_cast<T*>(xhat.data()), n0, (n1 / 2 + 1) * 2);
+
+  auto sub_xr =
+      Kokkos::subview(xr_correct, Kokkos::ALL(), Kokkos::pair<int, int>(0, n1));
+
+  const Kokkos::complex<T> I(1.0, 1.0);
+  Kokkos::Random_XorShift64_Pool<> random_pool(12345);
+  Kokkos::fill_random(xr_ref, random_pool, 1.0);
+  Kokkos::fill_random(x, random_pool, I);
+  Kokkos::fill_random(xhat, random_pool, I);
+  Kokkos::deep_copy(sub_xr, xr_ref);
+  Kokkos::deep_copy(x_ref, x);
+  Kokkos::deep_copy(xhat_ref, xhat);
+
+  using axes_type = KokkosFFT::axis_type<2>;
+  axes_type axes  = {-2, -1};
+
+  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
+    // in-place transforms are not supported if transpose is needed
+    EXPECT_THROW(KokkosFFT::fft2(execution_space(), x, xout,
+                                 KokkosFFT::Normalization::backward, axes),
+                 std::runtime_error);
+    EXPECT_THROW(KokkosFFT::ifft2(execution_space(), xout, _x,
+                                  KokkosFFT::Normalization::backward, axes),
+                 std::runtime_error);
+    EXPECT_THROW(KokkosFFT::rfft2(execution_space(), xr, xr_out,
+                                  KokkosFFT::Normalization::backward, axes),
+                 std::runtime_error);
+    EXPECT_THROW(KokkosFFT::irfft2(execution_space(), xhat, _xr,
+                                   KokkosFFT::Normalization::backward, axes),
+                 std::runtime_error);
+  } else {
+    // Identity tests for complex transforms
+    KokkosFFT::fft2(execution_space(), x, xout,
+                    KokkosFFT::Normalization::backward, axes);
+    KokkosFFT::ifft2(execution_space(), xout, _x,
+                     KokkosFFT::Normalization::backward, axes);
+    EXPECT_TRUE(allclose(_x, x_ref, 1.e-5, atol));
+
+    // In-place transforms
+    KokkosFFT::rfft2(execution_space(), xr, xr_out,
+                     KokkosFFT::Normalization::backward, axes);
+
+    // Out-of-place transforms (reference)
+    KokkosFFT::rfft2(execution_space(), xr_ref, xr_out_ref,
+                     KokkosFFT::Normalization::backward, axes);
+    EXPECT_TRUE(allclose(xr_out, xr_out_ref, 1.e-5, atol));
+
+    // In-place transforms
+    KokkosFFT::irfft2(execution_space(), xhat, _xr,
+                      KokkosFFT::Normalization::backward, axes);
+
+    // Out-of-place transforms (reference)
+    KokkosFFT::irfft2(execution_space(), xhat_ref, _xr_ref,
+                      KokkosFFT::Normalization::backward, axes);
+
+    auto sub_xr_correct = Kokkos::subview(_xr_correct, Kokkos::ALL(),
+                                          Kokkos::pair<int, int>(0, n1));
+    Kokkos::deep_copy(_xr_unpadded, sub_xr_correct);
+
+    EXPECT_TRUE(allclose(_xr_unpadded, _xr_ref, 1.e-5, atol));
+  }
+}
+
+template <typename T, typename LayoutType>
 void test_fft2_2dfft_3dview(T atol = 1.e-12) {
   const int n0 = 10, n1 = 6, n2 = 8;
   using RealView3DType = Kokkos::View<T***, LayoutType, execution_space>;
@@ -2215,6 +2273,14 @@ TYPED_TEST(FFT2D, 2DFFT_2DView_shape) {
   using layout_type = typename TestFixture::layout_type;
 
   test_fft2_2dfft_2dview_shape<float_type, layout_type>();
+}
+
+// fft2 on 2D Views with in-place transform
+TYPED_TEST(FFT2D, 2DFFT_2DView_in_place) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  test_fft2_2dfft_2dview_in_place<float_type, layout_type>();
 }
 
 // batced fft2 on 3D Views

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -86,7 +86,7 @@ void fft1(ViewType& in, ViewType& out) {
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "fft1: ViewType must be complex");
 
-  constexpr auto pi = pi_v<real_value_type>;
+  constexpr auto pi = pi_v<double>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 
@@ -134,7 +134,7 @@ void ifft1(ViewType& in, ViewType& out) {
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "ifft1: ViewType must be complex");
 
-  constexpr auto pi = pi_v<real_value_type>;
+  constexpr auto pi = pi_v<double>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -60,10 +60,102 @@ void display(ViewType& a) {
   auto* data = h_a.data();
 
   std::cout << std::scientific << std::setprecision(16) << std::flush;
-  for (int i = 0; i < n; i++) {
+  for (std::size_t i = 0; i < n; i++) {
     std::cout << label + "[" << i << "]: " << i << ", " << data[i] << std::endl;
   }
   std::cout << std::resetiosflags(std::ios_base::floatfield);
+}
+
+/// \brief Kokkos equivalent of fft1 with numpy
+/// def fft1(x):
+///    L = len(x)
+///    phase = -2j * np.pi * (np.arange(L) / L)
+///    phase = np.arange(L).reshape(-1, 1) * phase
+///    return np.sum(x*np.exp(phase), axis=1)
+///
+/// \tparam ViewType: Input and output view type
+///
+/// \param in [in]: Input rank 1 view
+/// \param out [out]: Output rank 1 view
+template <typename ViewType>
+void fft1(ViewType& in, ViewType& out) {
+  using value_type      = typename ViewType::non_const_value_type;
+  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
+
+  static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
+                "fft1: ViewType must be complex");
+
+  const value_type I(0.0, 1.0);
+  std::size_t L = in.size();
+
+  Kokkos::parallel_for(
+      "KokkosFFT::Test::fft1",
+      Kokkos::TeamPolicy<execution_space>(L, Kokkos::AUTO),
+      KOKKOS_LAMBDA(
+          const Kokkos::TeamPolicy<execution_space>::member_type& team_member) {
+        const int j = team_member.league_rank();
+
+        value_type sum = 0;
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, L),
+            [&](const int i, value_type& lsum) {
+              auto phase = -2 * I * M_PI * static_cast<real_value_type>(i) /
+                           static_cast<real_value_type>(L);
+
+              auto tmp_in = in(i);
+              lsum +=
+                  tmp_in * Kokkos::exp(static_cast<real_value_type>(j) * phase);
+            },
+            sum);
+
+        out(j) = sum;
+      });
+}
+
+/// \brief Kokkos equivalent of ifft1 with numpy
+/// def ifft1(x):
+///    L = len(x)
+///    phase = 2j * np.pi * (np.arange(L) / L)
+///    phase = np.arange(L).reshape(-1, 1) * phase
+///    return np.sum(x*np.exp(phase), axis=1)
+///
+/// \tparam ViewType: Input and output view type
+///
+/// \param in [in]: Input rank 1 view
+/// \param out [out]: Output rank 1 view
+template <typename ViewType>
+void ifft1(ViewType& in, ViewType& out) {
+  using value_type      = typename ViewType::non_const_value_type;
+  using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
+
+  static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
+                "ifft1: ViewType must be complex");
+
+  const value_type I(0.0, 1.0);
+  std::size_t L = in.size();
+
+  Kokkos::parallel_for(
+      "KokkosFFT::Test::ifft1",
+      Kokkos::TeamPolicy<execution_space>(L, Kokkos::AUTO),
+      KOKKOS_LAMBDA(
+          const Kokkos::TeamPolicy<execution_space>::member_type& team_member) {
+        const int j = team_member.league_rank();
+
+        value_type sum = 0;
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, L),
+            [&](const int i, value_type& lsum) {
+              auto phase = 2 * I * M_PI * static_cast<real_value_type>(i) /
+                           static_cast<real_value_type>(L);
+
+              auto tmp_in = in(i);
+              lsum +=
+                  tmp_in * Kokkos::exp(static_cast<real_value_type>(j) * phase);
+            },
+            sum);
+
+        out(j) = sum;
+      });
 }
 
 #endif

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -81,10 +81,12 @@ template <typename ViewType>
 void fft1(ViewType& in, ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
   using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
+  using Kokkos::numbers::pi_v;
 
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "fft1: ViewType must be complex");
 
+  constexpr auto pi = pi_v<real_value_type>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 
@@ -99,8 +101,7 @@ void fft1(ViewType& in, ViewType& out) {
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange(team_member, L),
             [&](const int i, value_type& lsum) {
-              auto phase = -2 * I * Kokkos::numbers::pi *
-                           static_cast<real_value_type>(i) /
+              auto phase = -2 * I * pi * static_cast<real_value_type>(i) /
                            static_cast<real_value_type>(L);
 
               auto tmp_in = in(i);
@@ -128,10 +129,12 @@ template <typename ViewType>
 void ifft1(ViewType& in, ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
   using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
+  using Kokkos::numbers::pi_v;
 
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "ifft1: ViewType must be complex");
 
+  constexpr auto pi = pi_v<real_value_type>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 
@@ -146,8 +149,7 @@ void ifft1(ViewType& in, ViewType& out) {
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange(team_member, L),
             [&](const int i, value_type& lsum) {
-              auto phase = 2 * I * Kokkos::numbers::pi *
-                           static_cast<real_value_type>(i) /
+              auto phase = 2 * I * pi * static_cast<real_value_type>(i) /
                            static_cast<real_value_type>(L);
 
               auto tmp_in = in(i);

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -99,7 +99,8 @@ void fft1(ViewType& in, ViewType& out) {
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange(team_member, L),
             [&](const int i, value_type& lsum) {
-              auto phase = -2 * I * M_PI * static_cast<real_value_type>(i) /
+              auto phase = -2 * I * Kokkos::numbers::pi *
+                           static_cast<real_value_type>(i) /
                            static_cast<real_value_type>(L);
 
               auto tmp_in = in(i);
@@ -145,7 +146,8 @@ void ifft1(ViewType& in, ViewType& out) {
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange(team_member, L),
             [&](const int i, value_type& lsum) {
-              auto phase = 2 * I * M_PI * static_cast<real_value_type>(i) /
+              auto phase = 2 * I * Kokkos::numbers::pi *
+                           static_cast<real_value_type>(i) /
                            static_cast<real_value_type>(L);
 
               auto tmp_in = in(i);

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -78,15 +78,14 @@ void display(ViewType& a) {
 /// \param in [in]: Input rank 1 view
 /// \param out [out]: Output rank 1 view
 template <typename ViewType>
-void fft1(ViewType& in, ViewType& out) {
+void fft1(const ViewType& in, const ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
   using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
-  using Kokkos::numbers::pi_v;
 
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "fft1: ViewType must be complex");
 
-  constexpr auto pi = pi_v<double>;
+  constexpr auto pi = Kokkos::numbers::pi_v<double>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 
@@ -126,15 +125,14 @@ void fft1(ViewType& in, ViewType& out) {
 /// \param in [in]: Input rank 1 view
 /// \param out [out]: Output rank 1 view
 template <typename ViewType>
-void ifft1(ViewType& in, ViewType& out) {
+void ifft1(const ViewType& in, const ViewType& out) {
   using value_type      = typename ViewType::non_const_value_type;
   using real_value_type = KokkosFFT::Impl::base_floating_point_type<value_type>;
-  using Kokkos::numbers::pi_v;
 
   static_assert(KokkosFFT::Impl::is_complex_v<value_type>,
                 "ifft1: ViewType must be complex");
 
-  constexpr auto pi = pi_v<double>;
+  constexpr auto pi = Kokkos::numbers::pi_v<double>;
   const value_type I(0.0, 1.0);
   std::size_t L = in.size();
 


### PR DESCRIPTION
Resolves #61

This PR aims at supporting in-place transform.
Following changes are made.

- [x] Add a function `are_aliasing` to check if the input and output views are alias
- [x] Add a test function for `are_aliasing`
- [x] Improve `get_extents` function to compute extents for `in-place` case
- [x] Use `in-place` options for `ROCM` and `SYCL` in case of `in-place` transforms
- [x] Add tests for 1D and 2D `in-place` transforms