### PR TITLE
Avoid variables from underscore under common and fft

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-Checks: '-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
+Checks: '-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast,bugprone-reserved-identifier'
 FormatStyle: file
 HeaderFileExtensions: ['h','hh','hpp','hxx']
 ImplementationFileExtensions: ['c','cc','cpp','cxx']

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -92,7 +92,7 @@ axis_type<ViewType::rank()> compute_transpose_extents(
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<2> /*_map*/) {
+                    const OutViewType& out, axis_type<2> /*map*/) {
   constexpr std::size_t DIM = 2;
 
   using range_type = Kokkos::MDRangePolicy<
@@ -115,7 +115,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<3> _map) {
+                    const OutViewType& out, axis_type<3> map) {
   constexpr std::size_t DIM  = 3;
   constexpr std::size_t rank = InViewType::rank();
 
@@ -132,13 +132,13 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
       tile_type{{4, 4, 4}}  // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range, KOKKOS_LAMBDA(int i0, int i1, int i2) {
         int dst_indices[rank] = {i0, i1, i2};
-        int dst_i0            = dst_indices[map[0]];
-        int dst_i1            = dst_indices[map[1]];
-        int dst_i2            = dst_indices[map[2]];
+        int dst_i0            = dst_indices[map_array[0]];
+        int dst_i1            = dst_indices[map_array[1]];
+        int dst_i2            = dst_indices[map_array[2]];
 
         out(dst_i0, dst_i1, dst_i2) = in(i0, i1, i2);
       });
@@ -146,7 +146,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<4> _map) {
+                    const OutViewType& out, axis_type<4> map) {
   constexpr std::size_t DIM  = 4;
   constexpr std::size_t rank = InViewType::rank();
 
@@ -164,15 +164,15 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3) {
         int dst_indices[rank] = {i0, i1, i2, i3};
-        int dst_i0            = dst_indices[map[0]];
-        int dst_i1            = dst_indices[map[1]];
-        int dst_i2            = dst_indices[map[2]];
-        int dst_i3            = dst_indices[map[3]];
+        int dst_i0            = dst_indices[map_array[0]];
+        int dst_i1            = dst_indices[map_array[1]];
+        int dst_i2            = dst_indices[map_array[2]];
+        int dst_i3            = dst_indices[map_array[3]];
 
         out(dst_i0, dst_i1, dst_i2, dst_i3) = in(i0, i1, i2, i3);
       });
@@ -180,7 +180,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<5> _map) {
+                    const OutViewType& out, axis_type<5> map) {
   constexpr std::size_t DIM  = 5;
   constexpr std::size_t rank = InViewType::rank();
 
@@ -199,16 +199,16 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4) {
         int dst_indices[rank] = {i0, i1, i2, i3, i4};
-        int dst_i0            = dst_indices[map[0]];
-        int dst_i1            = dst_indices[map[1]];
-        int dst_i2            = dst_indices[map[2]];
-        int dst_i3            = dst_indices[map[3]];
-        int dst_i4            = dst_indices[map[4]];
+        int dst_i0            = dst_indices[map_array[0]];
+        int dst_i1            = dst_indices[map_array[1]];
+        int dst_i2            = dst_indices[map_array[2]];
+        int dst_i3            = dst_indices[map_array[3]];
+        int dst_i4            = dst_indices[map_array[4]];
 
         out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4) = in(i0, i1, i2, i3, i4);
       });
@@ -216,7 +216,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<6> _map) {
+                    const OutViewType& out, axis_type<6> map) {
   constexpr std::size_t DIM  = 6;
   constexpr std::size_t rank = InViewType::rank();
 
@@ -236,17 +236,17 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
         int dst_indices[rank] = {i0, i1, i2, i3, i4, i5};
-        int dst_i0            = dst_indices[map[0]];
-        int dst_i1            = dst_indices[map[1]];
-        int dst_i2            = dst_indices[map[2]];
-        int dst_i3            = dst_indices[map[3]];
-        int dst_i4            = dst_indices[map[4]];
-        int dst_i5            = dst_indices[map[5]];
+        int dst_i0            = dst_indices[map_array[0]];
+        int dst_i1            = dst_indices[map_array[1]];
+        int dst_i2            = dst_indices[map_array[2]];
+        int dst_i3            = dst_indices[map_array[3]];
+        int dst_i4            = dst_indices[map_array[4]];
+        int dst_i5            = dst_indices[map_array[5]];
 
         out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5) =
             in(i0, i1, i2, i3, i4, i5);
@@ -255,7 +255,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<7> _map) {
+                    const OutViewType& out, axis_type<7> map) {
   constexpr std::size_t DIM  = 6;
   constexpr std::size_t rank = InViewType::rank();
 
@@ -275,19 +275,19 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
         for (int i6 = 0; i6 < n6; i6++) {
           int dst_indices[rank] = {i0, i1, i2, i3, i4, i5, i6};
-          int dst_i0            = dst_indices[map[0]];
-          int dst_i1            = dst_indices[map[1]];
-          int dst_i2            = dst_indices[map[2]];
-          int dst_i3            = dst_indices[map[3]];
-          int dst_i4            = dst_indices[map[4]];
-          int dst_i5            = dst_indices[map[5]];
-          int dst_i6            = dst_indices[map[6]];
+          int dst_i0            = dst_indices[map_array[0]];
+          int dst_i1            = dst_indices[map_array[1]];
+          int dst_i2            = dst_indices[map_array[2]];
+          int dst_i3            = dst_indices[map_array[3]];
+          int dst_i4            = dst_indices[map_array[4]];
+          int dst_i5            = dst_indices[map_array[5]];
+          int dst_i6            = dst_indices[map_array[6]];
 
           out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5, dst_i6) =
               in(i0, i1, i2, i3, i4, i5, i6);
@@ -297,7 +297,7 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
 
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                    const OutViewType& out, axis_type<8> _map) {
+                    const OutViewType& out, axis_type<8> map) {
   constexpr std::size_t DIM = 6;
 
   constexpr std::size_t rank = InViewType::rank();
@@ -319,21 +319,21 @@ void transpose_impl(const ExecutionSpace& exec_space, const InViewType& in,
                    // [TO DO] Choose optimal tile sizes for each device
   );
 
-  Kokkos::Array<int, rank> map = to_array(_map);
+  Kokkos::Array<int, rank> map_array = to_array(map);
   Kokkos::parallel_for(
       "KokkosFFT::transpose", range,
       KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
         for (int i6 = 0; i6 < n6; i6++) {
           for (int i7 = 0; i7 < n7; i7++) {
             int dst_indices[rank] = {i0, i1, i2, i3, i4, i5, i6, i7};
-            int dst_i0            = dst_indices[map[0]];
-            int dst_i1            = dst_indices[map[1]];
-            int dst_i2            = dst_indices[map[2]];
-            int dst_i3            = dst_indices[map[3]];
-            int dst_i4            = dst_indices[map[4]];
-            int dst_i5            = dst_indices[map[5]];
-            int dst_i6            = dst_indices[map[6]];
-            int dst_i7            = dst_indices[map[7]];
+            int dst_i0            = dst_indices[map_array[0]];
+            int dst_i1            = dst_indices[map_array[1]];
+            int dst_i2            = dst_indices[map_array[2]];
+            int dst_i3            = dst_indices[map_array[3]];
+            int dst_i4            = dst_indices[map_array[4]];
+            int dst_i5            = dst_indices[map_array[5]];
+            int dst_i6            = dst_indices[map_array[6]];
+            int dst_i7            = dst_indices[map_array[7]];
 
             out(dst_i0, dst_i1, dst_i2, dst_i3, dst_i4, dst_i5, dst_i6,
                 dst_i7) = in(i0, i1, i2, i3, i4, i5, i6, i7);

--- a/common/unit_test/Test_Helpers.cpp
+++ b/common/unit_test/Test_Helpers.cpp
@@ -37,15 +37,15 @@ void test_fft_freq(T atol = 1.0e-12) {
   auto h_x_odd_ref  = Kokkos::create_mirror_view(x_odd_ref);
   auto h_x_even_ref = Kokkos::create_mirror_view(x_even_ref);
 
-  std::vector<int> _x_odd_ref  = {0, 1, 2, 3, 4, -4, -3, -2, -1};
-  std::vector<int> _x_even_ref = {0, 1, 2, 3, 4, -5, -4, -3, -2, -1};
+  std::vector<int> tmp_x_odd_ref  = {0, 1, 2, 3, 4, -4, -3, -2, -1};
+  std::vector<int> tmp_x_even_ref = {0, 1, 2, 3, 4, -5, -4, -3, -2, -1};
 
-  for (std::size_t i = 0; i < _x_odd_ref.size(); i++) {
-    h_x_odd_ref(i) = static_cast<T>(_x_odd_ref.at(i));
+  for (std::size_t i = 0; i < tmp_x_odd_ref.size(); i++) {
+    h_x_odd_ref(i) = static_cast<T>(tmp_x_odd_ref.at(i));
   }
 
-  for (std::size_t i = 0; i < _x_even_ref.size(); i++) {
-    h_x_even_ref(i) = static_cast<T>(_x_even_ref.at(i));
+  for (std::size_t i = 0; i < tmp_x_even_ref.size(); i++) {
+    h_x_even_ref(i) = static_cast<T>(tmp_x_even_ref.at(i));
   }
 
   Kokkos::deep_copy(x_odd_ref, h_x_odd_ref);
@@ -82,15 +82,15 @@ void test_rfft_freq(T atol = 1.0e-12) {
   auto h_x_odd_ref  = Kokkos::create_mirror_view(x_odd_ref);
   auto h_x_even_ref = Kokkos::create_mirror_view(x_even_ref);
 
-  std::vector<int> _x_odd_ref  = {0, 1, 2, 3, 4};
-  std::vector<int> _x_even_ref = {0, 1, 2, 3, 4, 5};
+  std::vector<int> tmp_x_odd_ref  = {0, 1, 2, 3, 4};
+  std::vector<int> tmp_x_even_ref = {0, 1, 2, 3, 4, 5};
 
-  for (std::size_t i = 0; i < _x_odd_ref.size(); i++) {
-    h_x_odd_ref(i) = static_cast<T>(_x_odd_ref.at(i));
+  for (std::size_t i = 0; i < tmp_x_odd_ref.size(); i++) {
+    h_x_odd_ref(i) = static_cast<T>(tmp_x_odd_ref.at(i));
   }
 
-  for (std::size_t i = 0; i < _x_even_ref.size(); i++) {
-    h_x_even_ref(i) = static_cast<T>(_x_even_ref.at(i));
+  for (std::size_t i = 0; i < tmp_x_even_ref.size(); i++) {
+    h_x_even_ref(i) = static_cast<T>(tmp_x_even_ref.at(i));
   }
 
   Kokkos::deep_copy(x_odd_ref, h_x_odd_ref);
@@ -218,20 +218,20 @@ void test_fftshift1D_1DView(int n0) {
   auto h_x_ref = Kokkos::create_mirror_view(x_ref);
   auto h_y_ref = Kokkos::create_mirror_view(y_ref);
 
-  std::vector<int> _x_ref;
-  std::vector<int> _y_ref;
+  std::vector<int> tmp_x_ref;
+  std::vector<int> tmp_y_ref;
 
   if (n0 % 2 == 0) {
-    _x_ref = {0, 1, 2, 3, 4, -5, -4, -3, -2, -1};
-    _y_ref = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
+    tmp_x_ref = {0, 1, 2, 3, 4, -5, -4, -3, -2, -1};
+    tmp_y_ref = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
   } else {
-    _x_ref = {0, 1, 2, 3, 4, -4, -3, -2, -1};
-    _y_ref = {-4, -3, -2, -1, 0, 1, 2, 3, 4};
+    tmp_x_ref = {0, 1, 2, 3, 4, -4, -3, -2, -1};
+    tmp_y_ref = {-4, -3, -2, -1, 0, 1, 2, 3, 4};
   }
 
   for (int i = 0; i < n0; i++) {
-    h_x_ref(i) = static_cast<double>(_x_ref.at(i));
-    h_y_ref(i) = static_cast<double>(_y_ref.at(i));
+    h_x_ref(i) = static_cast<double>(tmp_x_ref.at(i));
+    h_y_ref(i) = static_cast<double>(tmp_y_ref.at(i));
   }
 
   Kokkos::deep_copy(x_ref, h_x_ref);
@@ -261,34 +261,35 @@ void test_fftshift1D_2DView(int n0) {
   auto h_y_axis0_ref = Kokkos::create_mirror_view(y_axis0_ref);
   auto h_y_axis1_ref = Kokkos::create_mirror_view(y_axis1_ref);
 
-  std::vector<int> _x_ref;
-  std::vector<int> _y0_ref, _y1_ref;
+  std::vector<int> tmp_x_ref;
+  std::vector<int> tmp_y0_ref, tmp_y1_ref;
 
   if (n0 % 2 == 0) {
-    _x_ref  = {0,   1,   2,   3,   4,   5,   6,  7,  8,  9,  10, 11, 12, 13, 14,
-               -15, -14, -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
-    _y0_ref = {
+    tmp_x_ref  = {0,   1,  2,  3,  4,  5,   6,   7,   8,   9,
+                  10,  11, 12, 13, 14, -15, -14, -13, -12, -11,
+                  -10, -9, -8, -7, -6, -5,  -4,  -3,  -2,  -1};
+    tmp_y0_ref = {
         5,  6,  7,  8,  9,  0,  1,  2,  3,  4,  -15, -14, -13, -12, -11,
         10, 11, 12, 13, 14, -5, -4, -3, -2, -1, -10, -9,  -8,  -7,  -6,
     };
-    _y1_ref = {-10, -9, -8, -7, -6, -5,  -4,  -3,  -2,  -1,
-               0,   1,  2,  3,  4,  5,   6,   7,   8,   9,
-               10,  11, 12, 13, 14, -15, -14, -13, -12, -11};
+    tmp_y1_ref = {-10, -9, -8, -7, -6, -5,  -4,  -3,  -2,  -1,
+                  0,   1,  2,  3,  4,  5,   6,   7,   8,   9,
+                  10,  11, 12, 13, 14, -15, -14, -13, -12, -11};
   } else {
-    _x_ref  = {0,   1,   2,   3,   4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
-               -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
-    _y0_ref = {5,  6,  7,  8,  0,  1,  2,  3,  4,  -13, -12, -11, -10, 9,
-               10, 11, 12, 13, -4, -3, -2, -1, -9, -8,  -7,  -6,  -5};
-    _y1_ref = {-9, -8, -7, -6, -5, -4, -3, -2, -1, 0,   1,   2,   3,  4,
-               5,  6,  7,  8,  9,  10, 11, 12, 13, -13, -12, -11, -10};
+    tmp_x_ref  = {0,   1,   2,   3,   4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
+                  -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
+    tmp_y0_ref = {5,  6,  7,  8,  0,  1,  2,  3,  4,  -13, -12, -11, -10, 9,
+                  10, 11, 12, 13, -4, -3, -2, -1, -9, -8,  -7,  -6,  -5};
+    tmp_y1_ref = {-9, -8, -7, -6, -5, -4, -3, -2, -1, 0,   1,   2,   3,  4,
+                  5,  6,  7,  8,  9,  10, 11, 12, 13, -13, -12, -11, -10};
   }
 
   for (int i1 = 0; i1 < n1; i1++) {
     for (int i0 = 0; i0 < n0; i0++) {
       std::size_t i         = i0 + i1 * n0;
-      h_x_ref(i0, i1)       = static_cast<double>(_x_ref.at(i));
-      h_y_axis0_ref(i0, i1) = static_cast<double>(_y0_ref.at(i));
-      h_y_axis1_ref(i0, i1) = static_cast<double>(_y1_ref.at(i));
+      h_x_ref(i0, i1)       = static_cast<double>(tmp_x_ref.at(i));
+      h_y_axis0_ref(i0, i1) = static_cast<double>(tmp_y0_ref.at(i));
+      h_y_axis1_ref(i0, i1) = static_cast<double>(tmp_y1_ref.at(i));
     }
   }
 
@@ -325,26 +326,28 @@ void test_fftshift2D_2DView(int n0) {
   auto h_x_ref = Kokkos::create_mirror_view(x_ref);
   auto h_y_ref = Kokkos::create_mirror_view(y_ref);
 
-  std::vector<int> _x_ref;
-  std::vector<int> _y_ref;
+  std::vector<int> tmp_x_ref;
+  std::vector<int> tmp_y_ref;
 
   if (n0 % 2 == 0) {
-    _x_ref = {0,   1,   2,   3,   4,   5,   6,  7,  8,  9,  10, 11, 12, 13, 14,
-              -15, -14, -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
-    _y_ref = {-5, -4, -3, -2, -1, -10, -9,  -8,  -7,  -6,  5,  6,  7,  8,  9,
-              0,  1,  2,  3,  4,  -15, -14, -13, -12, -11, 10, 11, 12, 13, 14};
+    tmp_x_ref = {0,   1,  2,  3,  4,  5,   6,   7,   8,   9,
+                 10,  11, 12, 13, 14, -15, -14, -13, -12, -11,
+                 -10, -9, -8, -7, -6, -5,  -4,  -3,  -2,  -1};
+    tmp_y_ref = {-5,  -4,  -3,  -2,  -1,  -10, -9, -8, -7, -6,
+                 5,   6,   7,   8,   9,   0,   1,  2,  3,  4,
+                 -15, -14, -13, -12, -11, 10,  11, 12, 13, 14};
   } else {
-    _x_ref = {0,   1,   2,   3,   4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
-              -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
-    _y_ref = {-4, -3, -2, -1, -9,  -8,  -7,  -6,  -5, 5,  6,  7,  8, 0,
-              1,  2,  3,  4,  -13, -12, -11, -10, 9,  10, 11, 12, 13};
+    tmp_x_ref = {0,   1,   2,   3,   4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
+                 -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1};
+    tmp_y_ref = {-4, -3, -2, -1, -9,  -8,  -7,  -6,  -5, 5,  6,  7,  8, 0,
+                 1,  2,  3,  4,  -13, -12, -11, -10, 9,  10, 11, 12, 13};
   }
 
   for (int i1 = 0; i1 < n1; i1++) {
     for (int i0 = 0; i0 < n0; i0++) {
       std::size_t i   = i0 + i1 * n0;
-      h_x_ref(i0, i1) = static_cast<double>(_x_ref.at(i));
-      h_y_ref(i0, i1) = static_cast<double>(_y_ref.at(i));
+      h_x_ref(i0, i1) = static_cast<double>(tmp_x_ref.at(i));
+      h_y_ref(i0, i1) = static_cast<double>(tmp_y_ref.at(i));
     }
   }
 

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -76,15 +76,15 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_cuda_type =
+  static constexpr TransformTypeOnExecSpace m_cuda_type =
       std::is_same_v<T1, float> ? CUFFT_R2C : CUFFT_D2Z;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::R2C
-                                                   : FFTWTransformType::D2Z;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::R2C
+                                : FFTWTransformType::D2Z;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
       return m_cuda_type;
     } else {
@@ -97,15 +97,15 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_cuda_type =
+  static constexpr TransformTypeOnExecSpace m_cuda_type =
       std::is_same_v<T1, float> ? CUFFT_C2R : CUFFT_Z2D;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::C2R
-                                                   : FFTWTransformType::Z2D;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::C2R
+                                : FFTWTransformType::Z2D;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
       return m_cuda_type;
     } else {
@@ -119,15 +119,15 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_cuda_type =
+  static constexpr TransformTypeOnExecSpace m_cuda_type =
       std::is_same_v<T1, float> ? CUFFT_C2C : CUFFT_Z2Z;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::C2C
-                                                   : FFTWTransformType::Z2Z;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::C2C
+                                : FFTWTransformType::Z2Z;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
       return m_cuda_type;
     } else {
@@ -138,13 +138,13 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {
-  static constexpr FFTDirectionType _FORWARD =
+  static constexpr FFTDirectionType FORWARD =
       std::is_same_v<ExecutionSpace, Kokkos::Cuda> ? CUFFT_FORWARD
                                                    : FFTW_FORWARD;
-  static constexpr FFTDirectionType _BACKWARD =
+  static constexpr FFTDirectionType BACKWARD =
       std::is_same_v<ExecutionSpace, Kokkos::Cuda> ? CUFFT_INVERSE
                                                    : FFTW_BACKWARD;
-  return direction == Direction::forward ? _FORWARD : _BACKWARD;
+  return direction == Direction::forward ? FORWARD : BACKWARD;
 }
 #else
 template <typename ExecutionSpace>
@@ -173,20 +173,18 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr cufftType m_type =
       std::is_same_v<T1, float> ? CUFFT_R2C : CUFFT_D2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr cufftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr cufftType m_type =
       std::is_same_v<T2, float> ? CUFFT_C2R : CUFFT_Z2D;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr cufftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -194,10 +192,9 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr cufftType m_type =
       std::is_same_v<T1, float> ? CUFFT_C2C : CUFFT_Z2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr cufftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -76,15 +76,15 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_hip_type =
+  static constexpr TransformTypeOnExecSpace m_hip_type =
       std::is_same_v<T1, float> ? HIPFFT_R2C : HIPFFT_D2Z;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::R2C
-                                                   : FFTWTransformType::D2Z;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::R2C
+                                : FFTWTransformType::D2Z;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
       return m_hip_type;
     } else {
@@ -97,15 +97,15 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_hip_type =
+  static constexpr TransformTypeOnExecSpace m_hip_type =
       std::is_same_v<T1, float> ? HIPFFT_C2R : HIPFFT_Z2D;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::C2R
-                                                   : FFTWTransformType::Z2D;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::C2R
+                                : FFTWTransformType::Z2D;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
       return m_hip_type;
     } else {
@@ -119,15 +119,15 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
+  using TransformTypeOnExecSpace = TransformType<ExecutionSpace>;
 
-  static constexpr _TransformType m_hip_type =
+  static constexpr TransformTypeOnExecSpace m_hip_type =
       std::is_same_v<T1, float> ? HIPFFT_C2C : HIPFFT_Z2Z;
-  static constexpr _TransformType m_cpu_type = std::is_same_v<T1, float>
-                                                   ? FFTWTransformType::C2C
-                                                   : FFTWTransformType::Z2Z;
+  static constexpr TransformTypeOnExecSpace m_cpu_type =
+      std::is_same_v<T1, float> ? FFTWTransformType::C2C
+                                : FFTWTransformType::Z2Z;
 
-  static constexpr _TransformType type() {
+  static constexpr TransformTypeOnExecSpace type() {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
       return m_hip_type;
     } else {
@@ -138,13 +138,13 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {
-  static constexpr FFTDirectionType _FORWARD =
+  static constexpr FFTDirectionType FORWARD =
       std::is_same_v<ExecutionSpace, Kokkos::HIP> ? HIPFFT_FORWARD
                                                   : FFTW_FORWARD;
-  static constexpr FFTDirectionType _BACKWARD =
+  static constexpr FFTDirectionType BACKWARD =
       std::is_same_v<ExecutionSpace, Kokkos::HIP> ? HIPFFT_BACKWARD
                                                   : FFTW_BACKWARD;
-  return direction == Direction::forward ? _FORWARD : _BACKWARD;
+  return direction == Direction::forward ? FORWARD : BACKWARD;
 }
 #else
 template <typename ExecutionSpace>
@@ -173,20 +173,18 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr hipfftType m_type =
       std::is_same_v<T1, float> ? HIPFFT_R2C : HIPFFT_D2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr hipfftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr hipfftType m_type =
       std::is_same_v<T2, float> ? HIPFFT_C2R : HIPFFT_Z2D;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr hipfftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -194,10 +192,9 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-  static constexpr _TransformType m_type =
+  static constexpr hipfftType m_type =
       std::is_same_v<T1, float> ? HIPFFT_C2C : HIPFFT_Z2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr hipfftType type() { return m_type; };
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -55,24 +55,20 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::R2C
-                                               : FFTWTransformType::D2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::R2C
+                                                  : FFTWTransformType::D2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T2, float>
-                                               ? FFTWTransformType::C2R
-                                               : FFTWTransformType::Z2D;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T2, float>
+                                                  ? FFTWTransformType::C2R
+                                                  : FFTWTransformType::Z2D;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -80,12 +76,10 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::C2C
-                                               : FFTWTransformType::Z2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::C2C
+                                                  : FFTWTransformType::Z2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -191,8 +191,8 @@ class Plan {
 
     shape_type<1> s = {0};
     if (n) {
-      std::size_t _n = n.value();
-      s              = shape_type<1>({_n});
+      std::size_t n_tmp = n.value();
+      s                 = shape_type<1>({n_tmp});
     }
 
     m_in_extents               = KokkosFFT::Impl::extract_extents(in);

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -125,7 +125,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   // Create plan
   auto in_strides  = compute_strides<int, std::size_t>(in_extents);
   auto out_strides = compute_strides<int, std::size_t>(out_extents);
-  auto _fft_extents =
+  auto reversed_fft_extents =
       convert_int_type_and_reverse<int, std::size_t>(fft_extents);
 
   // Create the description
@@ -160,10 +160,10 @@ auto create_plan(const ExecutionSpace& exec_space,
   // Create a plan
   plan   = std::make_unique<PlanType>();
   status = rocfft_plan_create(&(*plan), place, fft_direction, precision,
-                              _fft_extents.size(),  // Dimension
-                              _fft_extents.data(),  // Lengths
-                              howmany,              // Number of transforms
-                              description           // Description
+                              reversed_fft_extents.size(),  // Dimension
+                              reversed_fft_extents.data(),  // Lengths
+                              howmany,     // Number of transforms
+                              description  // Description
   );
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_plan_create failed");

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -49,24 +49,20 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::R2C
-                                               : FFTWTransformType::D2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::R2C
+                                                  : FFTWTransformType::D2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T2, float>
-                                               ? FFTWTransformType::C2R
-                                               : FFTWTransformType::Z2D;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T2, float>
+                                                  ? FFTWTransformType::C2R
+                                                  : FFTWTransformType::Z2D;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -74,12 +70,10 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::C2C
-                                               : FFTWTransformType::Z2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::C2C
+                                                  : FFTWTransformType::Z2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 #ifdef ENABLE_HOST_AND_DEVICE
@@ -112,14 +106,14 @@ using FFTInfoType =
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {
-  static constexpr FFTDirectionType _FORWARD =
+  static constexpr FFTDirectionType FORWARD =
       std::is_same_v<ExecutionSpace, Kokkos::HIP> ? ROCFFT_FORWARD
                                                   : FFTW_FORWARD;
 
-  static constexpr FFTDirectionType _BACKWARD =
+  static constexpr FFTDirectionType BACKWARD =
       std::is_same_v<ExecutionSpace, Kokkos::HIP> ? ROCFFT_BACKWARD
                                                   : FFTW_BACKWARD;
-  return direction == Direction::forward ? _FORWARD : _BACKWARD;
+  return direction == Direction::forward ? FORWARD : BACKWARD;
 }
 #else
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -78,23 +78,23 @@ auto create_plan(const ExecutionSpace& exec_space,
                                  std::multiplies<>());
 
   // Create plan
-  auto in_strides   = compute_strides<int, std::int64_t>(in_extents);
-  auto out_strides  = compute_strides<int, std::int64_t>(out_extents);
-  auto _fft_extents = convert_int_type<int, std::int64_t>(fft_extents);
+  auto in_strides        = compute_strides<int, std::int64_t>(in_extents);
+  auto out_strides       = compute_strides<int, std::int64_t>(out_extents);
+  auto int64_fft_extents = convert_int_type<int, std::int64_t>(fft_extents);
 
   // In oneMKL, the distance is always defined based on R2C transform
-  std::int64_t _idist = static_cast<std::int64_t>(std::max(idist, odist));
-  std::int64_t _odist = static_cast<std::int64_t>(std::min(idist, odist));
+  std::int64_t max_idist = static_cast<std::int64_t>(std::max(idist, odist));
+  std::int64_t max_odist = static_cast<std::int64_t>(std::min(idist, odist));
 
-  plan = std::make_unique<PlanType>(_fft_extents);
+  plan = std::make_unique<PlanType>(int64_fft_extents);
   plan->set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
                   in_strides.data());
   plan->set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
                   out_strides.data());
 
   // Configuration for batched plan
-  plan->set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, _idist);
-  plan->set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, _odist);
+  plan->set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, max_idist);
+  plan->set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, max_odist);
   plan->set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
                   static_cast<std::int64_t>(howmany));
 

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -56,24 +56,20 @@ template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::R2C
-                                               : FFTWTransformType::D2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::R2C
+                                                  : FFTWTransformType::D2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T2, float>
-                                               ? FFTWTransformType::C2R
-                                               : FFTWTransformType::Z2D;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T2, float>
+                                                  ? FFTWTransformType::C2R
+                                                  : FFTWTransformType::Z2D;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -81,12 +77,10 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                       Kokkos::complex<T2>> {
   static_assert(std::is_same_v<T1, T2>,
                 "T1 and T2 should have the same precision");
-  using _TransformType = TransformType<ExecutionSpace>;
-
-  static constexpr _TransformType m_type = std::is_same_v<T1, float>
-                                               ? FFTWTransformType::C2C
-                                               : FFTWTransformType::Z2Z;
-  static constexpr _TransformType type() { return m_type; };
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::C2C
+                                                  : FFTWTransformType::Z2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
 };
 
 #ifdef ENABLE_HOST_AND_DEVICE
@@ -178,15 +172,15 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>> {
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {
-  static constexpr FFTDirectionType _FORWARD =
+  static constexpr FFTDirectionType FORWARD =
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>
           ? MKL_FFT_FORWARD
           : FFTW_FORWARD;
-  static constexpr FFTDirectionType _BACKWARD =
+  static constexpr FFTDirectionType BACKWARD =
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>
           ? MKL_FFT_BACKWARD
           : FFTW_BACKWARD;
-  return direction == Direction::forward ? _FORWARD : _BACKWARD;
+  return direction == Direction::forward ? FORWARD : BACKWARD;
 }
 #else
 template <typename ExecutionSpace>


### PR DESCRIPTION
Resolves #81

- [x] Avoid variables starting from under score under `fft/src`
- [x] Avoid variables starting from under score under `fft/unit_test`
- [x] Add `bugprone-reserved-identifier` check in `.clang-tidy`

Added on 28/October after review
- [x] Avoid variables starting from under score under `common/src`
- [x] Avoid variables starting from under score under `common/unit_test`