### PR TITLE
Make Plan class as a part of API

### DIFF
--- a/docs/api/plan.rst
+++ b/docs/api/plan.rst
@@ -2,8 +2,8 @@
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-KokkosFFT::Impl::Plan
----------------------
+KokkosFFT::Plan
+---------------
 
-.. doxygenclass:: KokkosFFT::Impl::Plan
+.. doxygenclass:: KokkosFFT::Plan
    :members:

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -9,8 +9,8 @@ API Reference
 
 This section documents the public user interface of ``Kokkos-fft``. 
 APIs are defined in ``KokkosFFT`` namespace and implementation details are defined in ``KokkosFFT::Impl`` namespace. 
-Thus, it is highly discouraged for users to access functions in ``KokkosFFT::Impl`` namespace except for ``Plan``. 
-Except for ``KokkosFFT::Impl::Plan``, there are corresponding functions in ``numpy.fft`` as shown below.
+Thus, it is highly discouraged for users to access functions in ``KokkosFFT::Impl`` namespace. 
+Except for ``KokkosFFT::Plan``, there are corresponding functions in ``numpy.fft`` as shown below.
 
 FFT Plan
 --------

--- a/docs/intro/using.rst
+++ b/docs/intro/using.rst
@@ -123,7 +123,7 @@ Reuse FFT plan
 --------------
 
 Apart from the basic APIs, Kokkos-fft offers the capability to create a FFT plan wrapping the FFT plans of backend libraries.
-We can reuse the FFT plan created once to perform FFTs multiple times on different data.
+We can reuse the FFT plan created once to perform FFTs multiple times on different data given that they have the same properties.
 In some backend, FFT plan creation leads to some overhead, wherein we need this functionality.
 (see :doc:`minimum working example<../samples/06_1DFFT_reuse_plans>`)
 

--- a/docs/intro/using.rst
+++ b/docs/intro/using.rst
@@ -122,8 +122,8 @@ The following listing shows examples with and without transpose operation.
 Reuse FFT plan
 --------------
 
-Apart from the basic APIs, Kokkos-fft APIs include overloaded APIs which can take a FFT plan as an argument.
-Using these overloaded APIs, we can reuse the FFT plan created before. 
+Apart from the basic APIs, Kokkos-fft offers the capability to create a FFT plan wrapping the FFT plans of backend libraries.
+We can reuse the FFT plan created once to perform FFTs multiple times on different data.
 In some backend, FFT plan creation leads to some overhead, wherein we need this functionality.
 (see :doc:`minimum working example<../samples/06_1DFFT_reuse_plans>`)
 

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -27,31 +27,31 @@ int main(int argc, char* argv[]) {
     Kokkos::fill_random(exec, xc2c, random_pool, z);
 
     int axis = -1;
-    KokkosFFT::Impl::Plan fft_plan(exec, xc2c, xc2c_hat,
-                                   KokkosFFT::Direction::forward, axis);
-    KokkosFFT::Impl::fft_exec_impl(fft_plan, xc2c, xc2c_hat);
+    KokkosFFT::Plan fft_plan(exec, xc2c, xc2c_hat,
+                             KokkosFFT::Direction::forward, axis);
+    KokkosFFT::execute(fft_plan, xc2c, xc2c_hat);
 
-    KokkosFFT::Impl::Plan ifft_plan(exec, xc2c_hat, xc2c_inv,
-                                    KokkosFFT::Direction::backward, axis);
-    KokkosFFT::Impl::fft_exec_impl(ifft_plan, xc2c_hat, xc2c_inv);
+    KokkosFFT::Plan ifft_plan(exec, xc2c_hat, xc2c_inv,
+                              KokkosFFT::Direction::backward, axis);
+    KokkosFFT::execute(ifft_plan, xc2c_hat, xc2c_inv);
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
     View1D<Kokkos::complex<double> > xr2c_hat("xr2c_hat", n0 / 2 + 1);
     Kokkos::fill_random(exec, xr2c, random_pool, 1);
 
-    KokkosFFT::Impl::Plan rfft_plan(exec, xr2c, xr2c_hat,
-                                    KokkosFFT::Direction::forward, axis);
-    KokkosFFT::Impl::fft_exec_impl(rfft_plan, xr2c, xr2c_hat);
+    KokkosFFT::Plan rfft_plan(exec, xr2c, xr2c_hat,
+                              KokkosFFT::Direction::forward, axis);
+    KokkosFFT::execute(rfft_plan, xr2c, xr2c_hat);
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xc2r_hat", n0 / 2 + 1);
     View1D<double> xc2r_hat("xc2r", n0);
     Kokkos::fill_random(exec, xc2r, random_pool, z);
 
-    KokkosFFT::Impl::Plan irfft_plan(exec, xc2r, xc2r_hat,
-                                     KokkosFFT::Direction::backward, axis);
-    KokkosFFT::Impl::fft_exec_impl(irfft_plan, xc2r, xc2r_hat);
+    KokkosFFT::Plan irfft_plan(exec, xc2r, xc2r_hat,
+                               KokkosFFT::Direction::backward, axis);
+    KokkosFFT::execute(irfft_plan, xc2r, xc2r_hat);
     exec.fence();
   }
   Kokkos::finalize();

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -29,11 +29,11 @@ int main(int argc, char* argv[]) {
     int axis = -1;
     KokkosFFT::Plan fft_plan(exec, xc2c, xc2c_hat,
                              KokkosFFT::Direction::forward, axis);
-    KokkosFFT::execute(fft_plan, xc2c, xc2c_hat);
+    fft_plan.execute(xc2c, xc2c_hat);
 
     KokkosFFT::Plan ifft_plan(exec, xc2c_hat, xc2c_inv,
                               KokkosFFT::Direction::backward, axis);
-    KokkosFFT::execute(ifft_plan, xc2c_hat, xc2c_inv);
+    ifft_plan.execute(xc2c_hat, xc2c_inv);
 
     // 1D R2C FFT
     View1D<double> xr2c("xr2c", n0);
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Plan rfft_plan(exec, xr2c, xr2c_hat,
                               KokkosFFT::Direction::forward, axis);
-    KokkosFFT::execute(rfft_plan, xr2c, xr2c_hat);
+    rfft_plan.execute(xr2c, xr2c_hat);
 
     // 1D C2R FFT
     View1D<Kokkos::complex<double> > xc2r("xc2r_hat", n0 / 2 + 1);
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
 
     KokkosFFT::Plan irfft_plan(exec, xc2r, xc2r_hat,
                                KokkosFFT::Direction::backward, axis);
-    KokkosFFT::execute(irfft_plan, xc2r, xc2r_hat);
+    irfft_plan.execute(xc2r, xc2r_hat);
     exec.fence();
   }
   Kokkos::finalize();

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -46,7 +46,6 @@
 #endif
 
 namespace KokkosFFT {
-namespace Impl {
 /// \brief A class that manages a FFT plan of backend FFT library.
 ///
 /// This class is used to manage the FFT plan of backend FFT library.
@@ -261,8 +260,8 @@ class Plan {
   }
 
   ~Plan() {
-    destroy_plan_and_info<ExecutionSpace, fft_plan_type, fft_info_type>(m_plan,
-                                                                        m_info);
+    KokkosFFT::Impl::destroy_plan_and_info<ExecutionSpace, fft_plan_type,
+                                           fft_info_type>(m_plan, m_info);
   }
 
   Plan()            = delete;
@@ -318,7 +317,6 @@ class Plan {
   map_type map() const { return m_map; }
   map_type map_inv() const { return m_map_inv; }
 };
-}  // namespace Impl
 }  // namespace KokkosFFT
 
 #endif

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -67,7 +67,7 @@ namespace KokkosFFT {
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = 1>
 class Plan {
- public:
+ private:
   //! The type of Kokkos execution pace
   using execSpace = ExecutionSpace;
 
@@ -273,6 +273,7 @@ class Plan {
   ///
   /// \param in [in] Input data
   /// \param out [out] Ouput data
+  /// \param norm [in] How the normalization is applied (default, backward)
   void execute(const InViewType& in, const OutViewType& out,
                KokkosFFT::Normalization norm =
                    KokkosFFT::Normalization::backward) const {
@@ -327,9 +328,6 @@ class Plan {
  private:
   void execute_fft(const InViewType& in, const OutViewType& out,
                    KokkosFFT::Normalization norm) const {
-    using in_value_type  = typename InViewType::non_const_value_type;
-    using out_value_type = typename OutViewType::non_const_value_type;
-
     auto* idata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
         execSpace, in_value_type>::type*>(in.data());
     auto* odata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -67,15 +67,19 @@ void exec_impl(
                              plan.fft_size());
 }
 
+}  // namespace Impl
+}  // namespace KokkosFFT
+
+namespace KokkosFFT {
 template <typename PlanType, typename InViewType, typename OutViewType>
-void fft_exec_impl(
+void execute(
     const PlanType& plan, const InViewType& in, OutViewType& out,
     KokkosFFT::Normalization norm = KokkosFFT::Normalization::backward) {
   using ExecutionSpace = typename PlanType::execSpace;
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
-      "fft_exec_impl: InViewType and OutViewType must have the same base "
+      "execute: InViewType and OutViewType must have the same base "
       "floating point "
       "type (float/double), the same layout (LayoutLeft/LayoutRight), and the "
       "same rank. ExecutionSpace must be accessible to the data in InViewType "
@@ -119,10 +123,6 @@ void fft_exec_impl(
   }
 }
 
-}  // namespace Impl
-}  // namespace KokkosFFT
-
-namespace KokkosFFT {
 /// \brief One dimensional FFT in forward direction
 ///
 /// \param exec_space [in] Kokkos execution space
@@ -148,9 +148,9 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
                 "fft: View rank must be larger than or equal to 1");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
-                             axis, n);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axis,
+                       n);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief One dimensional FFT in backward direction
@@ -178,9 +178,9 @@ void ifft(const ExecutionSpace& exec_space, const InViewType& in,
                 "ifft: View rank must be larger than or equal to 1");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out,
-                             KokkosFFT::Direction::backward, axis, n);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axis, n);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief One dimensional FFT for real input
@@ -366,9 +366,9 @@ void fft2(const ExecutionSpace& exec_space, const InViewType& in,
                 "fft2: View rank must be larger than or equal to 2");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
-                             axes, s);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
+                       s);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief Two dimensional FFT in backward direction
@@ -396,9 +396,9 @@ void ifft2(const ExecutionSpace& exec_space, const InViewType& in,
                 "ifft2: View rank must be larger than or equal to 2");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out,
-                             KokkosFFT::Direction::backward, axes, s);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axes, s);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief Two dimensional FFT for real input
@@ -511,9 +511,9 @@ void fftn(
       "fftn: View rank must be larger than or equal to the Rank of FFT axes");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
-                             axes, s);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
+                       s);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief N-dimensional FFT in backward direction with a given plan
@@ -554,9 +554,9 @@ void ifftn(
       "ifftn: View rank must be larger than or equal to the Rank of FFT axes");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Impl::Plan plan(exec_space, in, out,
-                             KokkosFFT::Direction::backward, axes, s);
-  KokkosFFT::Impl::fft_exec_impl(plan, in, out, norm);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axes, s);
+  KokkosFFT::execute(plan, in, out, norm);
 }
 
 /// \brief N-dimensional FFT for real input

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -85,7 +85,7 @@ void test_plan_constructible() {
   using ComplexView1DType =
       Kokkos::View<Kokkos::complex<ValueType>*, ExecutionSpace>;
   using PlanType =
-      KokkosFFT::Impl::Plan<ExecutionSpace, RealView1DType, ComplexView1DType>;
+      KokkosFFT::Plan<ExecutionSpace, RealView1DType, ComplexView1DType>;
 
 #if !defined(ENABLE_HOST_AND_DEVICE) &&                           \
     (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
@@ -132,59 +132,59 @@ void test_plan_1dfft_1dview() {
   ComplexView1DType x_cin("x_cin", n), x_cout("x_cout", n);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axis_0(execution_space(), x, x_c,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_r2c_axes_0(execution_space(), x, x_c,
-                                        KokkosFFT::Direction::forward,
-                                        /*axes=*/axes_type<1>({0}));
+  KokkosFFT::Plan plan_r2c_axis_0(execution_space(), x, x_c,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/0);
+  KokkosFFT::Plan plan_r2c_axes_0(execution_space(), x, x_c,
+                                  KokkosFFT::Direction::forward,
+                                  /*axes=*/axes_type<1>({0}));
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axis0(execution_space(), x_c, x,
-                                       KokkosFFT::Direction::backward,
-                                       /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2r_axes0(execution_space(), x_c, x,
-                                       KokkosFFT::Direction::backward,
-                                       /*axes=*/axes_type<1>({0}));
+  KokkosFFT::Plan plan_c2r_axis0(execution_space(), x_c, x,
+                                 KokkosFFT::Direction::backward,
+                                 /*axis=*/0);
+  KokkosFFT::Plan plan_c2r_axes0(execution_space(), x_c, x,
+                                 KokkosFFT::Direction::backward,
+                                 /*axes=*/axes_type<1>({0}));
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axis0(execution_space(), x_cin, x_cout,
-                                         KokkosFFT::Direction::forward,
-                                         /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2c_f_axes0(execution_space(), x_cin, x_cout,
-                                         KokkosFFT::Direction::backward,
-                                         /*axes=*/axes_type<1>({0}));
+  KokkosFFT::Plan plan_c2c_f_axis0(execution_space(), x_cin, x_cout,
+                                   KokkosFFT::Direction::forward,
+                                   /*axis=*/0);
+  KokkosFFT::Plan plan_c2c_f_axes0(execution_space(), x_cin, x_cout,
+                                   KokkosFFT::Direction::backward,
+                                   /*axes=*/axes_type<1>({0}));
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis0(
-            execution_space(), x, x_c, KokkosFFT::Direction::backward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_r2c_axis0(execution_space(), x, x_c,
+                                             KokkosFFT::Direction::backward,
+                                             /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes0(
-            execution_space(), x, x_c, KokkosFFT::Direction::backward,
-            /*axes=*/axes_type<1>({0}));
+        KokkosFFT::Plan wrong_plan_r2c_axes0(execution_space(), x, x_c,
+                                             KokkosFFT::Direction::backward,
+                                             /*axes=*/axes_type<1>({0}));
       },
       std::runtime_error);
 
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis0(
-            execution_space(), x_c, x, KokkosFFT::Direction::forward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_c2r_axis0(execution_space(), x_c, x,
+                                             KokkosFFT::Direction::forward,
+                                             /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes0(
-            execution_space(), x_c, x, KokkosFFT::Direction::forward,
-            /*axes=*/axes_type<1>({0}));
+        KokkosFFT::Plan wrong_plan_c2r_axes0(execution_space(), x_c, x,
+                                             KokkosFFT::Direction::forward,
+                                             /*axes=*/axes_type<1>({0}));
       },
       std::runtime_error);
 }
@@ -201,54 +201,54 @@ void test_plan_1dfft_2dview() {
   ComplexView2DType x_cin("x_cin", n0, n1), x_cout("x_cout", n0, n1);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_r2c_axis_minus1(execution_space(), x, x_c_axis_1,
-                                             KokkosFFT::Direction::forward,
-                                             /*axis=*/-1);
+  KokkosFFT::Plan plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/0);
+  KokkosFFT::Plan plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/1);
+  KokkosFFT::Plan plan_r2c_axis_minus1(execution_space(), x, x_c_axis_1,
+                                       KokkosFFT::Direction::forward,
+                                       /*axis=*/-1);
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
-                                        KokkosFFT::Direction::backward,
-                                        /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
-                                        KokkosFFT::Direction::backward,
-                                        /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_c2r_axis_minus1(execution_space(), x_c_axis_1, x,
-                                             KokkosFFT::Direction::backward,
-                                             /*axis=*/-1);
+  KokkosFFT::Plan plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
+                                  KokkosFFT::Direction::backward,
+                                  /*axis=*/0);
+  KokkosFFT::Plan plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
+                                  KokkosFFT::Direction::backward,
+                                  /*axis=*/1);
+  KokkosFFT::Plan plan_c2r_axis_minus1(execution_space(), x_c_axis_1, x,
+                                       KokkosFFT::Direction::backward,
+                                       /*axis=*/-1);
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axis_0(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::forward,
-                                          /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2c_f_axis_1(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::forward,
-                                          /*axis=*/1);
+  KokkosFFT::Plan plan_c2c_f_axis_0(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::forward,
+                                    /*axis=*/0);
+  KokkosFFT::Plan plan_c2c_f_axis_1(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::forward,
+                                    /*axis=*/1);
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_0(
-            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
+                                              KokkosFFT::Direction::backward,
+                                              /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_1(
-            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
-            /*axis=*/1);
+        KokkosFFT::Plan wrong_plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
+                                              KokkosFFT::Direction::backward,
+                                              /*axis=*/1);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_minus1(
+        KokkosFFT::Plan wrong_plan_r2c_axis_minus1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axis=*/-1);
       },
@@ -257,21 +257,21 @@ void test_plan_1dfft_2dview() {
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_0(
-            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
+                                              KokkosFFT::Direction::forward,
+                                              /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_1(
-            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
-            /*axis=*/1);
+        KokkosFFT::Plan wrong_plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
+                                              KokkosFFT::Direction::forward,
+                                              /*axis=*/1);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_minus1(
+        KokkosFFT::Plan wrong_plan_c2r_axis_minus1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axis=*/-1);
       },
@@ -292,93 +292,93 @@ void test_plan_1dfft_3dview() {
   ComplexView3DType x_cin("x_cin", n0, n1, n2), x_cout("x_cout", n0, n1, n2);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_r2c_axis_2(execution_space(), x, x_c_axis_2,
-                                        KokkosFFT::Direction::forward,
-                                        /*axis=*/2);
+  KokkosFFT::Plan plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/0);
+  KokkosFFT::Plan plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/1);
+  KokkosFFT::Plan plan_r2c_axis_2(execution_space(), x, x_c_axis_2,
+                                  KokkosFFT::Direction::forward,
+                                  /*axis=*/2);
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
-                                        KokkosFFT::Direction::backward,
-                                        /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
-                                        KokkosFFT::Direction::backward,
-                                        /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_c2r_axis_2(execution_space(), x_c_axis_2, x,
-                                        KokkosFFT::Direction::backward,
-                                        /*axis=*/2);
+  KokkosFFT::Plan plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
+                                  KokkosFFT::Direction::backward,
+                                  /*axis=*/0);
+  KokkosFFT::Plan plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
+                                  KokkosFFT::Direction::backward,
+                                  /*axis=*/1);
+  KokkosFFT::Plan plan_c2r_axis_2(execution_space(), x_c_axis_2, x,
+                                  KokkosFFT::Direction::backward,
+                                  /*axis=*/2);
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axis_0(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::forward,
-                                          /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2c_f_axis_1(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::forward,
-                                          /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_c2c_f_axis_2(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::forward,
-                                          /*axis=*/2);
-  KokkosFFT::Impl::Plan plan_c2c_b_axis_0(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::backward,
-                                          /*axis=*/0);
-  KokkosFFT::Impl::Plan plan_c2c_b_axis_1(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::backward,
-                                          /*axis=*/1);
-  KokkosFFT::Impl::Plan plan_c2c_b_axis_2(execution_space(), x_cin, x_cout,
-                                          KokkosFFT::Direction::backward,
-                                          /*axis=*/2);
+  KokkosFFT::Plan plan_c2c_f_axis_0(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::forward,
+                                    /*axis=*/0);
+  KokkosFFT::Plan plan_c2c_f_axis_1(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::forward,
+                                    /*axis=*/1);
+  KokkosFFT::Plan plan_c2c_f_axis_2(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::forward,
+                                    /*axis=*/2);
+  KokkosFFT::Plan plan_c2c_b_axis_0(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::backward,
+                                    /*axis=*/0);
+  KokkosFFT::Plan plan_c2c_b_axis_1(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::backward,
+                                    /*axis=*/1);
+  KokkosFFT::Plan plan_c2c_b_axis_2(execution_space(), x_cin, x_cout,
+                                    KokkosFFT::Direction::backward,
+                                    /*axis=*/2);
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_0(
-            execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_r2c_axis_0(execution_space(), x, x_c_axis_0,
+                                              KokkosFFT::Direction::backward,
+                                              /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_1(
-            execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
-            /*axis=*/1);
+        KokkosFFT::Plan wrong_plan_r2c_axis_1(execution_space(), x, x_c_axis_1,
+                                              KokkosFFT::Direction::backward,
+                                              /*axis=*/1);
       },
       std::runtime_error);
 
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axis_2(
-            execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
-            /*axis=*/2);
+        KokkosFFT::Plan wrong_plan_r2c_axis_2(execution_space(), x, x_c_axis_2,
+                                              KokkosFFT::Direction::backward,
+                                              /*axis=*/2);
       },
       std::runtime_error);
 
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_0(
-            execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
-            /*axis=*/0);
+        KokkosFFT::Plan wrong_plan_c2r_axis_0(execution_space(), x_c_axis_0, x,
+                                              KokkosFFT::Direction::forward,
+                                              /*axis=*/0);
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_1(
-            execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
-            /*axis=*/1);
+        KokkosFFT::Plan wrong_plan_c2r_axis_1(execution_space(), x_c_axis_1, x,
+                                              KokkosFFT::Direction::forward,
+                                              /*axis=*/1);
       },
       std::runtime_error);
 
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axis_2(
-            execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
-            /*axis=*/2);
+        KokkosFFT::Plan wrong_plan_c2r_axis_2(execution_space(), x_c_axis_2, x,
+                                              KokkosFFT::Direction::forward,
+                                              /*axis=*/2);
       },
       std::runtime_error);
 }
@@ -420,41 +420,41 @@ void test_plan_2dfft_2dview() {
   ComplexView2DType x_cin("x_cin", n0, n1), x_cout("x_cout", n0, n1);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axes_0_1(execution_space(), x, x_c_axis_1,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_1_0(execution_space(), x, x_c_axis_0,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_r2c_axes_0_1(execution_space(), x, x_c_axis_1,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_r2c_axes_1_0(execution_space(), x, x_c_axis_0,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({1, 0}));
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axes_0_1(execution_space(), x_c_axis_1, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_1_0(execution_space(), x_c_axis_0, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_c2r_axes_0_1(execution_space(), x_c_axis_1, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_c2r_axes_1_0(execution_space(), x_c_axis_0, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({1, 0}));
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_0_1(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_1_0(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_c2c_f_axes_0_1(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_c2c_f_axes_1_0(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({1, 0}));
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1(
+        KokkosFFT::Plan wrong_plan_r2c_axes_0_1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0(
+        KokkosFFT::Plan wrong_plan_r2c_axes_1_0(
             execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({1, 0}));
       },
@@ -463,14 +463,14 @@ void test_plan_2dfft_2dview() {
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1(
+        KokkosFFT::Plan wrong_plan_c2r_axes_0_1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0(
+        KokkosFFT::Plan wrong_plan_c2r_axes_1_0(
             execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({1, 0}));
       },
@@ -491,105 +491,105 @@ void test_plan_2dfft_3dview() {
   ComplexView3DType x_cin("x_cin", n0, n1, n2), x_cout("x_cout", n0, n1, n2);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axes_0_1(execution_space(), x, x_c_axis_1,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_0_2(execution_space(), x, x_c_axis_2,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({0, 2}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_1_0(execution_space(), x, x_c_axis_0,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({1, 0}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_1_2(execution_space(), x, x_c_axis_2,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({1, 2}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_2_0(execution_space(), x, x_c_axis_0,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({2, 0}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_2_1(execution_space(), x, x_c_axis_1,
-                                          KokkosFFT::Direction::forward,
-                                          /*axes=*/axes_type<2>({2, 1}));
+  KokkosFFT::Plan plan_r2c_axes_0_1(execution_space(), x, x_c_axis_1,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_r2c_axes_0_2(execution_space(), x, x_c_axis_2,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({0, 2}));
+  KokkosFFT::Plan plan_r2c_axes_1_0(execution_space(), x, x_c_axis_0,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_r2c_axes_1_2(execution_space(), x, x_c_axis_2,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({1, 2}));
+  KokkosFFT::Plan plan_r2c_axes_2_0(execution_space(), x, x_c_axis_0,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({2, 0}));
+  KokkosFFT::Plan plan_r2c_axes_2_1(execution_space(), x, x_c_axis_1,
+                                    KokkosFFT::Direction::forward,
+                                    /*axes=*/axes_type<2>({2, 1}));
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axes_0_1(execution_space(), x_c_axis_1, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_0_2(execution_space(), x_c_axis_2, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({0, 2}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_1_0(execution_space(), x_c_axis_0, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({1, 0}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_1_2(execution_space(), x_c_axis_2, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({1, 2}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_2_0(execution_space(), x_c_axis_0, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({2, 0}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_2_1(execution_space(), x_c_axis_1, x,
-                                          KokkosFFT::Direction::backward,
-                                          /*axes=*/axes_type<2>({2, 1}));
+  KokkosFFT::Plan plan_c2r_axes_0_1(execution_space(), x_c_axis_1, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_c2r_axes_0_2(execution_space(), x_c_axis_2, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({0, 2}));
+  KokkosFFT::Plan plan_c2r_axes_1_0(execution_space(), x_c_axis_0, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_c2r_axes_1_2(execution_space(), x_c_axis_2, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({1, 2}));
+  KokkosFFT::Plan plan_c2r_axes_2_0(execution_space(), x_c_axis_0, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({2, 0}));
+  KokkosFFT::Plan plan_c2r_axes_2_1(execution_space(), x_c_axis_1, x,
+                                    KokkosFFT::Direction::backward,
+                                    /*axes=*/axes_type<2>({2, 1}));
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_0_1(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({0, 1}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_0_2(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({0, 2}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_1_0(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({1, 0}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_1_2(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({1, 2}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_2_0(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({2, 0}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_2_1(execution_space(), x_cin, x_cout,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<2>({2, 1}));
+  KokkosFFT::Plan plan_c2c_f_axes_0_1(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({0, 1}));
+  KokkosFFT::Plan plan_c2c_f_axes_0_2(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({0, 2}));
+  KokkosFFT::Plan plan_c2c_f_axes_1_0(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({1, 0}));
+  KokkosFFT::Plan plan_c2c_f_axes_1_2(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({1, 2}));
+  KokkosFFT::Plan plan_c2c_f_axes_2_0(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({2, 0}));
+  KokkosFFT::Plan plan_c2c_f_axes_2_1(execution_space(), x_cin, x_cout,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<2>({2, 1}));
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1(
+        KokkosFFT::Plan wrong_plan_r2c_axes_0_1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_2(
+        KokkosFFT::Plan wrong_plan_r2c_axes_0_2(
             execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({0, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0(
+        KokkosFFT::Plan wrong_plan_r2c_axes_1_0(
             execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({1, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_2(
+        KokkosFFT::Plan wrong_plan_r2c_axes_1_2(
             execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({1, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_0(
+        KokkosFFT::Plan wrong_plan_r2c_axes_2_0(
             execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({2, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_1(
+        KokkosFFT::Plan wrong_plan_r2c_axes_2_1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<2>({2, 1}));
       },
@@ -598,42 +598,42 @@ void test_plan_2dfft_3dview() {
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1(
+        KokkosFFT::Plan wrong_plan_c2r_axes_0_1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_2(
+        KokkosFFT::Plan wrong_plan_c2r_axes_0_2(
             execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({0, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0(
+        KokkosFFT::Plan wrong_plan_c2r_axes_1_0(
             execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({1, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_2(
+        KokkosFFT::Plan wrong_plan_c2r_axes_1_2(
             execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({1, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_0(
+        KokkosFFT::Plan wrong_plan_c2r_axes_2_0(
             execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({2, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_1(
+        KokkosFFT::Plan wrong_plan_c2r_axes_2_1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<2>({2, 1}));
       },
@@ -671,105 +671,105 @@ void test_plan_3dfft_3dview() {
   ComplexView3DType x_cin("x_cin", n0, n1, n2), x_cout("x_cout", n0, n1, n2);
 
   // R2C plan
-  KokkosFFT::Impl::Plan plan_r2c_axes_0_1_2(execution_space(), x, x_c_axis_2,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({0, 1, 2}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_0_2_1(execution_space(), x, x_c_axis_1,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({0, 2, 1}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_1_0_2(execution_space(), x, x_c_axis_2,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({1, 0, 2}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_1_2_0(execution_space(), x, x_c_axis_0,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({1, 2, 0}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_2_0_1(execution_space(), x, x_c_axis_1,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({2, 0, 1}));
-  KokkosFFT::Impl::Plan plan_r2c_axes_2_1_0(execution_space(), x, x_c_axis_0,
-                                            KokkosFFT::Direction::forward,
-                                            /*axes=*/axes_type<3>({2, 1, 0}));
+  KokkosFFT::Plan plan_r2c_axes_0_1_2(execution_space(), x, x_c_axis_2,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({0, 1, 2}));
+  KokkosFFT::Plan plan_r2c_axes_0_2_1(execution_space(), x, x_c_axis_1,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({0, 2, 1}));
+  KokkosFFT::Plan plan_r2c_axes_1_0_2(execution_space(), x, x_c_axis_2,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({1, 0, 2}));
+  KokkosFFT::Plan plan_r2c_axes_1_2_0(execution_space(), x, x_c_axis_0,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({1, 2, 0}));
+  KokkosFFT::Plan plan_r2c_axes_2_0_1(execution_space(), x, x_c_axis_1,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({2, 0, 1}));
+  KokkosFFT::Plan plan_r2c_axes_2_1_0(execution_space(), x, x_c_axis_0,
+                                      KokkosFFT::Direction::forward,
+                                      /*axes=*/axes_type<3>({2, 1, 0}));
 
   // C2R plan
-  KokkosFFT::Impl::Plan plan_c2r_axes_0_1_2(execution_space(), x_c_axis_2, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({0, 1, 2}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_0_2_1(execution_space(), x_c_axis_1, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({0, 2, 1}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_1_0_2(execution_space(), x_c_axis_2, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({1, 0, 2}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_1_2_0(execution_space(), x_c_axis_0, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({1, 2, 0}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_2_0_1(execution_space(), x_c_axis_1, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({2, 0, 1}));
-  KokkosFFT::Impl::Plan plan_c2r_axes_2_1_0(execution_space(), x_c_axis_0, x,
-                                            KokkosFFT::Direction::backward,
-                                            /*axes=*/axes_type<3>({2, 1, 0}));
+  KokkosFFT::Plan plan_c2r_axes_0_1_2(execution_space(), x_c_axis_2, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({0, 1, 2}));
+  KokkosFFT::Plan plan_c2r_axes_0_2_1(execution_space(), x_c_axis_1, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({0, 2, 1}));
+  KokkosFFT::Plan plan_c2r_axes_1_0_2(execution_space(), x_c_axis_2, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({1, 0, 2}));
+  KokkosFFT::Plan plan_c2r_axes_1_2_0(execution_space(), x_c_axis_0, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({1, 2, 0}));
+  KokkosFFT::Plan plan_c2r_axes_2_0_1(execution_space(), x_c_axis_1, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({2, 0, 1}));
+  KokkosFFT::Plan plan_c2r_axes_2_1_0(execution_space(), x_c_axis_0, x,
+                                      KokkosFFT::Direction::backward,
+                                      /*axes=*/axes_type<3>({2, 1, 0}));
 
   // C2C plan
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_0_1_2(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({0, 1, 2}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_0_2_1(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({0, 2, 1}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_1_0_2(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({1, 0, 2}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_1_2_0(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({1, 2, 0}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_2_0_1(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({2, 0, 1}));
-  KokkosFFT::Impl::Plan plan_c2c_f_axes_2_1_0(execution_space(), x_cin, x_cout,
-                                              KokkosFFT::Direction::forward,
-                                              /*axes=*/axes_type<3>({2, 1, 0}));
+  KokkosFFT::Plan plan_c2c_f_axes_0_1_2(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({0, 1, 2}));
+  KokkosFFT::Plan plan_c2c_f_axes_0_2_1(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({0, 2, 1}));
+  KokkosFFT::Plan plan_c2c_f_axes_1_0_2(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({1, 0, 2}));
+  KokkosFFT::Plan plan_c2c_f_axes_1_2_0(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({1, 2, 0}));
+  KokkosFFT::Plan plan_c2c_f_axes_2_0_1(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({2, 0, 1}));
+  KokkosFFT::Plan plan_c2c_f_axes_2_1_0(execution_space(), x_cin, x_cout,
+                                        KokkosFFT::Direction::forward,
+                                        /*axes=*/axes_type<3>({2, 1, 0}));
 
   // Check if errors are correctly raised aginst wrong dirction
   // Input Real, Output Complex -> must be forward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_1_2(
+        KokkosFFT::Plan wrong_plan_r2c_axes_0_1_2(
             execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({0, 1, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_0_2_1(
+        KokkosFFT::Plan wrong_plan_r2c_axes_0_2_1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({0, 2, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_0_2(
+        KokkosFFT::Plan wrong_plan_r2c_axes_1_0_2(
             execution_space(), x, x_c_axis_2, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({1, 0, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_1_2_0(
+        KokkosFFT::Plan wrong_plan_r2c_axes_1_2_0(
             execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({1, 2, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_0_1(
+        KokkosFFT::Plan wrong_plan_r2c_axes_2_0_1(
             execution_space(), x, x_c_axis_1, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({2, 0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_r2c_axes_2_1_0(
+        KokkosFFT::Plan wrong_plan_r2c_axes_2_1_0(
             execution_space(), x, x_c_axis_0, KokkosFFT::Direction::backward,
             /*axes=*/axes_type<3>({2, 1, 0}));
       },
@@ -778,42 +778,42 @@ void test_plan_3dfft_3dview() {
   // Input Complex, Output Real -> must be backward plan
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_1_2(
+        KokkosFFT::Plan wrong_plan_c2r_axes_0_1_2(
             execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({0, 1, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_0_2_1(
+        KokkosFFT::Plan wrong_plan_c2r_axes_0_2_1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({0, 2, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_0_2(
+        KokkosFFT::Plan wrong_plan_c2r_axes_1_0_2(
             execution_space(), x_c_axis_2, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({1, 0, 2}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_1_2_0(
+        KokkosFFT::Plan wrong_plan_c2r_axes_1_2_0(
             execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({1, 2, 0}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_0_1(
+        KokkosFFT::Plan wrong_plan_c2r_axes_2_0_1(
             execution_space(), x_c_axis_1, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({2, 0, 1}));
       },
       std::runtime_error);
   EXPECT_THROW(
       {
-        KokkosFFT::Impl::Plan wrong_plan_c2r_axes_2_1_0(
+        KokkosFFT::Plan wrong_plan_c2r_axes_2_1_0(
             execution_space(), x_c_axis_0, x, KokkosFFT::Direction::forward,
             /*axes=*/axes_type<3>({2, 1, 0}));
       },

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -180,19 +180,19 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
     int axis = -1;
     KokkosFFT::Plan fft_plan(execution_space(), a, out,
                              KokkosFFT::Direction::forward, axis);
-    KokkosFFT::execute(fft_plan, a, out);
+    fft_plan.execute(a, out);
 
     KokkosFFT::Plan ifft_plan(execution_space(), out, _a,
                               KokkosFFT::Direction::backward, axis);
-    KokkosFFT::execute(ifft_plan, out, _a);
+    ifft_plan.execute(out, _a);
 
     KokkosFFT::Plan rfft_plan(execution_space(), ar, outr,
                               KokkosFFT::Direction::forward, axis);
-    KokkosFFT::execute(rfft_plan, ar, outr);
+    rfft_plan.execute(ar, outr);
 
     KokkosFFT::Plan irfft_plan(execution_space(), outr, _ar,
                                KokkosFFT::Direction::backward, axis);
-    KokkosFFT::execute(irfft_plan, outr, _ar);
+    irfft_plan.execute(outr, _ar);
 
     EXPECT_TRUE(allclose(_a, a_ref, 1.e-5, atol));
     EXPECT_TRUE(allclose(_ar, ar_ref, 1.e-5, atol));
@@ -234,47 +234,47 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
 
   // fft
   // With incorrect input shape
-  EXPECT_THROW(KokkosFFT::execute(fft_plan, a_wrong, out,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      fft_plan.execute(a_wrong, out, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(KokkosFFT::execute(fft_plan, a, out_wrong,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      fft_plan.execute(a, out_wrong, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // ifft
   // With incorrect input shape
-  EXPECT_THROW(KokkosFFT::execute(ifft_plan, out_wrong, _a,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      ifft_plan.execute(out_wrong, _a, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(KokkosFFT::execute(ifft_plan, out, _a_wrong,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      ifft_plan.execute(out, _a_wrong, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // rfft
   // With incorrect input shape
-  EXPECT_THROW(KokkosFFT::execute(rfft_plan, ar_wrong, outr,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      rfft_plan.execute(ar_wrong, outr, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(KokkosFFT::execute(rfft_plan, ar, out_wrong,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      rfft_plan.execute(ar, out_wrong, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // irfft
   // With incorrect input shape
-  EXPECT_THROW(KokkosFFT::execute(irfft_plan, outr_wrong, _ar,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      irfft_plan.execute(outr_wrong, _ar, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(KokkosFFT::execute(irfft_plan, outr, _ar_wrong,
-                                  KokkosFFT::Normalization::backward),
-               std::runtime_error);
+  EXPECT_THROW(
+      irfft_plan.execute(outr, _ar_wrong, KokkosFFT::Normalization::backward),
+      std::runtime_error);
 }
 
 template <typename T, typename LayoutType>
@@ -1316,10 +1316,10 @@ void test_fft2_2dfft_2dview() {
   KokkosFFT::Plan fft2_plan(execution_space(), x, out,
                             KokkosFFT::Direction::forward, axes);
 
-  KokkosFFT::execute(fft2_plan, x, out);
-  KokkosFFT::execute(fft2_plan, x, out_b, KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(fft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(fft2_plan, x, out_f, KokkosFFT::Normalization::forward);
+  fft2_plan.execute(x, out);
+  fft2_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
+  fft2_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  fft2_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1355,12 +1355,9 @@ void test_fft2_2dfft_2dview() {
   KokkosFFT::Plan fft2_plan_axes10(execution_space(), x, out,
                                    KokkosFFT::Direction::forward, axes10);
 
-  KokkosFFT::execute(fft2_plan_axes10, x, out_b,
-                     KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(fft2_plan_axes10, x, out_o,
-                     KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(fft2_plan_axes10, x, out_f,
-                     KokkosFFT::Normalization::forward);
+  fft2_plan_axes10.execute(x, out_b, KokkosFFT::Normalization::backward);
+  fft2_plan_axes10.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  fft2_plan_axes10.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1417,10 +1414,10 @@ void test_fft2_2difft_2dview() {
   KokkosFFT::Plan ifft2_plan(execution_space(), x, out,
                              KokkosFFT::Direction::backward, axes);
 
-  KokkosFFT::execute(ifft2_plan, x, out);
-  KokkosFFT::execute(ifft2_plan, x, out_b, KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(ifft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(ifft2_plan, x, out_f, KokkosFFT::Normalization::forward);
+  ifft2_plan.execute(x, out);
+  ifft2_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
+  ifft2_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  ifft2_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -1454,12 +1451,9 @@ void test_fft2_2difft_2dview() {
   KokkosFFT::Plan ifft2_plan_axes10(execution_space(), x, out,
                                     KokkosFFT::Direction::backward, axes10);
 
-  KokkosFFT::execute(ifft2_plan_axes10, x, out_b,
-                     KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(ifft2_plan_axes10, x, out_o,
-                     KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(ifft2_plan_axes10, x, out_f,
-                     KokkosFFT::Normalization::forward);
+  ifft2_plan_axes10.execute(x, out_b, KokkosFFT::Normalization::backward);
+  ifft2_plan_axes10.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  ifft2_plan_axes10.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -1524,16 +1518,16 @@ void test_fft2_2drfft_2dview() {
                              KokkosFFT::Direction::forward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfft2_plan, x, out);
+  rfft2_plan.execute(x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfft2_plan, x, out_b, KokkosFFT::Normalization::backward);
+  rfft2_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  rfft2_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfft2_plan, x, out_f, KokkosFFT::Normalization::forward);
+  rfft2_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1599,17 +1593,17 @@ void test_fft2_2dirfft_2dview() {
                               KokkosFFT::Direction::backward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfft2_plan, x,
-                     out);  // default: KokkosFFT::Normalization::backward
+  irfft2_plan.execute(x,
+                      out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfft2_plan, x, out_b, KokkosFFT::Normalization::backward);
+  irfft2_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  irfft2_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfft2_plan, x, out_f, KokkosFFT::Normalization::forward);
+  irfft2_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -2328,10 +2322,10 @@ void test_fftn_2dfft_2dview() {
   KokkosFFT::Plan fftn_plan(execution_space(), x, out,
                             KokkosFFT::Direction::forward, axes);
 
-  KokkosFFT::execute(fftn_plan, x, out);
-  KokkosFFT::execute(fftn_plan, x, out_b, KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(fftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(fftn_plan, x, out_f, KokkosFFT::Normalization::forward);
+  fftn_plan.execute(x, out);
+  fftn_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
+  fftn_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  fftn_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -2393,10 +2387,10 @@ void test_ifftn_2dfft_2dview() {
   KokkosFFT::Plan ifftn_plan(execution_space(), x, out,
                              KokkosFFT::Direction::backward, axes);
 
-  KokkosFFT::execute(ifftn_plan, x, out);
-  KokkosFFT::execute(ifftn_plan, x, out_b, KokkosFFT::Normalization::backward);
-  KokkosFFT::execute(ifftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
-  KokkosFFT::execute(ifftn_plan, x, out_f, KokkosFFT::Normalization::forward);
+  ifftn_plan.execute(x, out);
+  ifftn_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
+  ifftn_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
+  ifftn_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -2467,16 +2461,16 @@ void test_rfftn_2dfft_2dview() {
                              KokkosFFT::Direction::forward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfftn_plan, x, out);
+  rfftn_plan.execute(x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfftn_plan, x, out_b, KokkosFFT::Normalization::backward);
+  rfftn_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  rfftn_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(rfftn_plan, x, out_f, KokkosFFT::Normalization::forward);
+  rfftn_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -2548,16 +2542,16 @@ void test_irfftn_2dfft_2dview() {
   KokkosFFT::Plan irfftn_plan(execution_space(), x, out,
                               KokkosFFT::Direction::backward, axes);
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfftn_plan, x, out);
+  irfftn_plan.execute(x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfftn_plan, x, out_b, KokkosFFT::Normalization::backward);
+  irfftn_plan.execute(x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  irfftn_plan.execute(x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::execute(irfftn_plan, x, out_f, KokkosFFT::Normalization::forward);
+  irfftn_plan.execute(x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -178,21 +178,21 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
     Kokkos::fence();
 
     int axis = -1;
-    KokkosFFT::Impl::Plan fft_plan(execution_space(), a, out,
-                                   KokkosFFT::Direction::forward, axis);
-    KokkosFFT::Impl::fft_exec_impl(fft_plan, a, out);
+    KokkosFFT::Plan fft_plan(execution_space(), a, out,
+                             KokkosFFT::Direction::forward, axis);
+    KokkosFFT::execute(fft_plan, a, out);
 
-    KokkosFFT::Impl::Plan ifft_plan(execution_space(), out, _a,
-                                    KokkosFFT::Direction::backward, axis);
-    KokkosFFT::Impl::fft_exec_impl(ifft_plan, out, _a);
+    KokkosFFT::Plan ifft_plan(execution_space(), out, _a,
+                              KokkosFFT::Direction::backward, axis);
+    KokkosFFT::execute(ifft_plan, out, _a);
 
-    KokkosFFT::Impl::Plan rfft_plan(execution_space(), ar, outr,
-                                    KokkosFFT::Direction::forward, axis);
-    KokkosFFT::Impl::fft_exec_impl(rfft_plan, ar, outr);
+    KokkosFFT::Plan rfft_plan(execution_space(), ar, outr,
+                              KokkosFFT::Direction::forward, axis);
+    KokkosFFT::execute(rfft_plan, ar, outr);
 
-    KokkosFFT::Impl::Plan irfft_plan(execution_space(), outr, _ar,
-                                     KokkosFFT::Direction::backward, axis);
-    KokkosFFT::Impl::fft_exec_impl(irfft_plan, outr, _ar);
+    KokkosFFT::Plan irfft_plan(execution_space(), outr, _ar,
+                               KokkosFFT::Direction::backward, axis);
+    KokkosFFT::execute(irfft_plan, outr, _ar);
 
     EXPECT_TRUE(allclose(_a, a_ref, 1.e-5, atol));
     EXPECT_TRUE(allclose(_ar, ar_ref, 1.e-5, atol));
@@ -213,17 +213,17 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
 
   // Create correct plans
   int axis = -1;
-  KokkosFFT::Impl::Plan fft_plan(execution_space(), a, out,
-                                 KokkosFFT::Direction::forward, axis);
+  KokkosFFT::Plan fft_plan(execution_space(), a, out,
+                           KokkosFFT::Direction::forward, axis);
 
-  KokkosFFT::Impl::Plan ifft_plan(execution_space(), out, _a,
-                                  KokkosFFT::Direction::backward, axis);
+  KokkosFFT::Plan ifft_plan(execution_space(), out, _a,
+                            KokkosFFT::Direction::backward, axis);
 
-  KokkosFFT::Impl::Plan rfft_plan(execution_space(), ar, outr,
-                                  KokkosFFT::Direction::forward, axis);
+  KokkosFFT::Plan rfft_plan(execution_space(), ar, outr,
+                            KokkosFFT::Direction::forward, axis);
 
-  KokkosFFT::Impl::Plan irfft_plan(execution_space(), outr, _ar,
-                                   KokkosFFT::Direction::backward, axis);
+  KokkosFFT::Plan irfft_plan(execution_space(), outr, _ar,
+                             KokkosFFT::Direction::backward, axis);
 
   // Check if errors are correctly raised aginst wrong extents
   const int maxlen_wrong = 32 * 2;
@@ -234,53 +234,47 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
 
   // fft
   // With incorrect input shape
-  EXPECT_THROW(KokkosFFT::Impl::fft_exec_impl(
-                   fft_plan, a_wrong, out, KokkosFFT::Normalization::backward),
+  EXPECT_THROW(KokkosFFT::execute(fft_plan, a_wrong, out,
+                                  KokkosFFT::Normalization::backward),
                std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(KokkosFFT::Impl::fft_exec_impl(
-                   fft_plan, a, out_wrong, KokkosFFT::Normalization::backward),
+  EXPECT_THROW(KokkosFFT::execute(fft_plan, a, out_wrong,
+                                  KokkosFFT::Normalization::backward),
                std::runtime_error);
 
   // ifft
   // With incorrect input shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(ifft_plan, out_wrong, _a,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(ifft_plan, out_wrong, _a,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(ifft_plan, out, _a_wrong,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(ifft_plan, out, _a_wrong,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 
   // rfft
   // With incorrect input shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(rfft_plan, ar_wrong, outr,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(rfft_plan, ar_wrong, outr,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(rfft_plan, ar, out_wrong,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(rfft_plan, ar, out_wrong,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 
   // irfft
   // With incorrect input shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(irfft_plan, outr_wrong, _ar,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(irfft_plan, outr_wrong, _ar,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 
   // With incorrect output shape
-  EXPECT_THROW(
-      KokkosFFT::Impl::fft_exec_impl(irfft_plan, outr, _ar_wrong,
-                                     KokkosFFT::Normalization::backward),
-      std::runtime_error);
+  EXPECT_THROW(KokkosFFT::execute(irfft_plan, outr, _ar_wrong,
+                                  KokkosFFT::Normalization::backward),
+               std::runtime_error);
 }
 
 template <typename T, typename LayoutType>
@@ -1319,16 +1313,13 @@ void test_fft2_2dfft_2dview() {
   // Reuse plans
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
-  KokkosFFT::Impl::Plan fft2_plan(execution_space(), x, out,
-                                  KokkosFFT::Direction::forward, axes);
+  KokkosFFT::Plan fft2_plan(execution_space(), x, out,
+                            KokkosFFT::Direction::forward, axes);
 
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan, x, out);
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(fft2_plan, x, out);
+  KokkosFFT::execute(fft2_plan, x, out_b, KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(fft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(fft2_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1361,15 +1352,15 @@ void test_fft2_2dfft_2dview() {
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
   // Reuse plans np.fft2(axes=(-1, -2))
-  KokkosFFT::Impl::Plan fft2_plan_axes10(execution_space(), x, out,
-                                         KokkosFFT::Direction::forward, axes10);
+  KokkosFFT::Plan fft2_plan_axes10(execution_space(), x, out,
+                                   KokkosFFT::Direction::forward, axes10);
 
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan_axes10, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan_axes10, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(fft2_plan_axes10, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(fft2_plan_axes10, x, out_b,
+                     KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(fft2_plan_axes10, x, out_o,
+                     KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(fft2_plan_axes10, x, out_f,
+                     KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1423,16 +1414,13 @@ void test_fft2_2difft_2dview() {
   // Reuse plans
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
-  KokkosFFT::Impl::Plan ifft2_plan(execution_space(), x, out,
-                                   KokkosFFT::Direction::backward, axes);
+  KokkosFFT::Plan ifft2_plan(execution_space(), x, out,
+                             KokkosFFT::Direction::backward, axes);
 
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan, x, out);
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(ifft2_plan, x, out);
+  KokkosFFT::execute(ifft2_plan, x, out_b, KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(ifft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(ifft2_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -1463,15 +1451,15 @@ void test_fft2_2difft_2dview() {
   EXPECT_TRUE(allclose(out_o, out2, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
-  KokkosFFT::Impl::Plan ifft2_plan_axes10(
-      execution_space(), x, out, KokkosFFT::Direction::backward, axes10);
+  KokkosFFT::Plan ifft2_plan_axes10(execution_space(), x, out,
+                                    KokkosFFT::Direction::backward, axes10);
 
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan_axes10, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan_axes10, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(ifft2_plan_axes10, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(ifft2_plan_axes10, x, out_b,
+                     KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(ifft2_plan_axes10, x, out_o,
+                     KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(ifft2_plan_axes10, x, out_f,
+                     KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -1532,23 +1520,20 @@ void test_fft2_2drfft_2dview() {
   // Reuse plans
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
-  KokkosFFT::Impl::Plan rfft2_plan(execution_space(), x, out,
-                                   KokkosFFT::Direction::forward, axes);
+  KokkosFFT::Plan rfft2_plan(execution_space(), x, out,
+                             KokkosFFT::Direction::forward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfft2_plan, x, out);
+  KokkosFFT::execute(rfft2_plan, x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfft2_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(rfft2_plan, x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfft2_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(rfft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfft2_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(rfft2_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -1610,24 +1595,21 @@ void test_fft2_2dirfft_2dview() {
   // Reuse plans
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
-  KokkosFFT::Impl::Plan irfft2_plan(execution_space(), x, out,
-                                    KokkosFFT::Direction::backward, axes);
+  KokkosFFT::Plan irfft2_plan(execution_space(), x, out,
+                              KokkosFFT::Direction::backward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(
-      irfft2_plan, x, out);  // default: KokkosFFT::Normalization::backward
+  KokkosFFT::execute(irfft2_plan, x,
+                     out);  // default: KokkosFFT::Normalization::backward
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfft2_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(irfft2_plan, x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfft2_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(irfft2_plan, x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfft2_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(irfft2_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -2343,16 +2325,13 @@ void test_fftn_2dfft_2dview() {
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
   // Reuse plans
-  KokkosFFT::Impl::Plan fftn_plan(execution_space(), x, out,
-                                  KokkosFFT::Direction::forward, axes);
+  KokkosFFT::Plan fftn_plan(execution_space(), x, out,
+                            KokkosFFT::Direction::forward, axes);
 
-  KokkosFFT::Impl::fft_exec_impl(fftn_plan, x, out);
-  KokkosFFT::Impl::fft_exec_impl(fftn_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(fftn_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(fftn_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(fftn_plan, x, out);
+  KokkosFFT::execute(fftn_plan, x, out_b, KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(fftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(fftn_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -2411,16 +2390,13 @@ void test_ifftn_2dfft_2dview() {
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
   // Reuse plans
-  KokkosFFT::Impl::Plan ifftn_plan(execution_space(), x, out,
-                                   KokkosFFT::Direction::backward, axes);
+  KokkosFFT::Plan ifftn_plan(execution_space(), x, out,
+                             KokkosFFT::Direction::backward, axes);
 
-  KokkosFFT::Impl::fft_exec_impl(ifftn_plan, x, out);
-  KokkosFFT::Impl::fft_exec_impl(ifftn_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
-  KokkosFFT::Impl::fft_exec_impl(ifftn_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
-  KokkosFFT::Impl::fft_exec_impl(ifftn_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(ifftn_plan, x, out);
+  KokkosFFT::execute(ifftn_plan, x, out_b, KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(ifftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(ifftn_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));
@@ -2487,23 +2463,20 @@ void test_rfftn_2dfft_2dview() {
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
   // Reuse plans
-  KokkosFFT::Impl::Plan rfftn_plan(execution_space(), x, out,
-                                   KokkosFFT::Direction::forward, axes);
+  KokkosFFT::Plan rfftn_plan(execution_space(), x, out,
+                             KokkosFFT::Direction::forward, axes);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfftn_plan, x, out);
+  KokkosFFT::execute(rfftn_plan, x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfftn_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(rfftn_plan, x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfftn_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(rfftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(rfftn_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(rfftn_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, static_cast<T>(n0 * n1));
@@ -2572,22 +2545,19 @@ void test_irfftn_2dfft_2dview() {
   EXPECT_TRUE(allclose(out_f, out2, 1.e-5, 1.e-6));
 
   // Reuse plans
-  KokkosFFT::Impl::Plan irfftn_plan(execution_space(), x, out,
-                                    KokkosFFT::Direction::backward, axes);
+  KokkosFFT::Plan irfftn_plan(execution_space(), x, out,
+                              KokkosFFT::Direction::backward, axes);
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfftn_plan, x, out);
+  KokkosFFT::execute(irfftn_plan, x, out);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfftn_plan, x, out_b,
-                                 KokkosFFT::Normalization::backward);
+  KokkosFFT::execute(irfftn_plan, x, out_b, KokkosFFT::Normalization::backward);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfftn_plan, x, out_o,
-                                 KokkosFFT::Normalization::ortho);
+  KokkosFFT::execute(irfftn_plan, x, out_o, KokkosFFT::Normalization::ortho);
 
   Kokkos::deep_copy(x, x_ref);
-  KokkosFFT::Impl::fft_exec_impl(irfftn_plan, x, out_f,
-                                 KokkosFFT::Normalization::forward);
+  KokkosFFT::execute(irfftn_plan, x, out_f, KokkosFFT::Normalization::forward);
 
   multiply(out_o, 1.0 / sqrt(static_cast<T>(n0 * n1)));
   multiply(out_f, 1.0 / static_cast<T>(n0 * n1));


### PR DESCRIPTION
Resolves #156 

This PR aims at making Plan class as a part of API. 

- [x] `KokkosFFT::Impl::Plan` -> `KokkosFFT::Plan`
- [x] `KokkosFFT::Impl::fft_exec_impl` -> ~~`KokkosFFT::execute`~~ `plan.execute`
- [x] Remove unused variables from plan class `m_in_T` and `m_out_T`
- [x] Update implementation details and tests
- [x] Update [example 6](https://github.com/kokkos/kokkos-fft/tree/main/examples/06_1DFFT_reuse_plans)
- [x] Update docs 
- [x] Make internal types in Plan class private 