### PR TITLE
Apply to_array helper

### DIFF
--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -132,7 +132,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
       tile_type{{4, 4, 4}}  // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, 3> map = {_map[0], _map[1], _map[2]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range, KOKKOS_LAMBDA(int i0, int i1, int i2) {
         int _indices[rank] = {i0, i1, i2};
@@ -164,7 +164,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = {_map[0], _map[1], _map[2], _map[3]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3) {
@@ -199,7 +199,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = {_map[0], _map[1], _map[2], _map[3], _map[4]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4) {
@@ -236,8 +236,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = {_map[0], _map[1], _map[2],
-                                  _map[3], _map[4], _map[5]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
@@ -275,8 +274,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = {_map[0], _map[1], _map[2], _map[3],
-                                  _map[4], _map[5], _map[6]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
@@ -320,8 +318,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = {_map[0], _map[1], _map[2], _map[3],
-                                  _map[4], _map[5], _map[6], _map[7]};
+  Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -226,11 +226,11 @@ constexpr Kokkos::Array<T, N> to_array_rvalue_helper(
   return {{std::move(a[Is])...}};
 }
 
-template <class T, size_t N, size_t... Is>
+template <class T, size_t N>
 constexpr Kokkos::Array<T, N> to_array(const std::array<T, N>& a) {
   return to_array_lvalue_helper(a, std::make_index_sequence<N>());
 }
-template <class T, size_t N, size_t... Is>
+template <class T, size_t N>
 constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
   return to_array_rvalue_helper(std::move(a), std::make_index_sequence<N>());
 }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -217,7 +217,7 @@ Layout create_layout(const std::array<int, N>& extents) {
 
 template <class T, size_t N, size_t... Is>
 constexpr Kokkos::Array<T, N> to_array_lvalue_helper(
-    std::array<T, N>& a, std::index_sequence<Is...>) {
+    const std::array<T, N>& a, std::index_sequence<Is...>) {
   return {{a[Is]...}};
 }
 template <class T, size_t N, size_t... Is>
@@ -227,7 +227,7 @@ constexpr Kokkos::Array<T, N> to_array_rvalue_helper(
 }
 
 template <class T, size_t N, size_t... Is>
-constexpr Kokkos::Array<T, N> to_array(std::array<T, N>& a) {
+constexpr Kokkos::Array<T, N> to_array(const std::array<T, N>& a) {
   return to_array_lvalue_helper(a, std::make_index_sequence<N>());
 }
 template <class T, size_t N, size_t... Is>

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -215,6 +215,26 @@ Layout create_layout(const std::array<int, N>& extents) {
   return layout;
 }
 
+template <class T, size_t N, size_t... Is>
+constexpr Kokkos::Array<T, N> to_array_lvalue_helper(
+    std::array<T, N>& a, std::index_sequence<Is...>) {
+  return {{a[Is]...}};
+}
+template <class T, size_t N, size_t... Is>
+constexpr Kokkos::Array<T, N> to_array_rvalue_helper(
+    std::array<T, N>&& a, std::index_sequence<Is...>) {
+  return {{std::move(a[Is])...}};
+}
+
+template <class T, size_t N, size_t... Is>
+constexpr Kokkos::Array<T, N> to_array(std::array<T, N>& a) {
+  return to_array_lvalue_helper(a, std::make_index_sequence<N>());
+}
+template <class T, size_t N, size_t... Is>
+constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
+  return to_array_rvalue_helper(std::move(a), std::make_index_sequence<N>());
+}
+
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -215,22 +215,22 @@ Layout create_layout(const std::array<int, N>& extents) {
   return layout;
 }
 
-template <class T, size_t N, size_t... Is>
+template <class T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<T, N> to_array_lvalue_helper(
     const std::array<T, N>& a, std::index_sequence<Is...>) {
   return {{a[Is]...}};
 }
-template <class T, size_t N, size_t... Is>
+template <class T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<T, N> to_array_rvalue_helper(
     std::array<T, N>&& a, std::index_sequence<Is...>) {
   return {{std::move(a[Is])...}};
 }
 
-template <class T, size_t N>
+template <class T, std::size_t N>
 constexpr Kokkos::Array<T, N> to_array(const std::array<T, N>& a) {
   return to_array_lvalue_helper(a, std::make_index_sequence<N>());
 }
-template <class T, size_t N>
+template <class T, std::size_t N>
 constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
   return to_array_rvalue_helper(std::move(a), std::make_index_sequence<N>());
 }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -215,24 +215,24 @@ Layout create_layout(const std::array<int, N>& extents) {
   return layout;
 }
 
-template <class T, std::size_t N, std::size_t... Is>
-constexpr Kokkos::Array<T, N> to_array_lvalue_helper(
-    const std::array<T, N>& a, std::index_sequence<Is...>) {
+template <typename T, std::size_t N, std::size_t... Is>
+constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_lvalue(
+    std::array<T, N>& a, std::index_sequence<Is...>) {
   return {{a[Is]...}};
 }
-template <class T, std::size_t N, std::size_t... Is>
-constexpr Kokkos::Array<T, N> to_array_rvalue_helper(
+template <typename T, std::size_t N, std::size_t... Is>
+constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_rvalue(
     std::array<T, N>&& a, std::index_sequence<Is...>) {
   return {{std::move(a[Is])...}};
 }
 
-template <class T, std::size_t N>
-constexpr Kokkos::Array<T, N> to_array(const std::array<T, N>& a) {
-  return to_array_lvalue_helper(a, std::make_index_sequence<N>());
+template <typename T, std::size_t N>
+constexpr Kokkos::Array<T, N> to_array(std::array<T, N>& a) {
+  return to_array_lvalue(a, std::make_index_sequence<N>());
 }
-template <class T, std::size_t N>
+template <typename T, std::size_t N>
 constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
-  return to_array_rvalue_helper(std::move(a), std::make_index_sequence<N>());
+  return to_array_rvalue(std::move(a), std::make_index_sequence<N>());
 }
 
 }  // namespace Impl

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -541,3 +541,16 @@ TEST(IndexSequence, 3Dto5D) {
   EXPECT_EQ(default_axes1, ref_axes1);
   EXPECT_EQ(default_axes2, ref_axes2);
 }
+
+TEST(ToArray, lvalue) {
+  std::array<int, 3> arr{1, 2, 3};
+  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array{1, 2, 3}));
+}
+
+TEST(ToArray, rvalue) {
+  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
+  // [TO DO] Need to update Kokkos version for compile time test
+  // GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
+  // static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==
+  // Kokkos::Array{1, 2});
+}

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -544,21 +544,11 @@ TEST(IndexSequence, 3Dto5D) {
 
 TEST(ToArray, lvalue) {
   std::array<int, 3> arr{1, 2, 3};
-  Kokkos::Array<int, 3> ref_arr{1, 2, 3};
-  auto kokkos_arr = KokkosFFT::Impl::to_array(arr);
-  for (std::size_t i = 0; i < arr.size(); ++i) {
-    ASSERT_EQ(kokkos_arr[i], ref_arr[i]);
-  }
+  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array{1, 2, 3}));
 }
 
 TEST(ToArray, rvalue) {
-  Kokkos::Array<int, 3> ref_arr{1, 2, 3};
-  auto kokkos_arr = KokkosFFT::Impl::to_array(std::array{1, 2, 3});
-  for (std::size_t i = 0; i < ref_arr.size(); ++i) {
-    ASSERT_EQ(kokkos_arr[i], ref_arr[i]);
-  }
-  // [TO DO] Need to update Kokkos version for compile time test
-  // GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
-  // static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==
-  // Kokkos::Array{1, 2});
+  GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
+  static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==
+                Kokkos::Array{1, 2});
 }

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -548,7 +548,5 @@ TEST(ToArray, lvalue) {
 }
 
 TEST(ToArray, rvalue) {
-  GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
-  static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==
-                Kokkos::Array{1, 2});
+  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
 }

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -543,7 +543,7 @@ TEST(IndexSequence, 3Dto5D) {
 }
 
 TEST(ToArray, lvalue) {
-  std::array<int, 3> arr{1, 2, 3};
+  std::array arr{1, 2, 3};
   ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array{1, 2, 3}));
 }
 

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -544,12 +544,19 @@ TEST(IndexSequence, 3Dto5D) {
 
 TEST(ToArray, lvalue) {
   std::array<int, 3> arr{1, 2, 3};
-  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array<int, 3>{1, 2, 3}));
+  Kokkos::Array<int, 3> ref_arr{1, 2, 3};
+  auto kokkos_arr = KokkosFFT::Impl::to_array(arr);
+  for (std::size_t i = 0; i < arr.size(); ++i) {
+    ASSERT_EQ(kokkos_arr[i], ref_arr[i]);
+  }
 }
 
 TEST(ToArray, rvalue) {
-  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}),
-            (Kokkos::Array<int, 2>{1, 2}));
+  Kokkos::Array<int, 3> ref_arr{1, 2, 3};
+  auto kokkos_arr = KokkosFFT::Impl::to_array(std::array{1, 2, 3});
+  for (std::size_t i = 0; i < ref_arr.size(); ++i) {
+    ASSERT_EQ(kokkos_arr[i], ref_arr[i]);
+  }
   // [TO DO] Need to update Kokkos version for compile time test
   // GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
   // static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -544,11 +544,12 @@ TEST(IndexSequence, 3Dto5D) {
 
 TEST(ToArray, lvalue) {
   std::array<int, 3> arr{1, 2, 3};
-  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array{1, 2, 3}));
+  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array<int, 3>{1, 2, 3}));
 }
 
 TEST(ToArray, rvalue) {
-  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
+  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}),
+            (Kokkos::Array<int, 2>{1, 2}));
   // [TO DO] Need to update Kokkos version for compile time test
   // GTEST_SKIP() << "Skipping ToArray::rvalue compile time test";
   // static_assert(KokkosFFT::Impl::to_array(std::array{1, 2}) ==


### PR DESCRIPTION
Improves #170 

This PR aims at introducing [`to_array`](https://godbolt.org/z/3vfv34MK3) helper which is used in `Transpose` functions. 
For the compile time testing, we need a newer version of Kokkos.