### PR TITLE
Avoid variables starting from underscore under common

### DIFF
--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -94,10 +94,10 @@ auto is_crop_or_pad_needed(const ViewType& view,
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<1> s) {
-  auto _n0 = s.at(0);
-  out      = OutViewType("out", _n0);
+  auto s0 = s.at(0);
+  out     = OutViewType("out", s0);
 
-  auto n0 = std::min(_n0, in.extent(0));
+  auto n0 = std::min(s0, in.extent(0));
 
   Kokkos::parallel_for(
       "KokkosFFT::crop_or_pad",
@@ -111,11 +111,11 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<2> s) {
   constexpr std::size_t DIM = 2;
 
-  auto [_n0, _n1] = s;
-  out             = OutViewType("out", _n0, _n1);
+  auto [s0, s1] = s;
+  out           = OutViewType("out", s0, s1);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -138,12 +138,12 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<3> s) {
   constexpr std::size_t DIM = 3;
 
-  auto [_n0, _n1, _n2] = s;
-  out                  = OutViewType("out", _n0, _n1, _n2);
+  auto [s0, s1, s2] = s;
+  out               = OutViewType("out", s0, s1, s2);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -167,13 +167,13 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<4> s) {
   constexpr std::size_t DIM = 4;
 
-  auto [_n0, _n1, _n2, _n3] = s;
-  out                       = OutViewType("out", _n0, _n1, _n2, _n3);
+  auto [s0, s1, s2, s3] = s;
+  out                   = OutViewType("out", s0, s1, s2, s3);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
-  int n3 = std::min(_n3, in.extent(3));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
+  int n3 = std::min(s3, in.extent(3));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -198,14 +198,14 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<5> s) {
   constexpr std::size_t DIM = 5;
 
-  auto [_n0, _n1, _n2, _n3, _n4] = s;
-  out                            = OutViewType("out", _n0, _n1, _n2, _n3, _n4);
+  auto [s0, s1, s2, s3, s4] = s;
+  out                       = OutViewType("out", s0, s1, s2, s3, s4);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
-  int n3 = std::min(_n3, in.extent(3));
-  int n4 = std::min(_n4, in.extent(4));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
+  int n3 = std::min(s3, in.extent(3));
+  int n4 = std::min(s4, in.extent(4));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -230,15 +230,15 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<6> s) {
   constexpr std::size_t DIM = 6;
 
-  auto [_n0, _n1, _n2, _n3, _n4, _n5] = s;
-  out = OutViewType("out", _n0, _n1, _n2, _n3, _n4, _n5);
+  auto [s0, s1, s2, s3, s4, s5] = s;
+  out                           = OutViewType("out", s0, s1, s2, s3, s4, s5);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
-  int n3 = std::min(_n3, in.extent(3));
-  int n4 = std::min(_n4, in.extent(4));
-  int n5 = std::min(_n5, in.extent(5));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
+  int n3 = std::min(s3, in.extent(3));
+  int n4 = std::min(s4, in.extent(4));
+  int n5 = std::min(s5, in.extent(5));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -264,16 +264,16 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<7> s) {
   constexpr std::size_t DIM = 6;
 
-  auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = s;
-  out = OutViewType("out", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+  auto [s0, s1, s2, s3, s4, s5, s6] = s;
+  out = OutViewType("out", s0, s1, s2, s3, s4, s5, s6);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
-  int n3 = std::min(_n3, in.extent(3));
-  int n4 = std::min(_n4, in.extent(4));
-  int n5 = std::min(_n5, in.extent(5));
-  int n6 = std::min(_n6, in.extent(6));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
+  int n3 = std::min(s3, in.extent(3));
+  int n4 = std::min(s4, in.extent(4));
+  int n5 = std::min(s5, in.extent(5));
+  int n6 = std::min(s6, in.extent(6));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
@@ -301,17 +301,17 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
                       OutViewType& out, shape_type<8> s) {
   constexpr std::size_t DIM = 6;
 
-  auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = s;
-  out = OutViewType("out", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+  auto [s0, s1, s2, s3, s4, s5, s6, s7] = s;
+  out = OutViewType("out", s0, s1, s2, s3, s4, s5, s6, s7);
 
-  int n0 = std::min(_n0, in.extent(0));
-  int n1 = std::min(_n1, in.extent(1));
-  int n2 = std::min(_n2, in.extent(2));
-  int n3 = std::min(_n3, in.extent(3));
-  int n4 = std::min(_n4, in.extent(4));
-  int n5 = std::min(_n5, in.extent(5));
-  int n6 = std::min(_n6, in.extent(6));
-  int n7 = std::min(_n7, in.extent(7));
+  int n0 = std::min(s0, in.extent(0));
+  int n1 = std::min(s1, in.extent(1));
+  int n2 = std::min(s2, in.extent(2));
+  int n3 = std::min(s3, in.extent(3));
+  int n4 = std::min(s4, in.extent(4));
+  int n5 = std::min(s5, in.extent(5));
+  int n6 = std::min(s6, in.extent(6));
+  int n7 = std::min(s7, in.extent(7));
 
   using range_type = Kokkos::MDRangePolicy<
       ExecutionSpace,

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -135,12 +135,12 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::Array<int, rank> map = to_array(_map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range, KOKKOS_LAMBDA(int i0, int i1, int i2) {
-        int _indices[rank] = {i0, i1, i2};
-        int _i0            = _indices[map[0]];
-        int _i1            = _indices[map[1]];
-        int _i2            = _indices[map[2]];
+        int dst_indices[rank] = {i0, i1, i2};
+        int dst_i0            = dst_indices[map[0]];
+        int dst_i1            = dst_indices[map[1]];
+        int dst_i2            = dst_indices[map[2]];
 
-        out(_i0, _i1, _i2) = in(i0, i1, i2);
+        out(dst_i0, dst_i1, dst_i2) = in(i0, i1, i2);
       });
 }
 
@@ -168,13 +168,13 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3) {
-        int _indices[rank] = {i0, i1, i2, i3};
-        int _i0            = _indices[map[0]];
-        int _i1            = _indices[map[1]];
-        int _i2            = _indices[map[2]];
-        int _i3            = _indices[map[3]];
+        int dst_indices[rank] = {i0, i1, i2, i3};
+        int dst_i0            = dst_indices[map[0]];
+        int dst_i1            = dst_indices[map[1]];
+        int dst_i2            = dst_indices[map[2]];
+        int dst_i3            = dst_indices[map[3]];
 
-        out(_i0, _i1, _i2, _i3) = in(i0, i1, i2, i3);
+        out(dst_i0, dst_i1, dst_i2, dst_i3) = in(i0, i1, i2, i3);
       });
 }
 
@@ -203,14 +203,14 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4) {
-        int _indices[rank] = {i0, i1, i2, i3, i4};
-        int _i0            = _indices[map[0]];
-        int _i1            = _indices[map[1]];
-        int _i2            = _indices[map[2]];
-        int _i3            = _indices[map[3]];
-        int _i4            = _indices[map[4]];
+        int dst_indices[rank] = {i0, i1, i2, i3, i4};
+        int dst_i0            = dst_indices[map[0]];
+        int dst_i1            = dst_indices[map[1]];
+        int dst_i2            = dst_indices[map[2]];
+        int dst_i3            = dst_indices[map[3]];
+        int dst_i4            = dst_indices[map[4]];
 
-        out(_i0, _i1, _i2, _i3, _i4) = in(i0, i1, i2, i3, i4);
+        out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4) = in(i0, i1, i2, i3, i4);
       });
 }
 
@@ -240,15 +240,16 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
-        int _indices[rank] = {i0, i1, i2, i3, i4, i5};
-        int _i0            = _indices[map[0]];
-        int _i1            = _indices[map[1]];
-        int _i2            = _indices[map[2]];
-        int _i3            = _indices[map[3]];
-        int _i4            = _indices[map[4]];
-        int _i5            = _indices[map[5]];
+        int dst_indices[rank] = {i0, i1, i2, i3, i4, i5};
+        int dst_i0            = dst_indices[map[0]];
+        int dst_i1            = dst_indices[map[1]];
+        int dst_i2            = dst_indices[map[2]];
+        int dst_i3            = dst_indices[map[3]];
+        int dst_i4            = dst_indices[map[4]];
+        int dst_i5            = dst_indices[map[5]];
 
-        out(_i0, _i1, _i2, _i3, _i4, _i5) = in(i0, i1, i2, i3, i4, i5);
+        out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5) =
+            in(i0, i1, i2, i3, i4, i5);
       });
 }
 
@@ -279,16 +280,16 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
         for (int i6 = 0; i6 < n6; i6++) {
-          int _indices[rank] = {i0, i1, i2, i3, i4, i5, i6};
-          int _i0            = _indices[map[0]];
-          int _i1            = _indices[map[1]];
-          int _i2            = _indices[map[2]];
-          int _i3            = _indices[map[3]];
-          int _i4            = _indices[map[4]];
-          int _i5            = _indices[map[5]];
-          int _i6            = _indices[map[6]];
+          int dst_indices[rank] = {i0, i1, i2, i3, i4, i5, i6};
+          int dst_i0            = dst_indices[map[0]];
+          int dst_i1            = dst_indices[map[1]];
+          int dst_i2            = dst_indices[map[2]];
+          int dst_i3            = dst_indices[map[3]];
+          int dst_i4            = dst_indices[map[4]];
+          int dst_i5            = dst_indices[map[5]];
+          int dst_i6            = dst_indices[map[6]];
 
-          out(_i0, _i1, _i2, _i3, _i4, _i5, _i6) =
+          out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5, dst_i6) =
               in(i0, i1, i2, i3, i4, i5, i6);
         }
       });
@@ -324,42 +325,50 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
         for (int i6 = 0; i6 < n6; i6++) {
           for (int i7 = 0; i7 < n7; i7++) {
-            int _indices[rank] = {i0, i1, i2, i3, i4, i5, i6, i7};
-            int _i0            = _indices[map[0]];
-            int _i1            = _indices[map[1]];
-            int _i2            = _indices[map[2]];
-            int _i3            = _indices[map[3]];
-            int _i4            = _indices[map[4]];
-            int _i5            = _indices[map[5]];
-            int _i6            = _indices[map[6]];
-            int _i7            = _indices[map[7]];
+            int dst_indices[rank] = {i0, i1, i2, i3, i4, i5, i6, i7};
+            int dst_i0            = dst_indices[map[0]];
+            int dst_i1            = dst_indices[map[1]];
+            int dst_i2            = dst_indices[map[2]];
+            int dst_i3            = dst_indices[map[3]];
+            int dst_i4            = dst_indices[map[4]];
+            int dst_i5            = dst_indices[map[5]];
+            int dst_i6            = dst_indices[map[6]];
+            int dst_i7            = dst_indices[map[7]];
 
-            out(_i0, _i1, _i2, _i3, _i4, _i5, _i6, _i7) =
-                in(i0, i1, i2, i3, i4, i5, i6, i7);
+            out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5, dst_i6,
+                dst_i7) = in(i0, i1, i2, i3, i4, i5, i6, i7);
           }
         }
       });
 }
 
-/* Make the axis direction to the inner most direction
-   axis should be the range in [-(rank-1), rank-1], where
-   negative number is interpreted as rank + axis.
-   E.g. axis = -1 for rank 3 matrix is interpreted as axis = 2
-
- * E.g.
-        Layout Left
-        A (3, 4, 2) and axis = 1 -> A' (4, 3, 2)
-        B (2, 4, 3, 5) and axis = 2 -> B' (3, 2, 4, 5)
-        C (8, 6, 3) and axis = 0 -> C' (8, 6, 3)
-        D (7, 5) and axis = -1 -> D' (5, 7)
-
-        Layout Right
-        A (3, 4, 2) and axis = 1 -> A' (3, 2, 4)
-        B (2, 4, 3, 5) and axis = 2 -> B' (2, 4, 5, 3)
-        C (8, 6, 3) and axis = 0 -> C' (6, 3, 8)
-        D (5, 7) and axis = -1 -> D' (5, 7)
- *
-*/
+/// \brief Make the axis direction to the inner most direction
+/// axis should be the range in [-(rank-1), rank-1], where
+/// negative number is interpreted as rank + axis.
+/// E.g. axis = -1 for rank 3 matrix is interpreted as axis = 2
+///
+/// E.g.
+///      Layout Left
+///      A (3, 4, 2) and axis = 1 -> A' (4, 3, 2)
+///      B (2, 4, 3, 5) and axis = 2 -> B' (3, 2, 4, 5)
+///      C (8, 6, 3) and axis = 0 -> C' (8, 6, 3)
+///      D (7, 5) and axis = -1 -> D' (5, 7)
+///
+///      Layout Right
+///      A (3, 4, 2) and axis = 1 -> A' (3, 2, 4)
+///      B (2, 4, 3, 5) and axis = 2 -> B' (2, 4, 5, 3)
+///      C (8, 6, 3) and axis = 0 -> C' (6, 3, 8)
+///      D (5, 7) and axis = -1 -> D' (5, 7)
+///
+/// \tparam ExecutionSpace Kokkos execution space type
+/// \tparam InViewType The input view type
+/// \tparam OutViewType The output view type
+/// \tparam DIM         The dimensionality of the map
+///
+/// \param exec_space execution space instance
+/// \param in         The input view
+/// \param out        The output view
+/// \param map        The axis map for transpose
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t DIM = 1>
 void transpose(const ExecutionSpace& exec_space, const InViewType& in,

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -23,33 +23,33 @@ bool are_aliasing(const ScalarType1* ptr1, const ScalarType2* ptr2) {
 }
 
 template <typename ViewType>
-auto convert_negative_axis(ViewType, int _axis = -1) {
+auto convert_negative_axis(ViewType, int axis = -1) {
   static_assert(Kokkos::is_view_v<ViewType>,
                 "convert_negative_axis: ViewType must be a Kokkos::View.");
   int rank = static_cast<int>(ViewType::rank());
 
-  KOKKOSFFT_THROW_IF(_axis < -rank || _axis >= rank,
+  KOKKOSFFT_THROW_IF(axis < -rank || axis >= rank,
                      "Axis must be in [-rank, rank-1]");
 
-  int axis = _axis < 0 ? rank + _axis : _axis;
-  return axis;
+  int non_negative_axis = axis < 0 ? rank + axis : axis;
+  return non_negative_axis;
 }
 
 template <typename ViewType>
-auto convert_negative_shift(const ViewType& view, int _shift, int _axis) {
+auto convert_negative_shift(const ViewType& view, int shift, int axis) {
   static_assert(Kokkos::is_view_v<ViewType>,
                 "convert_negative_shift: ViewType must be a Kokkos::View.");
-  int axis   = convert_negative_axis(view, _axis);
-  int extent = view.extent(axis);
+  int non_negative_axis = convert_negative_axis(view, axis);
+  int extent            = view.extent(non_negative_axis);
   int shift0 = 0, shift1 = 0, shift2 = extent / 2;
 
-  if (_shift < 0) {
-    shift0 = -_shift + extent % 2;  // add 1 for odd case
-    shift1 = -_shift;
+  if (shift < 0) {
+    shift0 = -shift + extent % 2;  // add 1 for odd case
+    shift1 = -shift;
     shift2 = 0;
-  } else if (_shift > 0) {
-    shift0 = _shift;
-    shift1 = _shift + extent % 2;  // add 1 for odd case
+  } else if (shift > 0) {
+    shift0 = shift;
+    shift1 = shift + extent % 2;  // add 1 for odd case
     shift2 = 0;
   }
 

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -77,8 +77,8 @@ void test_reshape1D_2DView() {
   for (int axis0 = 0; axis0 < DIM; axis0++) {
     shape_type<2> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1]        = in_shape;
-    View2D<Kokkos::complex<double>> x_in("x_in", _n0, _n1);
+    auto [s0, s1]          = in_shape;
+    View2D<Kokkos::complex<double>> x_in("x_in", s0, s1);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<2> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -104,8 +104,8 @@ void test_reshape1D_3DView() {
   for (int axis0 = 0; axis0 < DIM; axis0++) {
     shape_type<3> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2]   = in_shape;
-    View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
+    auto [s0, s1, s2]      = in_shape;
+    View3D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<3> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -128,10 +128,10 @@ void test_reshape1D_4DView() {
   constexpr int DIM = 4;
   shape_type<4> default_shape({n0, n1, n2, n3});
   for (int axis0 = 0; axis0 < DIM; axis0++) {
-    shape_type<4> in_shape    = default_shape;
-    in_shape.at(axis0)        = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2, _n3] = in_shape;
-    View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
+    shape_type<4> in_shape = default_shape;
+    in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
+    auto [s0, s1, s2, s3]  = in_shape;
+    View4D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<4> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -155,10 +155,10 @@ void test_reshape1D_5DView() {
   shape_type<5> default_shape({n0, n1, n2, n3, n4});
 
   for (int axis0 = 0; axis0 < DIM; axis0++) {
-    shape_type<5> in_shape         = default_shape;
-    in_shape.at(axis0)             = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-    View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
+    shape_type<5> in_shape    = default_shape;
+    in_shape.at(axis0)        = get_c2r_shape(x_out.extent(axis0), is_C2R);
+    auto [s0, s1, s2, s3, s4] = in_shape;
+    View5D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<5> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -181,10 +181,10 @@ void test_reshape1D_6DView() {
   constexpr int DIM = 6;
   shape_type<6> default_shape({n0, n1, n2, n3, n4, n5});
   for (int axis0 = 0; axis0 < DIM; axis0++) {
-    shape_type<6> in_shape = default_shape;
-    in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-    View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5);
+    shape_type<6> in_shape        = default_shape;
+    in_shape.at(axis0)            = get_c2r_shape(x_out.extent(axis0), is_C2R);
+    auto [s0, s1, s2, s3, s4, s5] = in_shape;
+    View6D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<6> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -209,9 +209,8 @@ void test_reshape1D_7DView() {
   for (int axis0 = 0; axis0 < DIM; axis0++) {
     shape_type<7> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-    View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
-                                         _n6);
+    auto [s0, s1, s2, s3, s4, s5, s6] = in_shape;
+    View7D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5, s6);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<7> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -236,9 +235,9 @@ void test_reshape1D_8DView() {
   for (int axis0 = 0; axis0 < DIM; axis0++) {
     shape_type<8> in_shape = default_shape;
     in_shape.at(axis0)     = get_c2r_shape(x_out.extent(axis0), is_C2R);
-    auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-    View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
-                                         _n6, _n7);
+    auto [s0, s1, s2, s3, s4, s5, s6, s7] = in_shape;
+    View8D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5, s6,
+                                         s7);
     for (int i0 = -1; i0 <= 1; i0++) {
       shape_type<8> ref_shape = default_shape;
       auto n_new              = x_in.extent(axis0) + i0;
@@ -306,8 +305,8 @@ void test_reshape2D_2DView() {
       axes_type<2> axes({axis0, axis1});
       shape_type<2> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1]        = in_shape;
-      View2D<Kokkos::complex<double>> x_in("x_in", _n0, _n1);
+      auto [s0, s1]          = in_shape;
+      View2D<Kokkos::complex<double>> x_in("x_in", s0, s1);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<2> ref_shape = default_shape;
@@ -341,8 +340,8 @@ void test_reshape2D_3DView() {
       axes_type<2> axes({axis0, axis1});
       shape_type<3> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2]   = in_shape;
-      View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
+      auto [s0, s1, s2]      = in_shape;
+      View3D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<3> ref_shape = default_shape;
@@ -374,10 +373,10 @@ void test_reshape2D_4DView() {
     for (int axis1 = 0; axis1 < DIM; axis1++) {
       if (axis0 == axis1) continue;
       axes_type<2> axes({axis0, axis1});
-      shape_type<4> in_shape    = default_shape;
-      in_shape.at(axis1)        = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2, _n3] = in_shape;
-      View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
+      shape_type<4> in_shape = default_shape;
+      in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
+      auto [s0, s1, s2, s3]  = in_shape;
+      View4D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<4> ref_shape = default_shape;
@@ -409,10 +408,10 @@ void test_reshape2D_5DView() {
     for (int axis1 = 0; axis1 < DIM; axis1++) {
       if (axis0 == axis1) continue;
       axes_type<2> axes({axis0, axis1});
-      shape_type<5> in_shape = default_shape;
-      in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-      View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
+      shape_type<5> in_shape    = default_shape;
+      in_shape.at(axis1)        = get_c2r_shape(x_out.extent(axis1), is_C2R);
+      auto [s0, s1, s2, s3, s4] = in_shape;
+      View5D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<5> ref_shape = default_shape;
@@ -446,9 +445,8 @@ void test_reshape2D_6DView() {
       axes_type<2> axes({axis0, axis1});
       shape_type<6> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-      View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
-                                           _n5);
+      auto [s0, s1, s2, s3, s4, s5] = in_shape;
+      View6D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<6> ref_shape = default_shape;
@@ -482,9 +480,8 @@ void test_reshape2D_7DView() {
       axes_type<2> axes({axis0, axis1});
       shape_type<7> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-      View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
-                                           _n6);
+      auto [s0, s1, s2, s3, s4, s5, s6] = in_shape;
+      View7D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5, s6);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<7> ref_shape = default_shape;
@@ -518,9 +515,9 @@ void test_reshape2D_8DView() {
       axes_type<2> axes({axis0, axis1});
       shape_type<8> in_shape = default_shape;
       in_shape.at(axis1)     = get_c2r_shape(x_out.extent(axis1), is_C2R);
-      auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-      View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4, _n5,
-                                           _n6, _n7);
+      auto [s0, s1, s2, s3, s4, s5, s6, s7] = in_shape;
+      View8D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5, s6,
+                                           s7);
       for (int i0 = -1; i0 <= 1; i0++) {
         for (int i1 = -1; i1 <= 1; i1++) {
           shape_type<8> ref_shape = default_shape;
@@ -591,8 +588,8 @@ void test_reshape3D_3DView() {
         axes_type<3> axes({axis0, axis1, axis2});
         shape_type<3> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2]   = in_shape;
-        View3D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2);
+        auto [s0, s1, s2]      = in_shape;
+        View3D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -632,10 +629,10 @@ void test_reshape3D_4DView() {
       for (int axis2 = 0; axis2 < DIM; axis2++) {
         if (axis0 == axis1 || axis0 == axis2 || axis1 == axis2) continue;
         axes_type<3> axes({axis0, axis1, axis2});
-        shape_type<4> in_shape    = default_shape;
-        in_shape.at(axis2)        = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2, _n3] = in_shape;
-        View4D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3);
+        shape_type<4> in_shape = default_shape;
+        in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
+        auto [s0, s1, s2, s3]  = in_shape;
+        View4D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -674,10 +671,10 @@ void test_reshape3D_5DView() {
       for (int axis2 = 0; axis2 < DIM; axis2++) {
         if (axis0 == axis1 || axis0 == axis2 || axis1 == axis2) continue;
         axes_type<3> axes({axis0, axis1, axis2});
-        shape_type<5> in_shape = default_shape;
-        in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2, _n3, _n4] = in_shape;
-        View5D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4);
+        shape_type<5> in_shape    = default_shape;
+        in_shape.at(axis2)        = get_c2r_shape(x_out.extent(axis2), is_C2R);
+        auto [s0, s1, s2, s3, s4] = in_shape;
+        View5D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -718,9 +715,8 @@ void test_reshape3D_6DView() {
         axes_type<3> axes({axis0, axis1, axis2});
         shape_type<6> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2, _n3, _n4, _n5] = in_shape;
-        View6D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
-                                             _n5);
+        auto [s0, s1, s2, s3, s4, s5] = in_shape;
+        View6D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -761,9 +757,9 @@ void test_reshape3D_7DView() {
         axes_type<3> axes({axis0, axis1, axis2});
         shape_type<7> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = in_shape;
-        View7D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
-                                             _n5, _n6);
+        auto [s0, s1, s2, s3, s4, s5, s6] = in_shape;
+        View7D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5,
+                                             s6);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -803,9 +799,9 @@ void test_reshape3D_8DView() {
         axes_type<3> axes({axis0, axis1, axis2});
         shape_type<8> in_shape = default_shape;
         in_shape.at(axis2)     = get_c2r_shape(x_out.extent(axis2), is_C2R);
-        auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = in_shape;
-        View8D<Kokkos::complex<double>> x_in("x_in", _n0, _n1, _n2, _n3, _n4,
-                                             _n5, _n6, _n7);
+        auto [s0, s1, s2, s3, s4, s5, s6, s7] = in_shape;
+        View8D<Kokkos::complex<double>> x_in("x_in", s0, s1, s2, s3, s4, s5, s6,
+                                             s7);
         for (int i0 = -1; i0 <= 1; i0++) {
           for (int i1 = -1; i1 <= 1; i1++) {
             for (int i2 = -1; i2 <= 1; i2++) {
@@ -917,7 +913,7 @@ TEST(CropOrPad1D, 1DView) {
   const int len = 30, len_pad = 32, len_crop = 28;
 
   View1D<double> x("x", len);
-  View1D<double> _x, _x_pad, _x_crop;
+  View1D<double> x_out, x_out_pad, x_out_crop;
   View1D<double> ref_x("ref_x", len), ref_x_pad("ref_x_pad", len_pad),
       ref_x_crop("ref_x_crop", len_crop);
 
@@ -936,15 +932,15 @@ TEST(CropOrPad1D, 1DView) {
   auto sub_x  = Kokkos::subview(x, range1);
   Kokkos::deep_copy(ref_x_crop, sub_x);
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_type<1>{len});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_type<1>{len});
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad,
                                shape_type<1>{len_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop,
                                shape_type<1>{len_crop});
 
-  EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad, ref_x_pad, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop, ref_x_crop, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad, ref_x_pad, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop, ref_x_crop, 1.e-5, 1.e-12));
 }
 
 TEST(CropOrPad1D, 2DView) {
@@ -952,12 +948,13 @@ TEST(CropOrPad1D, 2DView) {
   const int n1 = 5, n1_pad = 7, n1_crop = 3;
 
   View2D<double> x("x", n0, n1);
-  View2D<double> _x, _x_pad_axis0, _x_pad_axis1, _x_crop_axis0, _x_crop_axis1;
+  View2D<double> x_out, x_out_pad_axis0, x_out_pad_axis1, x_out_crop_axis0,
+      x_out_crop_axis1;
   View2D<double> ref_x("ref_x", n0, n1),
       ref_x_pad_axis0("ref_x_pad_axis0", n0_pad, n1),
       ref_x_crop_axis0("ref_x_crop_axis0", n0_crop, n1);
   View2D<double> ref_x_pad_axis1("ref_x_pad_axis1", n0, n1_pad),
-      ref_x_crop_axis1("ref_x_cro_axis1", n0, n1_crop);
+      ref_x_crop_axis1("ref_x_crop_axis1", n0, n1_crop);
 
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
   Kokkos::fill_random(x, random_pool, 1.0);
@@ -1005,22 +1002,23 @@ TEST(CropOrPad1D, 2DView) {
   Kokkos::deep_copy(ref_x_pad_axis1, h_ref_x_pad_axis1);
   Kokkos::deep_copy(ref_x_crop_axis1, h_ref_x_crop_axis1);
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_type<2>{n0, n1});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad_axis0,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out,
+                               shape_type<2>{n0, n1});
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad_axis0,
                                shape_type<2>{n0_pad, n1});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop_axis0,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop_axis0,
                                shape_type<2>{n0_crop, n1});
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad_axis1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad_axis1,
                                shape_type<2>{n0, n1_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop_axis1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop_axis1,
                                shape_type<2>{n0, n1_crop});
 
-  EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad_axis0, ref_x_pad_axis0, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop_axis0, ref_x_crop_axis0, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad_axis1, ref_x_pad_axis1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop_axis1, ref_x_crop_axis1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad_axis0, ref_x_pad_axis0, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop_axis0, ref_x_crop_axis0, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad_axis1, ref_x_pad_axis1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop_axis1, ref_x_crop_axis1, 1.e-5, 1.e-12));
 }
 
 TEST(CropOrPad1D, 3DView) {
@@ -1029,8 +1027,8 @@ TEST(CropOrPad1D, 3DView) {
   const int n2 = 8, n2_pad = 10, n2_crop = 6;
 
   View3D<double> x("x", n0, n1, n2);
-  View3D<double> _x, _x_pad_axis0, _x_crop_axis0, _x_pad_axis1, _x_crop_axis1,
-      _x_pad_axis2, _x_crop_axis2;
+  View3D<double> x_out, x_out_pad_axis0, x_out_crop_axis0, x_out_pad_axis1,
+      x_out_crop_axis1, x_out_pad_axis2, x_out_crop_axis2;
   View3D<double> ref_x("ref_x", n0, n1, n2),
       ref_x_pad_axis0("ref_x_pad_axis0", n0_pad, n1, n2),
       ref_x_crop_axis0("ref_x_crop_axis0", n0_crop, n1, n2);
@@ -1111,30 +1109,30 @@ TEST(CropOrPad1D, 3DView) {
   Kokkos::deep_copy(ref_x_pad_axis2, h_ref_x_pad_axis2);
   Kokkos::deep_copy(ref_x_crop_axis2, h_ref_x_crop_axis2);
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out,
                                shape_type<3>{n0, n1, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad_axis0,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad_axis0,
                                shape_type<3>{n0_pad, n1, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop_axis0,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop_axis0,
                                shape_type<3>{n0_crop, n1, n2});
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad_axis1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad_axis1,
                                shape_type<3>{n0, n1_pad, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop_axis1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop_axis1,
                                shape_type<3>{n0, n1_crop, n2});
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_pad_axis2,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_pad_axis2,
                                shape_type<3>{n0, n1, n2_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_crop_axis2,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_crop_axis2,
                                shape_type<3>{n0, n1, n2_crop});
 
-  EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad_axis0, ref_x_pad_axis0, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop_axis0, ref_x_crop_axis0, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad_axis1, ref_x_pad_axis1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop_axis1, ref_x_crop_axis1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_pad_axis2, ref_x_pad_axis2, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_crop_axis2, ref_x_crop_axis2, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad_axis0, ref_x_pad_axis0, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop_axis0, ref_x_crop_axis0, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad_axis1, ref_x_pad_axis1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop_axis1, ref_x_crop_axis1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_pad_axis2, ref_x_pad_axis2, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_crop_axis2, ref_x_crop_axis2, 1.e-5, 1.e-12));
 }
 
 TEST(CropOrPad2D, 2DView) {
@@ -1142,8 +1140,8 @@ TEST(CropOrPad2D, 2DView) {
   const int n1 = 5, n1_pad = 7, n1_crop = 3;
 
   View2D<double> x("x", n0, n1);
-  View2D<double> _x, _x_0_1p, _x_0_1c, _x_0p_1, _x_0p_1p, _x_0p_1c, _x_0c_1,
-      _x_0c_1p, _x_0c_1c;
+  View2D<double> x_out, x_out_0_1p, x_out_0_1c, x_out_0p_1, x_out_0p_1p,
+      x_out_0p_1c, x_out_0c_1, x_out_0c_1p, x_out_0c_1c;
   View2D<double> ref_x("ref_x", n0, n1), ref_x_0_1p("ref_x_0_1p", n0, n1_pad),
       ref_x_0_1c("ref_x_0_1c", n0, n1_crop);
   View2D<double> ref_x_0p_1("ref_x_0p_1", n0_pad, n1),
@@ -1217,33 +1215,34 @@ TEST(CropOrPad2D, 2DView) {
   Kokkos::deep_copy(ref_x_0c_1p, h_ref_x_0c_1p);
   Kokkos::deep_copy(ref_x_0c_1c, h_ref_x_0c_1c);
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_type<2>{n0, n1});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out,
+                               shape_type<2>{n0, n1});
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0_1p,
                                shape_type<2>{n0, n1_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0_1c,
                                shape_type<2>{n0, n1_crop});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1,
                                shape_type<2>{n0_pad, n1});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1p,
                                shape_type<2>{n0_pad, n1_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1c,
                                shape_type<2>{n0_pad, n1_crop});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1,
                                shape_type<2>{n0_crop, n1});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1p,
                                shape_type<2>{n0_crop, n1_pad});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1c,
                                shape_type<2>{n0_crop, n1_crop});
 
-  EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0_1p, ref_x_0_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0_1c, ref_x_0_1c, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1, ref_x_0p_1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1p, ref_x_0p_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1c, ref_x_0p_1c, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1, ref_x_0c_1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1p, ref_x_0c_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1c, ref_x_0c_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0_1p, ref_x_0_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0_1c, ref_x_0_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1, ref_x_0p_1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1p, ref_x_0p_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1c, ref_x_0p_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1, ref_x_0c_1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1p, ref_x_0c_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1c, ref_x_0c_1c, 1.e-5, 1.e-12));
 }
 
 TEST(CropOrPad2D, 3DView) {
@@ -1252,8 +1251,8 @@ TEST(CropOrPad2D, 3DView) {
   const int n2 = 8;
 
   View3D<double> x("x", n0, n1, n2);
-  View3D<double> _x, _x_0_1p, _x_0_1c, _x_0p_1, _x_0p_1p, _x_0p_1c, _x_0c_1,
-      _x_0c_1p, _x_0c_1c;
+  View3D<double> x_out, x_out_0_1p, x_out_0_1c, x_out_0p_1, x_out_0p_1p,
+      x_out_0p_1c, x_out_0c_1, x_out_0c_1p, x_out_0c_1c;
   View3D<double> ref_x("ref_x", n0, n1, n2),
       ref_x_0_1p("ref_x_0_1p", n0, n1_pad, n2),
       ref_x_0_1c("ref_x_0_1c", n0, n1_crop, n2);
@@ -1330,34 +1329,34 @@ TEST(CropOrPad2D, 3DView) {
   Kokkos::deep_copy(ref_x_0c_1p, h_ref_x_0c_1p);
   Kokkos::deep_copy(ref_x_0c_1c, h_ref_x_0c_1c);
 
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out,
                                shape_type<3>{n0, n1, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0_1p,
                                shape_type<3>{n0, n1_pad, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0_1c,
                                shape_type<3>{n0, n1_crop, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1,
                                shape_type<3>{n0_pad, n1, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1p,
                                shape_type<3>{n0_pad, n1_pad, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0p_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0p_1c,
                                shape_type<3>{n0_pad, n1_crop, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1,
                                shape_type<3>{n0_crop, n1, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1p,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1p,
                                shape_type<3>{n0_crop, n1_pad, n2});
-  KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x_0c_1c,
+  KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out_0c_1c,
                                shape_type<3>{n0_crop, n1_crop, n2});
 
-  EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0_1p, ref_x_0_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0_1c, ref_x_0_1c, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1, ref_x_0p_1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1p, ref_x_0p_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0p_1c, ref_x_0p_1c, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1, ref_x_0c_1, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1p, ref_x_0c_1p, 1.e-5, 1.e-12));
-  EXPECT_TRUE(allclose(_x_0c_1c, ref_x_0c_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0_1p, ref_x_0_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0_1c, ref_x_0_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1, ref_x_0p_1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1p, ref_x_0p_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0p_1c, ref_x_0p_1c, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1, ref_x_0c_1, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1p, ref_x_0c_1p, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_out_0c_1c, ref_x_0c_1c, 1.e-5, 1.e-12));
 }
 
 TEST(CropOrPad3D, 3DView) {
@@ -1377,7 +1376,7 @@ TEST(CropOrPad3D, 3DView) {
         std::size_t n2_new      = static_cast<std::size_t>(n2 + d2);
         shape_type<3> shape_new = {n0_new, n1_new, n2_new};
 
-        View3D<double> _x;
+        View3D<double> x_out;
         View3D<double> ref_x("ref_x", n0_new, n1_new, n2_new);
 
         auto h_ref_x = Kokkos::create_mirror_view(ref_x);
@@ -1394,8 +1393,8 @@ TEST(CropOrPad3D, 3DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1423,7 +1422,7 @@ TEST(CropOrPad4D, 4DView) {
         std::size_t n3_new      = static_cast<std::size_t>(n3 + d3);
         shape_type<4> shape_new = {n0_new, n1_new, n2_new, n3_new};
 
-        View4D<double> _x;
+        View4D<double> x_out;
         View4D<double> ref_x("ref_x", n0_new, n1_new, n2_new, n3_new);
 
         auto h_ref_x = Kokkos::create_mirror_view(ref_x);
@@ -1444,8 +1443,8 @@ TEST(CropOrPad4D, 4DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1475,7 +1474,7 @@ TEST(CropOrPad5D, 5DView) {
         std::size_t n4_new      = static_cast<std::size_t>(n4 + d4);
         shape_type<5> shape_new = {n0_new, n1_new, n2_new, n3_new, n4_new};
 
-        View5D<double> _x;
+        View5D<double> x_out;
         View5D<double> ref_x("ref_x", n0_new, n1_new, n2_new, n3_new, n4_new);
 
         auto h_ref_x = Kokkos::create_mirror_view(ref_x);
@@ -1498,8 +1497,8 @@ TEST(CropOrPad5D, 5DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1532,7 +1531,7 @@ TEST(CropOrPad6D, 6DView) {
         shape_type<6> shape_new = {n0_new, n1_new, n2_new,
                                    n3_new, n4_new, n5_new};
 
-        View6D<double> _x;
+        View6D<double> x_out;
         View6D<double> ref_x("ref_x", n0_new, n1_new, n2_new, n3_new, n4_new,
                              n5_new);
 
@@ -1560,8 +1559,8 @@ TEST(CropOrPad6D, 6DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1596,7 +1595,7 @@ TEST(CropOrPad7D, 7DView) {
         shape_type<7> shape_new = {n0_new, n1_new, n2_new, n3_new,
                                    n4_new, n5_new, n6_new};
 
-        View7D<double> _x;
+        View7D<double> x_out;
         View7D<double> ref_x("ref_x", n0_new, n1_new, n2_new, n3_new, n4_new,
                              n5_new, n6_new);
 
@@ -1627,8 +1626,8 @@ TEST(CropOrPad7D, 7DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1665,7 +1664,7 @@ TEST(CropOrPad8D, 8DView) {
         shape_type<8> shape_new = {n0_new, n1_new, n2_new, n3_new,
                                    n4_new, n5_new, n6_new, n7_new};
 
-        View8D<double> _x;
+        View8D<double> x_out;
         View8D<double> ref_x("ref_x", n0_new, n1_new, n2_new, n3_new, n4_new,
                              n5_new, n6_new, n7_new);
 
@@ -1699,8 +1698,8 @@ TEST(CropOrPad8D, 8DView) {
         }
 
         Kokkos::deep_copy(ref_x, h_ref_x);
-        KokkosFFT::Impl::crop_or_pad(execution_space(), x, _x, shape_new);
-        EXPECT_TRUE(allclose(_x, ref_x, 1.e-5, 1.e-12));
+        KokkosFFT::Impl::crop_or_pad(execution_space(), x, x_out, shape_new);
+        EXPECT_TRUE(allclose(x_out, ref_x, 1.e-5, 1.e-12));
       }
     }
   }

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -375,16 +375,16 @@ void test_transpose_1d_2dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1] = out_extents;
+    auto [nt0, nt1] = out_extents;
 
-    RealView2Dtype xt("xt", _n0, _n1);
+    RealView2Dtype xt("xt", nt0, nt1);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView2Dtype ref("ref", _n0, _n1);
+      RealView2Dtype ref("ref", nt0, nt1);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -401,9 +401,9 @@ void test_transpose_1d_2dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView2Dtype _x("_x", n0, n1);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView2Dtype x_inv("x_inv", n0, n1);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -430,26 +430,26 @@ void test_transpose_1d_3dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2] = out_extents;
+    auto [nt0, nt1, nt2] = out_extents;
 
-    RealView3Dtype xt("xt", _n0, _n1, _n2);
+    RealView3Dtype xt("xt", nt0, nt1, nt2);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView3Dtype ref("ref", _n0, _n1, _n2);
+      RealView3Dtype ref("ref", nt0, nt1, nt2);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
         for (int i1 = 0; static_cast<std::size_t>(i1) < h_x.extent(1); i1++) {
           for (int i2 = 0; static_cast<std::size_t>(i2) < h_x.extent(2); i2++) {
-            int _i0 = (map[0] == 1) ? i1 : (map[0] == 2) ? i2 : i0;
-            int _i1 = (map[1] == 0) ? i0 : (map[1] == 2) ? i2 : i1;
-            int _i2 = (map[2] == 0) ? i0 : (map[2] == 1) ? i1 : i2;
+            int dst_i0 = (map[0] == 1) ? i1 : (map[0] == 2) ? i2 : i0;
+            int dst_i1 = (map[1] == 0) ? i0 : (map[1] == 2) ? i2 : i1;
+            int dst_i2 = (map[2] == 0) ? i0 : (map[2] == 1) ? i1 : i2;
 
-            h_ref(_i0, _i1, _i2) = h_x(i0, i1, i2);
+            h_ref(dst_i0, dst_i1, dst_i2) = h_x(i0, i1, i2);
           }
         }
       }
@@ -462,9 +462,9 @@ void test_transpose_1d_3dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView3Dtype _x("_x", n0, n1, n2);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView3Dtype x_inv("x_invx", n0, n1, n2);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -491,16 +491,16 @@ void test_transpose_1d_4dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2, _n3] = out_extents;
+    auto [nt0, nt1, nt2, nt3] = out_extents;
 
-    RealView4Dtype xt("xt", _n0, _n1, _n2, _n3);
+    RealView4Dtype xt("xt", nt0, nt1, nt2, nt3);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView4Dtype ref("ref", _n0, _n1, _n2, _n3);
+      RealView4Dtype ref("ref", nt0, nt1, nt2, nt3);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -508,24 +508,24 @@ void test_transpose_1d_4dview() {
           for (int i2 = 0; static_cast<std::size_t>(i2) < h_x.extent(2); i2++) {
             for (int i3 = 0; static_cast<std::size_t>(i3) < h_x.extent(3);
                  i3++) {
-              int _i0 = (map[0] == 1)   ? i1
-                        : (map[0] == 2) ? i2
-                        : (map[0] == 3) ? i3
-                                        : i0;
-              int _i1 = (map[1] == 0)   ? i0
-                        : (map[1] == 2) ? i2
-                        : (map[1] == 3) ? i3
-                                        : i1;
-              int _i2 = (map[2] == 0)   ? i0
-                        : (map[2] == 1) ? i1
-                        : (map[2] == 3) ? i3
-                                        : i2;
-              int _i3 = (map[3] == 0)   ? i0
-                        : (map[3] == 1) ? i1
-                        : (map[3] == 2) ? i2
-                                        : i3;
+              int dst_i0 = (map[0] == 1)   ? i1
+                           : (map[0] == 2) ? i2
+                           : (map[0] == 3) ? i3
+                                           : i0;
+              int dst_i1 = (map[1] == 0)   ? i0
+                           : (map[1] == 2) ? i2
+                           : (map[1] == 3) ? i3
+                                           : i1;
+              int dst_i2 = (map[2] == 0)   ? i0
+                           : (map[2] == 1) ? i1
+                           : (map[2] == 3) ? i3
+                                           : i2;
+              int dst_i3 = (map[3] == 0)   ? i0
+                           : (map[3] == 1) ? i1
+                           : (map[3] == 2) ? i2
+                                           : i3;
 
-              h_ref(_i0, _i1, _i2, _i3) = h_x(i0, i1, i2, i3);
+              h_ref(dst_i0, dst_i1, dst_i2, dst_i3) = h_x(i0, i1, i2, i3);
             }
           }
         }
@@ -539,9 +539,9 @@ void test_transpose_1d_4dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView4Dtype _x("_x", n0, n1, n2, n3);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView4Dtype x_inv("x_inv", n0, n1, n2, n3);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -568,16 +568,16 @@ void test_transpose_1d_5dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2, _n3, _n4] = out_extents;
+    auto [nt0, nt1, nt2, nt3, nt4] = out_extents;
 
-    RealView5Dtype xt("xt", _n0, _n1, _n2, _n3, _n4);
+    RealView5Dtype xt("xt", nt0, nt1, nt2, nt3, nt4);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView5Dtype ref("ref", _n0, _n1, _n2, _n3, _n4);
+      RealView5Dtype ref("ref", nt0, nt1, nt2, nt3, nt4);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -587,32 +587,33 @@ void test_transpose_1d_5dview() {
                  i3++) {
               for (int i4 = 0; static_cast<std::size_t>(i4) < h_x.extent(4);
                    i4++) {
-                int _i0                        = (map[0] == 1)   ? i1
-                                                 : (map[0] == 2) ? i2
-                                                 : (map[0] == 3) ? i3
-                                                 : (map[0] == 4) ? i4
-                                                                 : i0;
-                int _i1                        = (map[1] == 0)   ? i0
-                                                 : (map[1] == 2) ? i2
-                                                 : (map[1] == 3) ? i3
-                                                 : (map[1] == 4) ? i4
-                                                                 : i1;
-                int _i2                        = (map[2] == 0)   ? i0
-                                                 : (map[2] == 1) ? i1
-                                                 : (map[2] == 3) ? i3
-                                                 : (map[2] == 4) ? i4
-                                                                 : i2;
-                int _i3                        = (map[3] == 0)   ? i0
-                                                 : (map[3] == 1) ? i1
-                                                 : (map[3] == 2) ? i2
-                                                 : (map[3] == 4) ? i4
-                                                                 : i3;
-                int _i4                        = (map[4] == 0)   ? i0
-                                                 : (map[4] == 1) ? i1
-                                                 : (map[4] == 2) ? i2
-                                                 : (map[4] == 3) ? i3
-                                                                 : i4;
-                h_ref(_i0, _i1, _i2, _i3, _i4) = h_x(i0, i1, i2, i3, i4);
+                int dst_i0 = (map[0] == 1)   ? i1
+                             : (map[0] == 2) ? i2
+                             : (map[0] == 3) ? i3
+                             : (map[0] == 4) ? i4
+                                             : i0;
+                int dst_i1 = (map[1] == 0)   ? i0
+                             : (map[1] == 2) ? i2
+                             : (map[1] == 3) ? i3
+                             : (map[1] == 4) ? i4
+                                             : i1;
+                int dst_i2 = (map[2] == 0)   ? i0
+                             : (map[2] == 1) ? i1
+                             : (map[2] == 3) ? i3
+                             : (map[2] == 4) ? i4
+                                             : i2;
+                int dst_i3 = (map[3] == 0)   ? i0
+                             : (map[3] == 1) ? i1
+                             : (map[3] == 2) ? i2
+                             : (map[3] == 4) ? i4
+                                             : i3;
+                int dst_i4 = (map[4] == 0)   ? i0
+                             : (map[4] == 1) ? i1
+                             : (map[4] == 2) ? i2
+                             : (map[4] == 3) ? i3
+                                             : i4;
+                h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4) =
+                    h_x(i0, i1, i2, i3, i4);
               }
             }
           }
@@ -627,9 +628,9 @@ void test_transpose_1d_5dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView5Dtype _x("_x", n0, n1, n2, n3, n4);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView5Dtype x_inv("x_inv", n0, n1, n2, n3, n4);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -657,16 +658,16 @@ void test_transpose_1d_6dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2, _n3, _n4, _n5] = out_extents;
+    auto [nt0, nt1, nt2, nt3, nt4, nt5] = out_extents;
 
-    RealView6Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5);
+    RealView6Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView6Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5);
+      RealView6Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -678,43 +679,43 @@ void test_transpose_1d_6dview() {
                    i4++) {
                 for (int i5 = 0; static_cast<std::size_t>(i5) < h_x.extent(5);
                      i5++) {
-                  int _i0 = (map[0] == 1)   ? i1
-                            : (map[0] == 2) ? i2
-                            : (map[0] == 3) ? i3
-                            : (map[0] == 4) ? i4
-                            : (map[0] == 5) ? i5
-                                            : i0;
-                  int _i1 = (map[1] == 0)   ? i0
-                            : (map[1] == 2) ? i2
-                            : (map[1] == 3) ? i3
-                            : (map[1] == 4) ? i4
-                            : (map[1] == 5) ? i5
-                                            : i1;
-                  int _i2 = (map[2] == 0)   ? i0
-                            : (map[2] == 1) ? i1
-                            : (map[2] == 3) ? i3
-                            : (map[2] == 4) ? i4
-                            : (map[2] == 5) ? i5
-                                            : i2;
-                  int _i3 = (map[3] == 0)   ? i0
-                            : (map[3] == 1) ? i1
-                            : (map[3] == 2) ? i2
-                            : (map[3] == 4) ? i4
-                            : (map[3] == 5) ? i5
-                                            : i3;
-                  int _i4 = (map[4] == 0)   ? i0
-                            : (map[4] == 1) ? i1
-                            : (map[4] == 2) ? i2
-                            : (map[4] == 3) ? i3
-                            : (map[4] == 5) ? i5
-                                            : i4;
-                  int _i5 = (map[5] == 0)   ? i0
-                            : (map[5] == 1) ? i1
-                            : (map[5] == 2) ? i2
-                            : (map[5] == 3) ? i3
-                            : (map[5] == 4) ? i4
-                                            : i5;
-                  h_ref(_i0, _i1, _i2, _i3, _i4, _i5) =
+                  int dst_i0 = (map[0] == 1)   ? i1
+                               : (map[0] == 2) ? i2
+                               : (map[0] == 3) ? i3
+                               : (map[0] == 4) ? i4
+                               : (map[0] == 5) ? i5
+                                               : i0;
+                  int dst_i1 = (map[1] == 0)   ? i0
+                               : (map[1] == 2) ? i2
+                               : (map[1] == 3) ? i3
+                               : (map[1] == 4) ? i4
+                               : (map[1] == 5) ? i5
+                                               : i1;
+                  int dst_i2 = (map[2] == 0)   ? i0
+                               : (map[2] == 1) ? i1
+                               : (map[2] == 3) ? i3
+                               : (map[2] == 4) ? i4
+                               : (map[2] == 5) ? i5
+                                               : i2;
+                  int dst_i3 = (map[3] == 0)   ? i0
+                               : (map[3] == 1) ? i1
+                               : (map[3] == 2) ? i2
+                               : (map[3] == 4) ? i4
+                               : (map[3] == 5) ? i5
+                                               : i3;
+                  int dst_i4 = (map[4] == 0)   ? i0
+                               : (map[4] == 1) ? i1
+                               : (map[4] == 2) ? i2
+                               : (map[4] == 3) ? i3
+                               : (map[4] == 5) ? i5
+                                               : i4;
+                  int dst_i5 = (map[5] == 0)   ? i0
+                               : (map[5] == 1) ? i1
+                               : (map[5] == 2) ? i2
+                               : (map[5] == 3) ? i3
+                               : (map[5] == 4) ? i4
+                                               : i5;
+                  h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5) =
                       h_x(i0, i1, i2, i3, i4, i5);
                 }
               }
@@ -731,9 +732,9 @@ void test_transpose_1d_6dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView6Dtype _x("_x", n0, n1, n2, n3, n4, n5);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView6Dtype x_inv("x_inv_x", n0, n1, n2, n3, n4, n5);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -761,16 +762,16 @@ void test_transpose_1d_7dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = out_extents;
+    auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6] = out_extents;
 
-    RealView7Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+    RealView7Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView7Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+      RealView7Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -784,57 +785,57 @@ void test_transpose_1d_7dview() {
                      i5++) {
                   for (int i6 = 0; static_cast<std::size_t>(i6) < h_x.extent(6);
                        i6++) {
-                    int _i0 = (map[0] == 1)   ? i1
-                              : (map[0] == 2) ? i2
-                              : (map[0] == 3) ? i3
-                              : (map[0] == 4) ? i4
-                              : (map[0] == 5) ? i5
-                              : (map[0] == 6) ? i6
-                                              : i0;
-                    int _i1 = (map[1] == 0)   ? i0
-                              : (map[1] == 2) ? i2
-                              : (map[1] == 3) ? i3
-                              : (map[1] == 4) ? i4
-                              : (map[1] == 5) ? i5
-                              : (map[1] == 6) ? i6
-                                              : i1;
-                    int _i2 = (map[2] == 0)   ? i0
-                              : (map[2] == 1) ? i1
-                              : (map[2] == 3) ? i3
-                              : (map[2] == 4) ? i4
-                              : (map[2] == 5) ? i5
-                              : (map[2] == 6) ? i6
-                                              : i2;
-                    int _i3 = (map[3] == 0)   ? i0
-                              : (map[3] == 1) ? i1
-                              : (map[3] == 2) ? i2
-                              : (map[3] == 4) ? i4
-                              : (map[3] == 5) ? i5
-                              : (map[3] == 6) ? i6
-                                              : i3;
-                    int _i4 = (map[4] == 0)   ? i0
-                              : (map[4] == 1) ? i1
-                              : (map[4] == 2) ? i2
-                              : (map[4] == 3) ? i3
-                              : (map[4] == 5) ? i5
-                              : (map[4] == 6) ? i6
-                                              : i4;
-                    int _i5 = (map[5] == 0)   ? i0
-                              : (map[5] == 1) ? i1
-                              : (map[5] == 2) ? i2
-                              : (map[5] == 3) ? i3
-                              : (map[5] == 4) ? i4
-                              : (map[5] == 6) ? i6
-                                              : i5;
-                    int _i6 = (map[6] == 0)   ? i0
-                              : (map[6] == 1) ? i1
-                              : (map[6] == 2) ? i2
-                              : (map[6] == 3) ? i3
-                              : (map[6] == 4) ? i4
-                              : (map[6] == 5) ? i5
-                                              : i6;
-                    h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6) =
-                        h_x(i0, i1, i2, i3, i4, i5, i6);
+                    int dst_i0    = (map[0] == 1)   ? i1
+                                    : (map[0] == 2) ? i2
+                                    : (map[0] == 3) ? i3
+                                    : (map[0] == 4) ? i4
+                                    : (map[0] == 5) ? i5
+                                    : (map[0] == 6) ? i6
+                                                    : i0;
+                    int dst_i1    = (map[1] == 0)   ? i0
+                                    : (map[1] == 2) ? i2
+                                    : (map[1] == 3) ? i3
+                                    : (map[1] == 4) ? i4
+                                    : (map[1] == 5) ? i5
+                                    : (map[1] == 6) ? i6
+                                                    : i1;
+                    int dst_i2    = (map[2] == 0)   ? i0
+                                    : (map[2] == 1) ? i1
+                                    : (map[2] == 3) ? i3
+                                    : (map[2] == 4) ? i4
+                                    : (map[2] == 5) ? i5
+                                    : (map[2] == 6) ? i6
+                                                    : i2;
+                    int dst_i3    = (map[3] == 0)   ? i0
+                                    : (map[3] == 1) ? i1
+                                    : (map[3] == 2) ? i2
+                                    : (map[3] == 4) ? i4
+                                    : (map[3] == 5) ? i5
+                                    : (map[3] == 6) ? i6
+                                                    : i3;
+                    int dst_i4    = (map[4] == 0)   ? i0
+                                    : (map[4] == 1) ? i1
+                                    : (map[4] == 2) ? i2
+                                    : (map[4] == 3) ? i3
+                                    : (map[4] == 5) ? i5
+                                    : (map[4] == 6) ? i6
+                                                    : i4;
+                    int dst_i5    = (map[5] == 0)   ? i0
+                                    : (map[5] == 1) ? i1
+                                    : (map[5] == 2) ? i2
+                                    : (map[5] == 3) ? i3
+                                    : (map[5] == 4) ? i4
+                                    : (map[5] == 6) ? i6
+                                                    : i5;
+                    int dst_i6    = (map[6] == 0)   ? i0
+                                    : (map[6] == 1) ? i1
+                                    : (map[6] == 2) ? i2
+                                    : (map[6] == 3) ? i3
+                                    : (map[6] == 4) ? i4
+                                    : (map[6] == 5) ? i5
+                                                    : i6;
+                    h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                          dst_i6) = h_x(i0, i1, i2, i3, i4, i5, i6);
                   }
                 }
               }
@@ -851,9 +852,9 @@ void test_transpose_1d_7dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView7Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView7Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -881,16 +882,16 @@ void test_transpose_1d_8dview() {
     for (int i = 0; i < DIM; i++) {
       out_extents.at(i) = x.extent(map.at(i));
     }
-    auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = out_extents;
+    auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7] = out_extents;
 
-    RealView8Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+    RealView8Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
     if (map == default_axes) {
       EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                               map),  // xt is identical to x
                    std::runtime_error);
     } else {
       // Transposed Views
-      RealView8Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+      RealView8Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
       auto h_ref = Kokkos::create_mirror_view(ref);
       // Filling the transposed View
       for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -906,71 +907,72 @@ void test_transpose_1d_8dview() {
                        i6++) {
                     for (int i7 = 0;
                          static_cast<std::size_t>(i7) < h_x.extent(7); i7++) {
-                      int _i0 = (map[0] == 1)   ? i1
-                                : (map[0] == 2) ? i2
-                                : (map[0] == 3) ? i3
-                                : (map[0] == 4) ? i4
-                                : (map[0] == 5) ? i5
-                                : (map[0] == 6) ? i6
-                                : (map[0] == 7) ? i7
-                                                : i0;
-                      int _i1 = (map[1] == 0)   ? i0
-                                : (map[1] == 2) ? i2
-                                : (map[1] == 3) ? i3
-                                : (map[1] == 4) ? i4
-                                : (map[1] == 5) ? i5
-                                : (map[1] == 6) ? i6
-                                : (map[1] == 7) ? i7
-                                                : i1;
-                      int _i2 = (map[2] == 0)   ? i0
-                                : (map[2] == 1) ? i1
-                                : (map[2] == 3) ? i3
-                                : (map[2] == 4) ? i4
-                                : (map[2] == 5) ? i5
-                                : (map[2] == 6) ? i6
-                                : (map[2] == 7) ? i7
-                                                : i2;
-                      int _i3 = (map[3] == 0)   ? i0
-                                : (map[3] == 1) ? i1
-                                : (map[3] == 2) ? i2
-                                : (map[3] == 4) ? i4
-                                : (map[3] == 5) ? i5
-                                : (map[3] == 6) ? i6
-                                : (map[3] == 7) ? i7
-                                                : i3;
-                      int _i4 = (map[4] == 0)   ? i0
-                                : (map[4] == 1) ? i1
-                                : (map[4] == 2) ? i2
-                                : (map[4] == 3) ? i3
-                                : (map[4] == 5) ? i5
-                                : (map[4] == 6) ? i6
-                                : (map[4] == 7) ? i7
-                                                : i4;
-                      int _i5 = (map[5] == 0)   ? i0
-                                : (map[5] == 1) ? i1
-                                : (map[5] == 2) ? i2
-                                : (map[5] == 3) ? i3
-                                : (map[5] == 4) ? i4
-                                : (map[5] == 6) ? i6
-                                : (map[5] == 7) ? i7
-                                                : i5;
-                      int _i6 = (map[6] == 0)   ? i0
-                                : (map[6] == 1) ? i1
-                                : (map[6] == 2) ? i2
-                                : (map[6] == 3) ? i3
-                                : (map[6] == 4) ? i4
-                                : (map[6] == 5) ? i5
-                                : (map[6] == 7) ? i7
-                                                : i6;
-                      int _i7 = (map[7] == 0)   ? i0
-                                : (map[7] == 1) ? i1
-                                : (map[7] == 2) ? i2
-                                : (map[7] == 3) ? i3
-                                : (map[7] == 4) ? i4
-                                : (map[7] == 5) ? i5
-                                : (map[7] == 6) ? i6
-                                                : i7;
-                      h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6, _i7) =
+                      int dst_i0 = (map[0] == 1)   ? i1
+                                   : (map[0] == 2) ? i2
+                                   : (map[0] == 3) ? i3
+                                   : (map[0] == 4) ? i4
+                                   : (map[0] == 5) ? i5
+                                   : (map[0] == 6) ? i6
+                                   : (map[0] == 7) ? i7
+                                                   : i0;
+                      int dst_i1 = (map[1] == 0)   ? i0
+                                   : (map[1] == 2) ? i2
+                                   : (map[1] == 3) ? i3
+                                   : (map[1] == 4) ? i4
+                                   : (map[1] == 5) ? i5
+                                   : (map[1] == 6) ? i6
+                                   : (map[1] == 7) ? i7
+                                                   : i1;
+                      int dst_i2 = (map[2] == 0)   ? i0
+                                   : (map[2] == 1) ? i1
+                                   : (map[2] == 3) ? i3
+                                   : (map[2] == 4) ? i4
+                                   : (map[2] == 5) ? i5
+                                   : (map[2] == 6) ? i6
+                                   : (map[2] == 7) ? i7
+                                                   : i2;
+                      int dst_i3 = (map[3] == 0)   ? i0
+                                   : (map[3] == 1) ? i1
+                                   : (map[3] == 2) ? i2
+                                   : (map[3] == 4) ? i4
+                                   : (map[3] == 5) ? i5
+                                   : (map[3] == 6) ? i6
+                                   : (map[3] == 7) ? i7
+                                                   : i3;
+                      int dst_i4 = (map[4] == 0)   ? i0
+                                   : (map[4] == 1) ? i1
+                                   : (map[4] == 2) ? i2
+                                   : (map[4] == 3) ? i3
+                                   : (map[4] == 5) ? i5
+                                   : (map[4] == 6) ? i6
+                                   : (map[4] == 7) ? i7
+                                                   : i4;
+                      int dst_i5 = (map[5] == 0)   ? i0
+                                   : (map[5] == 1) ? i1
+                                   : (map[5] == 2) ? i2
+                                   : (map[5] == 3) ? i3
+                                   : (map[5] == 4) ? i4
+                                   : (map[5] == 6) ? i6
+                                   : (map[5] == 7) ? i7
+                                                   : i5;
+                      int dst_i6 = (map[6] == 0)   ? i0
+                                   : (map[6] == 1) ? i1
+                                   : (map[6] == 2) ? i2
+                                   : (map[6] == 3) ? i3
+                                   : (map[6] == 4) ? i4
+                                   : (map[6] == 5) ? i5
+                                   : (map[6] == 7) ? i7
+                                                   : i6;
+                      int dst_i7 = (map[7] == 0)   ? i0
+                                   : (map[7] == 1) ? i1
+                                   : (map[7] == 2) ? i2
+                                   : (map[7] == 3) ? i3
+                                   : (map[7] == 4) ? i4
+                                   : (map[7] == 5) ? i5
+                                   : (map[7] == 6) ? i6
+                                                   : i7;
+                      h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                            dst_i6, dst_i7) =
                           h_x(i0, i1, i2, i3, i4, i5, i6, i7);
                     }
                   }
@@ -989,9 +991,9 @@ void test_transpose_1d_8dview() {
       EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
       // Inverse (transpose of transpose is identical to the original)
-      RealView8Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6, n7);
-      KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-      EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+      RealView8Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6, n7);
+      KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+      EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
     }
   }
 }
@@ -1048,7 +1050,7 @@ template <typename LayoutType>
 void test_transpose_2d_2dview() {
   using RealView2Dtype = Kokkos::View<double**, LayoutType, execution_space>;
   const int n0 = 3, n1 = 5;
-  RealView2Dtype x("x", n0, n1), _x("_x", n0, n1), ref("ref", n1, n0);
+  RealView2Dtype x("x", n0, n1), x_inv("x_inv", n0, n1), ref("ref", n1, n0);
   RealView2Dtype xt_axis01("xt_axis01", n0, n1), xt_axis10("xt_axis10", n1, n0);
 
   Kokkos::Random_XorShift64_Pool<> random_pool(12345);
@@ -1077,9 +1079,9 @@ void test_transpose_2d_2dview() {
   EXPECT_TRUE(allclose(xt_axis10, ref, 1.e-5, 1.e-12));
 
   // Inverse (transpose of transpose is identical to the original)
-  KokkosFFT::Impl::transpose(execution_space(), xt_axis10, _x,
+  KokkosFFT::Impl::transpose(execution_space(), xt_axis10, x_inv,
                              axes_type<2>({1, 0}));  // xt is the transpose of x
-  EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+  EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
 }
 
 template <typename LayoutType>
@@ -1108,27 +1110,27 @@ void test_transpose_2d_3dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2] = out_extents;
+      auto [nt0, nt1, nt2] = out_extents;
 
-      RealView3Dtype xt("xt", _n0, _n1, _n2);
+      RealView3Dtype xt("xt", nt0, nt1, nt2);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView3Dtype ref("ref", _n0, _n1, _n2);
+        RealView3Dtype ref("ref", nt0, nt1, nt2);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
           for (int i1 = 0; static_cast<std::size_t>(i1) < h_x.extent(1); i1++) {
             for (int i2 = 0; static_cast<std::size_t>(i2) < h_x.extent(2);
                  i2++) {
-              int _i0 = (map[0] == 1) ? i1 : (map[0] == 2) ? i2 : i0;
-              int _i1 = (map[1] == 0) ? i0 : (map[1] == 2) ? i2 : i1;
-              int _i2 = (map[2] == 0) ? i0 : (map[2] == 1) ? i1 : i2;
+              int dst_i0 = (map[0] == 1) ? i1 : (map[0] == 2) ? i2 : i0;
+              int dst_i1 = (map[1] == 0) ? i0 : (map[1] == 2) ? i2 : i1;
+              int dst_i2 = (map[2] == 0) ? i0 : (map[2] == 1) ? i1 : i2;
 
-              h_ref(_i0, _i1, _i2) = h_x(i0, i1, i2);
+              h_ref(dst_i0, dst_i1, dst_i2) = h_x(i0, i1, i2);
             }
           }
         }
@@ -1141,9 +1143,9 @@ void test_transpose_2d_3dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView3Dtype _x("_x", n0, n1, n2);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView3Dtype x_inv("x_inv", n0, n1, n2);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1175,16 +1177,16 @@ void test_transpose_2d_4dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2, _n3] = out_extents;
+      auto [nt0, nt1, nt2, nt3] = out_extents;
 
-      RealView4Dtype xt("xt", _n0, _n1, _n2, _n3);
+      RealView4Dtype xt("xt", nt0, nt1, nt2, nt3);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView4Dtype ref("ref", _n0, _n1, _n2, _n3);
+        RealView4Dtype ref("ref", nt0, nt1, nt2, nt3);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1193,24 +1195,24 @@ void test_transpose_2d_4dview() {
                  i2++) {
               for (int i3 = 0; static_cast<std::size_t>(i3) < h_x.extent(3);
                    i3++) {
-                int _i0 = (map[0] == 1)   ? i1
-                          : (map[0] == 2) ? i2
-                          : (map[0] == 3) ? i3
-                                          : i0;
-                int _i1 = (map[1] == 0)   ? i0
-                          : (map[1] == 2) ? i2
-                          : (map[1] == 3) ? i3
-                                          : i1;
-                int _i2 = (map[2] == 0)   ? i0
-                          : (map[2] == 1) ? i1
-                          : (map[2] == 3) ? i3
-                                          : i2;
-                int _i3 = (map[3] == 0)   ? i0
-                          : (map[3] == 1) ? i1
-                          : (map[3] == 2) ? i2
-                                          : i3;
+                int dst_i0 = (map[0] == 1)   ? i1
+                             : (map[0] == 2) ? i2
+                             : (map[0] == 3) ? i3
+                                             : i0;
+                int dst_i1 = (map[1] == 0)   ? i0
+                             : (map[1] == 2) ? i2
+                             : (map[1] == 3) ? i3
+                                             : i1;
+                int dst_i2 = (map[2] == 0)   ? i0
+                             : (map[2] == 1) ? i1
+                             : (map[2] == 3) ? i3
+                                             : i2;
+                int dst_i3 = (map[3] == 0)   ? i0
+                             : (map[3] == 1) ? i1
+                             : (map[3] == 2) ? i2
+                                             : i3;
 
-                h_ref(_i0, _i1, _i2, _i3) = h_x(i0, i1, i2, i3);
+                h_ref(dst_i0, dst_i1, dst_i2, dst_i3) = h_x(i0, i1, i2, i3);
               }
             }
           }
@@ -1224,9 +1226,9 @@ void test_transpose_2d_4dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView4Dtype _x("_x", n0, n1, n2, n3);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView4Dtype x_inv("x_inv", n0, n1, n2, n3);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1258,16 +1260,16 @@ void test_transpose_2d_5dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2, _n3, _n4] = out_extents;
+      auto [nt0, nt1, nt2, nt3, nt4] = out_extents;
 
-      RealView5Dtype xt("xt", _n0, _n1, _n2, _n3, _n4);
+      RealView5Dtype xt("xt", nt0, nt1, nt2, nt3, nt4);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView5Dtype ref("ref", _n0, _n1, _n2, _n3, _n4);
+        RealView5Dtype ref("ref", nt0, nt1, nt2, nt3, nt4);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1278,32 +1280,33 @@ void test_transpose_2d_5dview() {
                    i3++) {
                 for (int i4 = 0; static_cast<std::size_t>(i4) < h_x.extent(4);
                      i4++) {
-                  int _i0                        = (map[0] == 1)   ? i1
-                                                   : (map[0] == 2) ? i2
-                                                   : (map[0] == 3) ? i3
-                                                   : (map[0] == 4) ? i4
-                                                                   : i0;
-                  int _i1                        = (map[1] == 0)   ? i0
-                                                   : (map[1] == 2) ? i2
-                                                   : (map[1] == 3) ? i3
-                                                   : (map[1] == 4) ? i4
-                                                                   : i1;
-                  int _i2                        = (map[2] == 0)   ? i0
-                                                   : (map[2] == 1) ? i1
-                                                   : (map[2] == 3) ? i3
-                                                   : (map[2] == 4) ? i4
-                                                                   : i2;
-                  int _i3                        = (map[3] == 0)   ? i0
-                                                   : (map[3] == 1) ? i1
-                                                   : (map[3] == 2) ? i2
-                                                   : (map[3] == 4) ? i4
-                                                                   : i3;
-                  int _i4                        = (map[4] == 0)   ? i0
-                                                   : (map[4] == 1) ? i1
-                                                   : (map[4] == 2) ? i2
-                                                   : (map[4] == 3) ? i3
-                                                                   : i4;
-                  h_ref(_i0, _i1, _i2, _i3, _i4) = h_x(i0, i1, i2, i3, i4);
+                  int dst_i0 = (map[0] == 1)   ? i1
+                               : (map[0] == 2) ? i2
+                               : (map[0] == 3) ? i3
+                               : (map[0] == 4) ? i4
+                                               : i0;
+                  int dst_i1 = (map[1] == 0)   ? i0
+                               : (map[1] == 2) ? i2
+                               : (map[1] == 3) ? i3
+                               : (map[1] == 4) ? i4
+                                               : i1;
+                  int dst_i2 = (map[2] == 0)   ? i0
+                               : (map[2] == 1) ? i1
+                               : (map[2] == 3) ? i3
+                               : (map[2] == 4) ? i4
+                                               : i2;
+                  int dst_i3 = (map[3] == 0)   ? i0
+                               : (map[3] == 1) ? i1
+                               : (map[3] == 2) ? i2
+                               : (map[3] == 4) ? i4
+                                               : i3;
+                  int dst_i4 = (map[4] == 0)   ? i0
+                               : (map[4] == 1) ? i1
+                               : (map[4] == 2) ? i2
+                               : (map[4] == 3) ? i3
+                                               : i4;
+                  h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4) =
+                      h_x(i0, i1, i2, i3, i4);
                 }
               }
             }
@@ -1318,9 +1321,9 @@ void test_transpose_2d_5dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView5Dtype _x("_x", n0, n1, n2, n3, n4);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView5Dtype x_inv("x_inv", n0, n1, n2, n3, n4);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1353,16 +1356,16 @@ void test_transpose_2d_6dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2, _n3, _n4, _n5] = out_extents;
+      auto [nt0, nt1, nt2, nt3, nt4, nt5] = out_extents;
 
-      RealView6Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5);
+      RealView6Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView6Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5);
+        RealView6Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1375,43 +1378,43 @@ void test_transpose_2d_6dview() {
                      i4++) {
                   for (int i5 = 0; static_cast<std::size_t>(i5) < h_x.extent(5);
                        i5++) {
-                    int _i0 = (map[0] == 1)   ? i1
-                              : (map[0] == 2) ? i2
-                              : (map[0] == 3) ? i3
-                              : (map[0] == 4) ? i4
-                              : (map[0] == 5) ? i5
-                                              : i0;
-                    int _i1 = (map[1] == 0)   ? i0
-                              : (map[1] == 2) ? i2
-                              : (map[1] == 3) ? i3
-                              : (map[1] == 4) ? i4
-                              : (map[1] == 5) ? i5
-                                              : i1;
-                    int _i2 = (map[2] == 0)   ? i0
-                              : (map[2] == 1) ? i1
-                              : (map[2] == 3) ? i3
-                              : (map[2] == 4) ? i4
-                              : (map[2] == 5) ? i5
-                                              : i2;
-                    int _i3 = (map[3] == 0)   ? i0
-                              : (map[3] == 1) ? i1
-                              : (map[3] == 2) ? i2
-                              : (map[3] == 4) ? i4
-                              : (map[3] == 5) ? i5
-                                              : i3;
-                    int _i4 = (map[4] == 0)   ? i0
-                              : (map[4] == 1) ? i1
-                              : (map[4] == 2) ? i2
-                              : (map[4] == 3) ? i3
-                              : (map[4] == 5) ? i5
-                                              : i4;
-                    int _i5 = (map[5] == 0)   ? i0
-                              : (map[5] == 1) ? i1
-                              : (map[5] == 2) ? i2
-                              : (map[5] == 3) ? i3
-                              : (map[5] == 4) ? i4
-                                              : i5;
-                    h_ref(_i0, _i1, _i2, _i3, _i4, _i5) =
+                    int dst_i0 = (map[0] == 1)   ? i1
+                                 : (map[0] == 2) ? i2
+                                 : (map[0] == 3) ? i3
+                                 : (map[0] == 4) ? i4
+                                 : (map[0] == 5) ? i5
+                                                 : i0;
+                    int dst_i1 = (map[1] == 0)   ? i0
+                                 : (map[1] == 2) ? i2
+                                 : (map[1] == 3) ? i3
+                                 : (map[1] == 4) ? i4
+                                 : (map[1] == 5) ? i5
+                                                 : i1;
+                    int dst_i2 = (map[2] == 0)   ? i0
+                                 : (map[2] == 1) ? i1
+                                 : (map[2] == 3) ? i3
+                                 : (map[2] == 4) ? i4
+                                 : (map[2] == 5) ? i5
+                                                 : i2;
+                    int dst_i3 = (map[3] == 0)   ? i0
+                                 : (map[3] == 1) ? i1
+                                 : (map[3] == 2) ? i2
+                                 : (map[3] == 4) ? i4
+                                 : (map[3] == 5) ? i5
+                                                 : i3;
+                    int dst_i4 = (map[4] == 0)   ? i0
+                                 : (map[4] == 1) ? i1
+                                 : (map[4] == 2) ? i2
+                                 : (map[4] == 3) ? i3
+                                 : (map[4] == 5) ? i5
+                                                 : i4;
+                    int dst_i5 = (map[5] == 0)   ? i0
+                                 : (map[5] == 1) ? i1
+                                 : (map[5] == 2) ? i2
+                                 : (map[5] == 3) ? i3
+                                 : (map[5] == 4) ? i4
+                                                 : i5;
+                    h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5) =
                         h_x(i0, i1, i2, i3, i4, i5);
                   }
                 }
@@ -1428,9 +1431,9 @@ void test_transpose_2d_6dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView6Dtype _x("_x", n0, n1, n2, n3, n4, n5);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView6Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1463,16 +1466,16 @@ void test_transpose_2d_7dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = out_extents;
+      auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6] = out_extents;
 
-      RealView7Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+      RealView7Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView7Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+        RealView7Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1487,57 +1490,57 @@ void test_transpose_2d_7dview() {
                        i5++) {
                     for (int i6 = 0;
                          static_cast<std::size_t>(i6) < h_x.extent(6); i6++) {
-                      int _i0 = (map[0] == 1)   ? i1
-                                : (map[0] == 2) ? i2
-                                : (map[0] == 3) ? i3
-                                : (map[0] == 4) ? i4
-                                : (map[0] == 5) ? i5
-                                : (map[0] == 6) ? i6
-                                                : i0;
-                      int _i1 = (map[1] == 0)   ? i0
-                                : (map[1] == 2) ? i2
-                                : (map[1] == 3) ? i3
-                                : (map[1] == 4) ? i4
-                                : (map[1] == 5) ? i5
-                                : (map[1] == 6) ? i6
-                                                : i1;
-                      int _i2 = (map[2] == 0)   ? i0
-                                : (map[2] == 1) ? i1
-                                : (map[2] == 3) ? i3
-                                : (map[2] == 4) ? i4
-                                : (map[2] == 5) ? i5
-                                : (map[2] == 6) ? i6
-                                                : i2;
-                      int _i3 = (map[3] == 0)   ? i0
-                                : (map[3] == 1) ? i1
-                                : (map[3] == 2) ? i2
-                                : (map[3] == 4) ? i4
-                                : (map[3] == 5) ? i5
-                                : (map[3] == 6) ? i6
-                                                : i3;
-                      int _i4 = (map[4] == 0)   ? i0
-                                : (map[4] == 1) ? i1
-                                : (map[4] == 2) ? i2
-                                : (map[4] == 3) ? i3
-                                : (map[4] == 5) ? i5
-                                : (map[4] == 6) ? i6
-                                                : i4;
-                      int _i5 = (map[5] == 0)   ? i0
-                                : (map[5] == 1) ? i1
-                                : (map[5] == 2) ? i2
-                                : (map[5] == 3) ? i3
-                                : (map[5] == 4) ? i4
-                                : (map[5] == 6) ? i6
-                                                : i5;
-                      int _i6 = (map[6] == 0)   ? i0
-                                : (map[6] == 1) ? i1
-                                : (map[6] == 2) ? i2
-                                : (map[6] == 3) ? i3
-                                : (map[6] == 4) ? i4
-                                : (map[6] == 5) ? i5
-                                                : i6;
-                      h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6) =
-                          h_x(i0, i1, i2, i3, i4, i5, i6);
+                      int dst_i0    = (map[0] == 1)   ? i1
+                                      : (map[0] == 2) ? i2
+                                      : (map[0] == 3) ? i3
+                                      : (map[0] == 4) ? i4
+                                      : (map[0] == 5) ? i5
+                                      : (map[0] == 6) ? i6
+                                                      : i0;
+                      int dst_i1    = (map[1] == 0)   ? i0
+                                      : (map[1] == 2) ? i2
+                                      : (map[1] == 3) ? i3
+                                      : (map[1] == 4) ? i4
+                                      : (map[1] == 5) ? i5
+                                      : (map[1] == 6) ? i6
+                                                      : i1;
+                      int dst_i2    = (map[2] == 0)   ? i0
+                                      : (map[2] == 1) ? i1
+                                      : (map[2] == 3) ? i3
+                                      : (map[2] == 4) ? i4
+                                      : (map[2] == 5) ? i5
+                                      : (map[2] == 6) ? i6
+                                                      : i2;
+                      int dst_i3    = (map[3] == 0)   ? i0
+                                      : (map[3] == 1) ? i1
+                                      : (map[3] == 2) ? i2
+                                      : (map[3] == 4) ? i4
+                                      : (map[3] == 5) ? i5
+                                      : (map[3] == 6) ? i6
+                                                      : i3;
+                      int dst_i4    = (map[4] == 0)   ? i0
+                                      : (map[4] == 1) ? i1
+                                      : (map[4] == 2) ? i2
+                                      : (map[4] == 3) ? i3
+                                      : (map[4] == 5) ? i5
+                                      : (map[4] == 6) ? i6
+                                                      : i4;
+                      int dst_i5    = (map[5] == 0)   ? i0
+                                      : (map[5] == 1) ? i1
+                                      : (map[5] == 2) ? i2
+                                      : (map[5] == 3) ? i3
+                                      : (map[5] == 4) ? i4
+                                      : (map[5] == 6) ? i6
+                                                      : i5;
+                      int dst_i6    = (map[6] == 0)   ? i0
+                                      : (map[6] == 1) ? i1
+                                      : (map[6] == 2) ? i2
+                                      : (map[6] == 3) ? i3
+                                      : (map[6] == 4) ? i4
+                                      : (map[6] == 5) ? i5
+                                                      : i6;
+                      h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                            dst_i6) = h_x(i0, i1, i2, i3, i4, i5, i6);
                     }
                   }
                 }
@@ -1554,9 +1557,9 @@ void test_transpose_2d_7dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView7Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView7Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1589,16 +1592,16 @@ void test_transpose_2d_8dview() {
       for (int i = 0; i < DIM; i++) {
         out_extents.at(i) = x.extent(map.at(i));
       }
-      auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = out_extents;
+      auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7] = out_extents;
 
-      RealView8Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+      RealView8Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
       if (map == default_axes) {
         EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                 map),  // xt is identical to x
                      std::runtime_error);
       } else {
         // Transposed Views
-        RealView8Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+        RealView8Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
         auto h_ref = Kokkos::create_mirror_view(ref);
         // Filling the transposed View
         for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1615,71 +1618,72 @@ void test_transpose_2d_8dview() {
                          static_cast<std::size_t>(i6) < h_x.extent(6); i6++) {
                       for (int i7 = 0;
                            static_cast<std::size_t>(i7) < h_x.extent(7); i7++) {
-                        int _i0 = (map[0] == 1)   ? i1
-                                  : (map[0] == 2) ? i2
-                                  : (map[0] == 3) ? i3
-                                  : (map[0] == 4) ? i4
-                                  : (map[0] == 5) ? i5
-                                  : (map[0] == 6) ? i6
-                                  : (map[0] == 7) ? i7
-                                                  : i0;
-                        int _i1 = (map[1] == 0)   ? i0
-                                  : (map[1] == 2) ? i2
-                                  : (map[1] == 3) ? i3
-                                  : (map[1] == 4) ? i4
-                                  : (map[1] == 5) ? i5
-                                  : (map[1] == 6) ? i6
-                                  : (map[1] == 7) ? i7
-                                                  : i1;
-                        int _i2 = (map[2] == 0)   ? i0
-                                  : (map[2] == 1) ? i1
-                                  : (map[2] == 3) ? i3
-                                  : (map[2] == 4) ? i4
-                                  : (map[2] == 5) ? i5
-                                  : (map[2] == 6) ? i6
-                                  : (map[2] == 7) ? i7
-                                                  : i2;
-                        int _i3 = (map[3] == 0)   ? i0
-                                  : (map[3] == 1) ? i1
-                                  : (map[3] == 2) ? i2
-                                  : (map[3] == 4) ? i4
-                                  : (map[3] == 5) ? i5
-                                  : (map[3] == 6) ? i6
-                                  : (map[3] == 7) ? i7
-                                                  : i3;
-                        int _i4 = (map[4] == 0)   ? i0
-                                  : (map[4] == 1) ? i1
-                                  : (map[4] == 2) ? i2
-                                  : (map[4] == 3) ? i3
-                                  : (map[4] == 5) ? i5
-                                  : (map[4] == 6) ? i6
-                                  : (map[4] == 7) ? i7
-                                                  : i4;
-                        int _i5 = (map[5] == 0)   ? i0
-                                  : (map[5] == 1) ? i1
-                                  : (map[5] == 2) ? i2
-                                  : (map[5] == 3) ? i3
-                                  : (map[5] == 4) ? i4
-                                  : (map[5] == 6) ? i6
-                                  : (map[5] == 7) ? i7
-                                                  : i5;
-                        int _i6 = (map[6] == 0)   ? i0
-                                  : (map[6] == 1) ? i1
-                                  : (map[6] == 2) ? i2
-                                  : (map[6] == 3) ? i3
-                                  : (map[6] == 4) ? i4
-                                  : (map[6] == 5) ? i5
-                                  : (map[6] == 7) ? i7
-                                                  : i6;
-                        int _i7 = (map[7] == 0)   ? i0
-                                  : (map[7] == 1) ? i1
-                                  : (map[7] == 2) ? i2
-                                  : (map[7] == 3) ? i3
-                                  : (map[7] == 4) ? i4
-                                  : (map[7] == 5) ? i5
-                                  : (map[7] == 6) ? i6
-                                                  : i7;
-                        h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6, _i7) =
+                        int dst_i0 = (map[0] == 1)   ? i1
+                                     : (map[0] == 2) ? i2
+                                     : (map[0] == 3) ? i3
+                                     : (map[0] == 4) ? i4
+                                     : (map[0] == 5) ? i5
+                                     : (map[0] == 6) ? i6
+                                     : (map[0] == 7) ? i7
+                                                     : i0;
+                        int dst_i1 = (map[1] == 0)   ? i0
+                                     : (map[1] == 2) ? i2
+                                     : (map[1] == 3) ? i3
+                                     : (map[1] == 4) ? i4
+                                     : (map[1] == 5) ? i5
+                                     : (map[1] == 6) ? i6
+                                     : (map[1] == 7) ? i7
+                                                     : i1;
+                        int dst_i2 = (map[2] == 0)   ? i0
+                                     : (map[2] == 1) ? i1
+                                     : (map[2] == 3) ? i3
+                                     : (map[2] == 4) ? i4
+                                     : (map[2] == 5) ? i5
+                                     : (map[2] == 6) ? i6
+                                     : (map[2] == 7) ? i7
+                                                     : i2;
+                        int dst_i3 = (map[3] == 0)   ? i0
+                                     : (map[3] == 1) ? i1
+                                     : (map[3] == 2) ? i2
+                                     : (map[3] == 4) ? i4
+                                     : (map[3] == 5) ? i5
+                                     : (map[3] == 6) ? i6
+                                     : (map[3] == 7) ? i7
+                                                     : i3;
+                        int dst_i4 = (map[4] == 0)   ? i0
+                                     : (map[4] == 1) ? i1
+                                     : (map[4] == 2) ? i2
+                                     : (map[4] == 3) ? i3
+                                     : (map[4] == 5) ? i5
+                                     : (map[4] == 6) ? i6
+                                     : (map[4] == 7) ? i7
+                                                     : i4;
+                        int dst_i5 = (map[5] == 0)   ? i0
+                                     : (map[5] == 1) ? i1
+                                     : (map[5] == 2) ? i2
+                                     : (map[5] == 3) ? i3
+                                     : (map[5] == 4) ? i4
+                                     : (map[5] == 6) ? i6
+                                     : (map[5] == 7) ? i7
+                                                     : i5;
+                        int dst_i6 = (map[6] == 0)   ? i0
+                                     : (map[6] == 1) ? i1
+                                     : (map[6] == 2) ? i2
+                                     : (map[6] == 3) ? i3
+                                     : (map[6] == 4) ? i4
+                                     : (map[6] == 5) ? i5
+                                     : (map[6] == 7) ? i7
+                                                     : i6;
+                        int dst_i7 = (map[7] == 0)   ? i0
+                                     : (map[7] == 1) ? i1
+                                     : (map[7] == 2) ? i2
+                                     : (map[7] == 3) ? i3
+                                     : (map[7] == 4) ? i4
+                                     : (map[7] == 5) ? i5
+                                     : (map[7] == 6) ? i6
+                                                     : i7;
+                        h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                              dst_i6, dst_i7) =
                             h_x(i0, i1, i2, i3, i4, i5, i6, i7);
                       }
                     }
@@ -1698,9 +1702,9 @@ void test_transpose_2d_8dview() {
         EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
         // Inverse (transpose of transpose is identical to the original)
-        RealView8Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6, n7);
-        KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-        EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+        RealView8Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6, n7);
+        KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+        EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
       }
     }
   }
@@ -1856,16 +1860,16 @@ void test_transpose_3d_4dview() {
         for (int i = 0; i < DIM; i++) {
           out_extents.at(i) = x.extent(map.at(i));
         }
-        auto [_n0, _n1, _n2, _n3] = out_extents;
+        auto [nt0, nt1, nt2, nt3] = out_extents;
 
-        RealView4Dtype xt("xt", _n0, _n1, _n2, _n3);
+        RealView4Dtype xt("xt", nt0, nt1, nt2, nt3);
         if (map == default_axes) {
           EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                   map),  // xt is identical to x
                        std::runtime_error);
         } else {
           // Transposed Views
-          RealView4Dtype ref("ref", _n0, _n1, _n2, _n3);
+          RealView4Dtype ref("ref", nt0, nt1, nt2, nt3);
           auto h_ref = Kokkos::create_mirror_view(ref);
           // Filling the transposed View
           for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1875,24 +1879,24 @@ void test_transpose_3d_4dview() {
                    i2++) {
                 for (int i3 = 0; static_cast<std::size_t>(i3) < h_x.extent(3);
                      i3++) {
-                  int _i0 = (map[0] == 1)   ? i1
-                            : (map[0] == 2) ? i2
-                            : (map[0] == 3) ? i3
-                                            : i0;
-                  int _i1 = (map[1] == 0)   ? i0
-                            : (map[1] == 2) ? i2
-                            : (map[1] == 3) ? i3
-                                            : i1;
-                  int _i2 = (map[2] == 0)   ? i0
-                            : (map[2] == 1) ? i1
-                            : (map[2] == 3) ? i3
-                                            : i2;
-                  int _i3 = (map[3] == 0)   ? i0
-                            : (map[3] == 1) ? i1
-                            : (map[3] == 2) ? i2
-                                            : i3;
+                  int dst_i0 = (map[0] == 1)   ? i1
+                               : (map[0] == 2) ? i2
+                               : (map[0] == 3) ? i3
+                                               : i0;
+                  int dst_i1 = (map[1] == 0)   ? i0
+                               : (map[1] == 2) ? i2
+                               : (map[1] == 3) ? i3
+                                               : i1;
+                  int dst_i2 = (map[2] == 0)   ? i0
+                               : (map[2] == 1) ? i1
+                               : (map[2] == 3) ? i3
+                                               : i2;
+                  int dst_i3 = (map[3] == 0)   ? i0
+                               : (map[3] == 1) ? i1
+                               : (map[3] == 2) ? i2
+                                               : i3;
 
-                  h_ref(_i0, _i1, _i2, _i3) = h_x(i0, i1, i2, i3);
+                  h_ref(dst_i0, dst_i1, dst_i2, dst_i3) = h_x(i0, i1, i2, i3);
                 }
               }
             }
@@ -1906,9 +1910,9 @@ void test_transpose_3d_4dview() {
           EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
           // Inverse (transpose of transpose is identical to the original)
-          RealView4Dtype _x("_x", n0, n1, n2, n3);
-          KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-          EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+          RealView4Dtype x_inv("x_inv", n0, n1, n2, n3);
+          KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+          EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
         }
       }
     }
@@ -1943,16 +1947,16 @@ void test_transpose_3d_5dview() {
         for (int i = 0; i < DIM; i++) {
           out_extents.at(i) = x.extent(map.at(i));
         }
-        auto [_n0, _n1, _n2, _n3, _n4] = out_extents;
+        auto [nt0, nt1, nt2, nt3, nt4] = out_extents;
 
-        RealView5Dtype xt("xt", _n0, _n1, _n2, _n3, _n4);
+        RealView5Dtype xt("xt", nt0, nt1, nt2, nt3, nt4);
         if (map == default_axes) {
           EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                   map),  // xt is identical to x
                        std::runtime_error);
         } else {
           // Transposed Views
-          RealView5Dtype ref("ref", _n0, _n1, _n2, _n3, _n4);
+          RealView5Dtype ref("ref", nt0, nt1, nt2, nt3, nt4);
           auto h_ref = Kokkos::create_mirror_view(ref);
           // Filling the transposed View
           for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -1964,32 +1968,33 @@ void test_transpose_3d_5dview() {
                      i3++) {
                   for (int i4 = 0; static_cast<std::size_t>(i4) < h_x.extent(4);
                        i4++) {
-                    int _i0                        = (map[0] == 1)   ? i1
-                                                     : (map[0] == 2) ? i2
-                                                     : (map[0] == 3) ? i3
-                                                     : (map[0] == 4) ? i4
-                                                                     : i0;
-                    int _i1                        = (map[1] == 0)   ? i0
-                                                     : (map[1] == 2) ? i2
-                                                     : (map[1] == 3) ? i3
-                                                     : (map[1] == 4) ? i4
-                                                                     : i1;
-                    int _i2                        = (map[2] == 0)   ? i0
-                                                     : (map[2] == 1) ? i1
-                                                     : (map[2] == 3) ? i3
-                                                     : (map[2] == 4) ? i4
-                                                                     : i2;
-                    int _i3                        = (map[3] == 0)   ? i0
-                                                     : (map[3] == 1) ? i1
-                                                     : (map[3] == 2) ? i2
-                                                     : (map[3] == 4) ? i4
-                                                                     : i3;
-                    int _i4                        = (map[4] == 0)   ? i0
-                                                     : (map[4] == 1) ? i1
-                                                     : (map[4] == 2) ? i2
-                                                     : (map[4] == 3) ? i3
-                                                                     : i4;
-                    h_ref(_i0, _i1, _i2, _i3, _i4) = h_x(i0, i1, i2, i3, i4);
+                    int dst_i0 = (map[0] == 1)   ? i1
+                                 : (map[0] == 2) ? i2
+                                 : (map[0] == 3) ? i3
+                                 : (map[0] == 4) ? i4
+                                                 : i0;
+                    int dst_i1 = (map[1] == 0)   ? i0
+                                 : (map[1] == 2) ? i2
+                                 : (map[1] == 3) ? i3
+                                 : (map[1] == 4) ? i4
+                                                 : i1;
+                    int dst_i2 = (map[2] == 0)   ? i0
+                                 : (map[2] == 1) ? i1
+                                 : (map[2] == 3) ? i3
+                                 : (map[2] == 4) ? i4
+                                                 : i2;
+                    int dst_i3 = (map[3] == 0)   ? i0
+                                 : (map[3] == 1) ? i1
+                                 : (map[3] == 2) ? i2
+                                 : (map[3] == 4) ? i4
+                                                 : i3;
+                    int dst_i4 = (map[4] == 0)   ? i0
+                                 : (map[4] == 1) ? i1
+                                 : (map[4] == 2) ? i2
+                                 : (map[4] == 3) ? i3
+                                                 : i4;
+                    h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4) =
+                        h_x(i0, i1, i2, i3, i4);
                   }
                 }
               }
@@ -2004,9 +2009,9 @@ void test_transpose_3d_5dview() {
           EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
           // Inverse (transpose of transpose is identical to the original)
-          RealView5Dtype _x("_x", n0, n1, n2, n3, n4);
-          KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-          EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+          RealView5Dtype x_inv("x_inv", n0, n1, n2, n3, n4);
+          KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+          EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
         }
       }
     }
@@ -2042,16 +2047,16 @@ void test_transpose_3d_6dview() {
         for (int i = 0; i < DIM; i++) {
           out_extents.at(i) = x.extent(map.at(i));
         }
-        auto [_n0, _n1, _n2, _n3, _n4, _n5] = out_extents;
+        auto [nt0, nt1, nt2, nt3, nt4, nt5] = out_extents;
 
-        RealView6Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5);
+        RealView6Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5);
         if (map == default_axes) {
           EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                   map),  // xt is identical to x
                        std::runtime_error);
         } else {
           // Transposed Views
-          RealView6Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5);
+          RealView6Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5);
           auto h_ref = Kokkos::create_mirror_view(ref);
           // Filling the transposed View
           for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -2065,43 +2070,43 @@ void test_transpose_3d_6dview() {
                        i4++) {
                     for (int i5 = 0;
                          static_cast<std::size_t>(i5) < h_x.extent(5); i5++) {
-                      int _i0 = (map[0] == 1)   ? i1
-                                : (map[0] == 2) ? i2
-                                : (map[0] == 3) ? i3
-                                : (map[0] == 4) ? i4
-                                : (map[0] == 5) ? i5
-                                                : i0;
-                      int _i1 = (map[1] == 0)   ? i0
-                                : (map[1] == 2) ? i2
-                                : (map[1] == 3) ? i3
-                                : (map[1] == 4) ? i4
-                                : (map[1] == 5) ? i5
-                                                : i1;
-                      int _i2 = (map[2] == 0)   ? i0
-                                : (map[2] == 1) ? i1
-                                : (map[2] == 3) ? i3
-                                : (map[2] == 4) ? i4
-                                : (map[2] == 5) ? i5
-                                                : i2;
-                      int _i3 = (map[3] == 0)   ? i0
-                                : (map[3] == 1) ? i1
-                                : (map[3] == 2) ? i2
-                                : (map[3] == 4) ? i4
-                                : (map[3] == 5) ? i5
-                                                : i3;
-                      int _i4 = (map[4] == 0)   ? i0
-                                : (map[4] == 1) ? i1
-                                : (map[4] == 2) ? i2
-                                : (map[4] == 3) ? i3
-                                : (map[4] == 5) ? i5
-                                                : i4;
-                      int _i5 = (map[5] == 0)   ? i0
-                                : (map[5] == 1) ? i1
-                                : (map[5] == 2) ? i2
-                                : (map[5] == 3) ? i3
-                                : (map[5] == 4) ? i4
-                                                : i5;
-                      h_ref(_i0, _i1, _i2, _i3, _i4, _i5) =
+                      int dst_i0 = (map[0] == 1)   ? i1
+                                   : (map[0] == 2) ? i2
+                                   : (map[0] == 3) ? i3
+                                   : (map[0] == 4) ? i4
+                                   : (map[0] == 5) ? i5
+                                                   : i0;
+                      int dst_i1 = (map[1] == 0)   ? i0
+                                   : (map[1] == 2) ? i2
+                                   : (map[1] == 3) ? i3
+                                   : (map[1] == 4) ? i4
+                                   : (map[1] == 5) ? i5
+                                                   : i1;
+                      int dst_i2 = (map[2] == 0)   ? i0
+                                   : (map[2] == 1) ? i1
+                                   : (map[2] == 3) ? i3
+                                   : (map[2] == 4) ? i4
+                                   : (map[2] == 5) ? i5
+                                                   : i2;
+                      int dst_i3 = (map[3] == 0)   ? i0
+                                   : (map[3] == 1) ? i1
+                                   : (map[3] == 2) ? i2
+                                   : (map[3] == 4) ? i4
+                                   : (map[3] == 5) ? i5
+                                                   : i3;
+                      int dst_i4 = (map[4] == 0)   ? i0
+                                   : (map[4] == 1) ? i1
+                                   : (map[4] == 2) ? i2
+                                   : (map[4] == 3) ? i3
+                                   : (map[4] == 5) ? i5
+                                                   : i4;
+                      int dst_i5 = (map[5] == 0)   ? i0
+                                   : (map[5] == 1) ? i1
+                                   : (map[5] == 2) ? i2
+                                   : (map[5] == 3) ? i3
+                                   : (map[5] == 4) ? i4
+                                                   : i5;
+                      h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5) =
                           h_x(i0, i1, i2, i3, i4, i5);
                     }
                   }
@@ -2118,9 +2123,9 @@ void test_transpose_3d_6dview() {
           EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
           // Inverse (transpose of transpose is identical to the original)
-          RealView6Dtype _x("_x", n0, n1, n2, n3, n4, n5);
-          KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-          EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+          RealView6Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5);
+          KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+          EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
         }
       }
     }
@@ -2156,16 +2161,16 @@ void test_transpose_3d_7dview() {
         for (int i = 0; i < DIM; i++) {
           out_extents.at(i) = x.extent(map.at(i));
         }
-        auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6] = out_extents;
+        auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6] = out_extents;
 
-        RealView7Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+        RealView7Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
         if (map == default_axes) {
           EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                   map),  // xt is identical to x
                        std::runtime_error);
         } else {
           // Transposed Views
-          RealView7Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6);
+          RealView7Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6);
           auto h_ref = Kokkos::create_mirror_view(ref);
           // Filling the transposed View
           for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -2181,57 +2186,57 @@ void test_transpose_3d_7dview() {
                          static_cast<std::size_t>(i5) < h_x.extent(5); i5++) {
                       for (int i6 = 0;
                            static_cast<std::size_t>(i6) < h_x.extent(6); i6++) {
-                        int _i0 = (map[0] == 1)   ? i1
-                                  : (map[0] == 2) ? i2
-                                  : (map[0] == 3) ? i3
-                                  : (map[0] == 4) ? i4
-                                  : (map[0] == 5) ? i5
-                                  : (map[0] == 6) ? i6
-                                                  : i0;
-                        int _i1 = (map[1] == 0)   ? i0
-                                  : (map[1] == 2) ? i2
-                                  : (map[1] == 3) ? i3
-                                  : (map[1] == 4) ? i4
-                                  : (map[1] == 5) ? i5
-                                  : (map[1] == 6) ? i6
-                                                  : i1;
-                        int _i2 = (map[2] == 0)   ? i0
-                                  : (map[2] == 1) ? i1
-                                  : (map[2] == 3) ? i3
-                                  : (map[2] == 4) ? i4
-                                  : (map[2] == 5) ? i5
-                                  : (map[2] == 6) ? i6
-                                                  : i2;
-                        int _i3 = (map[3] == 0)   ? i0
-                                  : (map[3] == 1) ? i1
-                                  : (map[3] == 2) ? i2
-                                  : (map[3] == 4) ? i4
-                                  : (map[3] == 5) ? i5
-                                  : (map[3] == 6) ? i6
-                                                  : i3;
-                        int _i4 = (map[4] == 0)   ? i0
-                                  : (map[4] == 1) ? i1
-                                  : (map[4] == 2) ? i2
-                                  : (map[4] == 3) ? i3
-                                  : (map[4] == 5) ? i5
-                                  : (map[4] == 6) ? i6
-                                                  : i4;
-                        int _i5 = (map[5] == 0)   ? i0
-                                  : (map[5] == 1) ? i1
-                                  : (map[5] == 2) ? i2
-                                  : (map[5] == 3) ? i3
-                                  : (map[5] == 4) ? i4
-                                  : (map[5] == 6) ? i6
-                                                  : i5;
-                        int _i6 = (map[6] == 0)   ? i0
-                                  : (map[6] == 1) ? i1
-                                  : (map[6] == 2) ? i2
-                                  : (map[6] == 3) ? i3
-                                  : (map[6] == 4) ? i4
-                                  : (map[6] == 5) ? i5
-                                                  : i6;
-                        h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6) =
-                            h_x(i0, i1, i2, i3, i4, i5, i6);
+                        int dst_i0    = (map[0] == 1)   ? i1
+                                        : (map[0] == 2) ? i2
+                                        : (map[0] == 3) ? i3
+                                        : (map[0] == 4) ? i4
+                                        : (map[0] == 5) ? i5
+                                        : (map[0] == 6) ? i6
+                                                        : i0;
+                        int dst_i1    = (map[1] == 0)   ? i0
+                                        : (map[1] == 2) ? i2
+                                        : (map[1] == 3) ? i3
+                                        : (map[1] == 4) ? i4
+                                        : (map[1] == 5) ? i5
+                                        : (map[1] == 6) ? i6
+                                                        : i1;
+                        int dst_i2    = (map[2] == 0)   ? i0
+                                        : (map[2] == 1) ? i1
+                                        : (map[2] == 3) ? i3
+                                        : (map[2] == 4) ? i4
+                                        : (map[2] == 5) ? i5
+                                        : (map[2] == 6) ? i6
+                                                        : i2;
+                        int dst_i3    = (map[3] == 0)   ? i0
+                                        : (map[3] == 1) ? i1
+                                        : (map[3] == 2) ? i2
+                                        : (map[3] == 4) ? i4
+                                        : (map[3] == 5) ? i5
+                                        : (map[3] == 6) ? i6
+                                                        : i3;
+                        int dst_i4    = (map[4] == 0)   ? i0
+                                        : (map[4] == 1) ? i1
+                                        : (map[4] == 2) ? i2
+                                        : (map[4] == 3) ? i3
+                                        : (map[4] == 5) ? i5
+                                        : (map[4] == 6) ? i6
+                                                        : i4;
+                        int dst_i5    = (map[5] == 0)   ? i0
+                                        : (map[5] == 1) ? i1
+                                        : (map[5] == 2) ? i2
+                                        : (map[5] == 3) ? i3
+                                        : (map[5] == 4) ? i4
+                                        : (map[5] == 6) ? i6
+                                                        : i5;
+                        int dst_i6    = (map[6] == 0)   ? i0
+                                        : (map[6] == 1) ? i1
+                                        : (map[6] == 2) ? i2
+                                        : (map[6] == 3) ? i3
+                                        : (map[6] == 4) ? i4
+                                        : (map[6] == 5) ? i5
+                                                        : i6;
+                        h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                              dst_i6) = h_x(i0, i1, i2, i3, i4, i5, i6);
                       }
                     }
                   }
@@ -2248,9 +2253,9 @@ void test_transpose_3d_7dview() {
           EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
           // Inverse (transpose of transpose is identical to the original)
-          RealView7Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6);
-          KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-          EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+          RealView7Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6);
+          KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+          EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
         }
       }
     }
@@ -2286,16 +2291,16 @@ void test_transpose_3d_8dview() {
         for (int i = 0; i < DIM; i++) {
           out_extents.at(i) = x.extent(map.at(i));
         }
-        auto [_n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7] = out_extents;
+        auto [nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7] = out_extents;
 
-        RealView8Dtype xt("xt", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+        RealView8Dtype xt("xt", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
         if (map == default_axes) {
           EXPECT_THROW(KokkosFFT::Impl::transpose(execution_space(), x, xt,
                                                   map),  // xt is identical to x
                        std::runtime_error);
         } else {
           // Transposed Views
-          RealView8Dtype ref("ref", _n0, _n1, _n2, _n3, _n4, _n5, _n6, _n7);
+          RealView8Dtype ref("ref", nt0, nt1, nt2, nt3, nt4, nt5, nt6, nt7);
           auto h_ref = Kokkos::create_mirror_view(ref);
           // Filling the transposed View
           for (int i0 = 0; static_cast<std::size_t>(i0) < h_x.extent(0); i0++) {
@@ -2314,71 +2319,72 @@ void test_transpose_3d_8dview() {
                         for (int i7 = 0;
                              static_cast<std::size_t>(i7) < h_x.extent(7);
                              i7++) {
-                          int _i0 = (map[0] == 1)   ? i1
-                                    : (map[0] == 2) ? i2
-                                    : (map[0] == 3) ? i3
-                                    : (map[0] == 4) ? i4
-                                    : (map[0] == 5) ? i5
-                                    : (map[0] == 6) ? i6
-                                    : (map[0] == 7) ? i7
-                                                    : i0;
-                          int _i1 = (map[1] == 0)   ? i0
-                                    : (map[1] == 2) ? i2
-                                    : (map[1] == 3) ? i3
-                                    : (map[1] == 4) ? i4
-                                    : (map[1] == 5) ? i5
-                                    : (map[1] == 6) ? i6
-                                    : (map[1] == 7) ? i7
-                                                    : i1;
-                          int _i2 = (map[2] == 0)   ? i0
-                                    : (map[2] == 1) ? i1
-                                    : (map[2] == 3) ? i3
-                                    : (map[2] == 4) ? i4
-                                    : (map[2] == 5) ? i5
-                                    : (map[2] == 6) ? i6
-                                    : (map[2] == 7) ? i7
-                                                    : i2;
-                          int _i3 = (map[3] == 0)   ? i0
-                                    : (map[3] == 1) ? i1
-                                    : (map[3] == 2) ? i2
-                                    : (map[3] == 4) ? i4
-                                    : (map[3] == 5) ? i5
-                                    : (map[3] == 6) ? i6
-                                    : (map[3] == 7) ? i7
-                                                    : i3;
-                          int _i4 = (map[4] == 0)   ? i0
-                                    : (map[4] == 1) ? i1
-                                    : (map[4] == 2) ? i2
-                                    : (map[4] == 3) ? i3
-                                    : (map[4] == 5) ? i5
-                                    : (map[4] == 6) ? i6
-                                    : (map[4] == 7) ? i7
-                                                    : i4;
-                          int _i5 = (map[5] == 0)   ? i0
-                                    : (map[5] == 1) ? i1
-                                    : (map[5] == 2) ? i2
-                                    : (map[5] == 3) ? i3
-                                    : (map[5] == 4) ? i4
-                                    : (map[5] == 6) ? i6
-                                    : (map[5] == 7) ? i7
-                                                    : i5;
-                          int _i6 = (map[6] == 0)   ? i0
-                                    : (map[6] == 1) ? i1
-                                    : (map[6] == 2) ? i2
-                                    : (map[6] == 3) ? i3
-                                    : (map[6] == 4) ? i4
-                                    : (map[6] == 5) ? i5
-                                    : (map[6] == 7) ? i7
-                                                    : i6;
-                          int _i7 = (map[7] == 0)   ? i0
-                                    : (map[7] == 1) ? i1
-                                    : (map[7] == 2) ? i2
-                                    : (map[7] == 3) ? i3
-                                    : (map[7] == 4) ? i4
-                                    : (map[7] == 5) ? i5
-                                    : (map[7] == 6) ? i6
-                                                    : i7;
-                          h_ref(_i0, _i1, _i2, _i3, _i4, _i5, _i6, _i7) =
+                          int dst_i0 = (map[0] == 1)   ? i1
+                                       : (map[0] == 2) ? i2
+                                       : (map[0] == 3) ? i3
+                                       : (map[0] == 4) ? i4
+                                       : (map[0] == 5) ? i5
+                                       : (map[0] == 6) ? i6
+                                       : (map[0] == 7) ? i7
+                                                       : i0;
+                          int dst_i1 = (map[1] == 0)   ? i0
+                                       : (map[1] == 2) ? i2
+                                       : (map[1] == 3) ? i3
+                                       : (map[1] == 4) ? i4
+                                       : (map[1] == 5) ? i5
+                                       : (map[1] == 6) ? i6
+                                       : (map[1] == 7) ? i7
+                                                       : i1;
+                          int dst_i2 = (map[2] == 0)   ? i0
+                                       : (map[2] == 1) ? i1
+                                       : (map[2] == 3) ? i3
+                                       : (map[2] == 4) ? i4
+                                       : (map[2] == 5) ? i5
+                                       : (map[2] == 6) ? i6
+                                       : (map[2] == 7) ? i7
+                                                       : i2;
+                          int dst_i3 = (map[3] == 0)   ? i0
+                                       : (map[3] == 1) ? i1
+                                       : (map[3] == 2) ? i2
+                                       : (map[3] == 4) ? i4
+                                       : (map[3] == 5) ? i5
+                                       : (map[3] == 6) ? i6
+                                       : (map[3] == 7) ? i7
+                                                       : i3;
+                          int dst_i4 = (map[4] == 0)   ? i0
+                                       : (map[4] == 1) ? i1
+                                       : (map[4] == 2) ? i2
+                                       : (map[4] == 3) ? i3
+                                       : (map[4] == 5) ? i5
+                                       : (map[4] == 6) ? i6
+                                       : (map[4] == 7) ? i7
+                                                       : i4;
+                          int dst_i5 = (map[5] == 0)   ? i0
+                                       : (map[5] == 1) ? i1
+                                       : (map[5] == 2) ? i2
+                                       : (map[5] == 3) ? i3
+                                       : (map[5] == 4) ? i4
+                                       : (map[5] == 6) ? i6
+                                       : (map[5] == 7) ? i7
+                                                       : i5;
+                          int dst_i6 = (map[6] == 0)   ? i0
+                                       : (map[6] == 1) ? i1
+                                       : (map[6] == 2) ? i2
+                                       : (map[6] == 3) ? i3
+                                       : (map[6] == 4) ? i4
+                                       : (map[6] == 5) ? i5
+                                       : (map[6] == 7) ? i7
+                                                       : i6;
+                          int dst_i7 = (map[7] == 0)   ? i0
+                                       : (map[7] == 1) ? i1
+                                       : (map[7] == 2) ? i2
+                                       : (map[7] == 3) ? i3
+                                       : (map[7] == 4) ? i4
+                                       : (map[7] == 5) ? i5
+                                       : (map[7] == 6) ? i6
+                                                       : i7;
+                          h_ref(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5,
+                                dst_i6, dst_i7) =
                               h_x(i0, i1, i2, i3, i4, i5, i6, i7);
                         }
                       }
@@ -2397,9 +2403,9 @@ void test_transpose_3d_8dview() {
           EXPECT_TRUE(allclose(xt, ref, 1.e-5, 1.e-12));
 
           // Inverse (transpose of transpose is identical to the original)
-          RealView8Dtype _x("_x", n0, n1, n2, n3, n4, n5, n6, n7);
-          KokkosFFT::Impl::transpose(execution_space(), xt, _x, map_inv);
-          EXPECT_TRUE(allclose(_x, x, 1.e-5, 1.e-12));
+          RealView8Dtype x_inv("x_inv", n0, n1, n2, n3, n4, n5, n6, n7);
+          KokkosFFT::Impl::transpose(execution_space(), xt, x_inv, map_inv);
+          EXPECT_TRUE(allclose(x_inv, x, 1.e-5, 1.e-12));
         }
       }
     }


### PR DESCRIPTION
Improves #81

- [x] Avoid variables starting from under score under `common/src`
- [x] Avoid variables starting from under score under `common/unit_test`