### PR TITLE
Harmonize the library name as kokkos-fft

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/__build_base.yaml
+++ b/.github/workflows/__build_base.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/__check_docker_files.yaml
+++ b/.github/workflows/__check_docker_files.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/cleanup_base.yaml
+++ b/.github/workflows/cleanup_base.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.github/workflows/pre_build_base.yaml
+++ b/.github/workflows/pre_build_base.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 Multiple people have contributed to kokkos-fft. To show our appreciation for their

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,10 +1,10 @@
 <!--
-SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see below
+SPDX-FileCopyrightText: (C) The kokkos-fft development team, see below
 
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 -->
 
-The Kokkos-FFT project licencing information follows the REUSE specification.
+The kokkos-fft project licencing information follows the REUSE specification.
 
 It is distributed under either:
 * the MIT License whose full text is available in the LICENSES/MIT.txt file,
@@ -12,7 +12,7 @@ or, at your option,
 * the Apache-2.0 licence with LLVM exception whose full text is available in
   the LICENSES/Apache-2.0.txt and LICENSES/LLVM-exception.txt files.
 
-For the purpose of copyright, the Kokkos-FFT development team is defined as follow:
+For the purpose of copyright, the kokkos-fft development team is defined as follow:
 * Centre national de la recherche scientifique (CNRS)
 * Commissariat a l'énergie atomique et aux énergies alternatives (CEA)
 * Université Paris-Saclay

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 -->
@@ -12,10 +12,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 > [!WARNING]
 > EXPERIMENTAL FFT interfaces for Kokkos C++ Performance Portability Programming EcoSystem
 
-Kokkos-fft implements local interfaces between [Kokkos](https://github.com/kokkos/kokkos) and de facto standard FFT libraries, including [fftw](http://www.fftw.org), [cufft](https://developer.nvidia.com/cufft), [hipfft](https://github.com/ROCm/hipFFT) ([rocfft](https://github.com/ROCm/rocFFT)), and [oneMKL](https://spec.oneapi.io/versions/latest/elements/oneMKL/source/index.html). "Local" means not using MPI, or running within a single MPI process without knowing about MPI. We are inclined to implement the [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html)-like interfaces adapted for [Kokkos](https://github.com/kokkos/kokkos).
+kokkos-fft implements local interfaces between [Kokkos](https://github.com/kokkos/kokkos) and de facto standard FFT libraries, including [fftw](http://www.fftw.org), [cufft](https://developer.nvidia.com/cufft), [hipfft](https://github.com/ROCm/hipFFT) ([rocfft](https://github.com/ROCm/rocFFT)), and [oneMKL](https://spec.oneapi.io/versions/latest/elements/oneMKL/source/index.html). "Local" means not using MPI, or running within a single MPI process without knowing about MPI. We are inclined to implement the [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html)-like interfaces adapted for [Kokkos](https://github.com/kokkos/kokkos).
 A key concept is that **"As easy as numpy, as fast as vendor libraries"**. Accordingly, our API follows the API by [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html) with minor differences. A fft library dedicated to Kokkos Device backend (e.g. [cufft](https://developer.nvidia.com/cufft) for CUDA backend) is automatically used. If something is wrong with runtime values (say `View` extents), it will raise runtime errors (C++ `std::runtime_error`). See [documentations](https://kokkosfft.readthedocs.io/) for more information.
 
-Here is an example for 1D real to complex transform with `rfft` in Kokkos-fft.
+Here is an example for 1D real to complex transform with `rfft` in kokkos-fft.
 ```C++
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Complex.hpp>
@@ -43,7 +43,7 @@ x = np.random.rand(4)
 x_hat = np.fft.rfft(x)
 ```
 
-There are two major differences: [`execution_space`](https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html) argument and output value (`x_hat`) is an argument of API (not returned value from API). As imagined, Kokkos-fft only accepts [Kokkos Views](https://kokkos.org/kokkos-core-wiki/API/core/View.html) as input data. The accessibilities of Views from `execution_space` are statically checked (compilation errors if not accessible).
+There are two major differences: [`execution_space`](https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html) argument and output value (`x_hat`) is an argument of API (not returned value from API). As imagined, kokkos-fft only accepts [Kokkos Views](https://kokkos.org/kokkos-core-wiki/API/core/View.html) as input data. The accessibilities of Views from `execution_space` are statically checked (compilation errors if not accessible).
 
 Depending on a View dimension, it automatically uses the batched plans as follows
 ```C++
@@ -79,14 +79,14 @@ In this example, the 1D batched `rfft` over 2D View along `axis -1` is executed.
 ## Disclaimer
 **KokkosFFT is under development and subject to change without warning. The authors do not guarantee that this code runs correctly in all the environments.**
 
-## Using KokkosFFT
-For the moment, there are two ways to use Kokkos-fft: including as a subdirectory in CMake project or installing as a library. First of all, you need to clone this repo.
+## Using kokkos-fft
+For the moment, there are two ways to use kokkos-fft: including as a subdirectory in CMake project or installing as a library. First of all, you need to clone this repo.
 ```bash
 git clone --recursive https://github.com/kokkos/kokkos-fft.git
 ```
 
 ### Prerequisites
-To use Kokkos-fft, we need the followings:
+To use kokkos-fft, we need the followings:
 * `CMake 3.22+`
 * `Kokkos 4.4+`
 * `gcc 8.3.0+` (CPUs)
@@ -95,9 +95,9 @@ To use Kokkos-fft, we need the followings:
 * `rocm 5.3.0+` (AMD GPUs)
 
 ### CMake
-Since Kokkos-fft is a header-only library, it is enough to simply add as a subdirectory. It is assumed that kokkos and Kokkos-fft are placed under `<project_directory>/tpls`.
+Since kokkos-fft is a header-only library, it is enough to simply add as a subdirectory. It is assumed that kokkos and kokkos-fft are placed under `<project_directory>/tpls`.
 
-Here is an example to use Kokkos-fft in the following CMake project.
+Here is an example to use kokkos-fft in the following CMake project.
 ```
 ---/
  |
@@ -136,4 +136,4 @@ This way, all the functionalities are executed on A100 GPUs. For installation, d
 [![License](https://img.shields.io/badge/License-Apache--2.0_WITH_LLVM--exception-blue)](https://spdx.org/licenses/LLVM-exception.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Kokkos-FFT is distributed under either the MIT license, or at your option, the Apache-2.0 licence with LLVM exception.
+kokkos-fft is distributed under either the MIT license, or at your option, the Apache-2.0 licence with LLVM exception.

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/cmake/KokkosFFTConfig.cmake.in
+++ b/cmake/KokkosFFTConfig.cmake.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/cmake/KokkosFFT_Git_Hash.cmake
+++ b/cmake/KokkosFFT_Git_Hash.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/cmake/KokkosFFT_config.h.in
+++ b/cmake/KokkosFFT_config.h.in
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/cmake/KokkosFFT_tpls.cmake
+++ b/cmake/KokkosFFT_tpls.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/cmake/KokkosFFT_utils.cmake
+++ b/cmake/KokkosFFT_utils.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/CMakeLists.txt
+++ b/common/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_asserts.hpp
+++ b/common/src/KokkosFFT_asserts.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_common_types.hpp
+++ b/common/src/KokkosFFT_common_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_layouts.hpp
+++ b/common/src/KokkosFFT_layouts.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_normalization.hpp
+++ b/common/src/KokkosFFT_normalization.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
@@ -35,7 +35,7 @@ struct is_real<
     : std::true_type {};
 
 /// \brief Helper to check if a type is an acceptable real type (float/double)
-/// for Kokkos-FFT
+/// for kokkos-fft
 template <typename T>
 inline constexpr bool is_real_v = is_real<T>::value;
 
@@ -49,7 +49,7 @@ struct is_complex<
     : std::true_type {};
 
 /// \brief Helper to check if a type is an acceptable complex type
-/// (Kokkos::complex<float>/Kokkos::complex<double>) for Kokkos-FFT
+/// (Kokkos::complex<float>/Kokkos::complex<double>) for kokkos-fft
 template <typename T>
 inline constexpr bool is_complex_v = is_complex<T>::value;
 
@@ -69,7 +69,7 @@ struct is_admissible_value_type<
     : std::true_type {};
 
 /// \brief Helper to check if a type is an acceptable value type
-/// (float/double/Kokkos::complex<float>/Kokkos::complex<double>) for Kokkos-FFT
+/// (float/double/Kokkos::complex<float>/Kokkos::complex<double>) for kokkos-fft
 /// When applied to Kokkos::View, then check if a value type is an acceptable
 /// real/complex type.
 template <typename T>
@@ -89,7 +89,7 @@ struct is_layout_left_or_right<
     : std::true_type {};
 
 /// \brief Helper to check if a View layout is an acceptable layout type
-/// (Kokkos::LayoutLeft/Kokkos::LayoutRight) for Kokkos-FFT
+/// (Kokkos::LayoutLeft/Kokkos::LayoutRight) for kokkos-fft
 template <typename ViewType>
 inline constexpr bool is_layout_left_or_right_v =
     is_layout_left_or_right<ViewType>::value;
@@ -104,7 +104,7 @@ struct is_admissible_view<
                                is_admissible_value_type_v<ViewType>>>
     : std::true_type {};
 
-/// \brief Helper to check if a View is an acceptable for Kokkos-FFT. Values and
+/// \brief Helper to check if a View is an acceptable for kokkos-fft. Values and
 /// layout are checked
 template <typename ViewType>
 inline constexpr bool is_admissible_view_v =
@@ -123,7 +123,7 @@ struct is_operatable_view<
             ExecutionSpace, typename ViewType::memory_space>::accessible>>
     : std::true_type {};
 
-/// \brief Helper to check if a View is an acceptable View for Kokkos-FFT and
+/// \brief Helper to check if a View is an acceptable View for kokkos-fft and
 /// memory space is accessible from the ExecutionSpace
 template <typename ExecutionSpace, typename ViewType>
 inline constexpr bool is_operatable_view_v =
@@ -206,7 +206,7 @@ struct are_operatable_views<
         have_same_layout_v<InViewType, OutViewType> &&
         have_same_rank_v<InViewType, OutViewType>>> : std::true_type {};
 
-/// \brief Helper to check if Views are acceptable View for Kokkos-FFT and
+/// \brief Helper to check if Views are acceptable View for kokkos-fft and
 /// memory space are accessible from the ExecutionSpace.
 /// In addition, precisions, layout and rank are checked to be identical.
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Helpers.cpp
+++ b/common/unit_test/Test_Helpers.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Layouts.cpp
+++ b/common/unit_test/Test_Layouts.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Normalization.cpp
+++ b/common/unit_test/Test_Normalization.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Types.hpp
+++ b/common/unit_test/Test_Types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Utils.cpp
+++ b/common/unit_test/Test_Utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/common/unit_test/Test_Utils.hpp
+++ b/common/unit_test/Test_Utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docker/clang/Dockerfile
+++ b/docker/clang/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docker/gcc/Dockerfile
+++ b/docker/gcc/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docker/intel/Dockerfile
+++ b/docker/intel/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docker/nvcc/Dockerfile
+++ b/docker/nvcc/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/helper/fftfreq.rst
+++ b/docs/api/helper/fftfreq.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/helper/fftshift.rst
+++ b/docs/api/helper/fftshift.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/helper/ifftshift.rst
+++ b/docs/api/helper/ifftshift.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/helper/rfftfreq.rst
+++ b/docs/api/helper/rfftfreq.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/hermitian/ihfft.rst
+++ b/docs/api/hermitian/ihfft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/plan.rst
+++ b/docs/api/plan.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/irfft.rst
+++ b/docs/api/real/irfft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/irfft2.rst
+++ b/docs/api/real/irfft2.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/irfftn.rst
+++ b/docs/api/real/irfftn.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/rfft.rst
+++ b/docs/api/real/rfft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/rfft2.rst
+++ b/docs/api/real/rfft2.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/real/rfftn.rst
+++ b/docs/api/real/rfftn.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/fft.rst
+++ b/docs/api/standard/fft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/fft2.rst
+++ b/docs/api/standard/fft2.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/fftn.rst
+++ b/docs/api/standard/fftn.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/ifft.rst
+++ b/docs/api/standard/ifft.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/ifft2.rst
+++ b/docs/api/standard/ifft2.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api/standard/ifftn.rst
+++ b/docs/api/standard/ifftn.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/finding_libraries.rst
+++ b/docs/finding_libraries.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/intro/quick_start.rst
+++ b/docs/intro/quick_start.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/intro/using.rst
+++ b/docs/intro/using.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/01_1DFFT.rst
+++ b/docs/samples/01_1DFFT.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/02_2DFFT.rst
+++ b/docs/samples/02_2DFFT.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/03_NDFFT.rst
+++ b/docs/samples/03_NDFFT.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/04_batchedFFT.rst
+++ b/docs/samples/04_batchedFFT.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/05_1DFFT_HOST_DEVICE.rst
+++ b/docs/samples/05_1DFFT_HOST_DEVICE.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/06_1DFFT_reuse_plans.rst
+++ b/docs/samples/06_1DFFT_reuse_plans.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/docs/samples/07_unmanaged_views.rst
+++ b/docs/samples/07_unmanaged_views.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 ..
 .. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/01_1DFFT/01_1DFFT.cpp
+++ b/examples/01_1DFFT/01_1DFFT.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/01_1DFFT/CMakeLists.txt
+++ b/examples/01_1DFFT/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/01_1DFFT/numpy_1DFFT.py
+++ b/examples/01_1DFFT/numpy_1DFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/02_2DFFT/02_2DFFT.cpp
+++ b/examples/02_2DFFT/02_2DFFT.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/02_2DFFT/CMakeLists.txt
+++ b/examples/02_2DFFT/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/02_2DFFT/numpy_2DFFT.py
+++ b/examples/02_2DFFT/numpy_2DFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/03_NDFFT/03_NDFFT.cpp
+++ b/examples/03_NDFFT/03_NDFFT.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/03_NDFFT/CMakeLists.txt
+++ b/examples/03_NDFFT/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/03_NDFFT/numpy_NDFFT.py
+++ b/examples/03_NDFFT/numpy_NDFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/04_batchedFFT/04_batchedFFT.cpp
+++ b/examples/04_batchedFFT/04_batchedFFT.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/04_batchedFFT/CMakeLists.txt
+++ b/examples/04_batchedFFT/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/04_batchedFFT/numpy_batchedFFT.py
+++ b/examples/04_batchedFFT/numpy_batchedFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/05_1DFFT_HOST_DEVICE/05_1DFFT_HOST_DEVICE.cpp
+++ b/examples/05_1DFFT_HOST_DEVICE/05_1DFFT_HOST_DEVICE.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/05_1DFFT_HOST_DEVICE/CMakeLists.txt
+++ b/examples/05_1DFFT_HOST_DEVICE/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/05_1DFFT_HOST_DEVICE/numpy_1DFFT.py
+++ b/examples/05_1DFFT_HOST_DEVICE/numpy_1DFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
+++ b/examples/06_1DFFT_reuse_plans/06_1DFFT_reuse_plans.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/06_1DFFT_reuse_plans/CMakeLists.txt
+++ b/examples/06_1DFFT_reuse_plans/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/06_1DFFT_reuse_plans/numpy_1DFFT.py
+++ b/examples/06_1DFFT_reuse_plans/numpy_1DFFT.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/07_unmanaged_views/07_unmanaged_views.cpp
+++ b/examples/07_unmanaged_views/07_unmanaged_views.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/07_unmanaged_views/CMakeLists.txt
+++ b/examples/07_unmanaged_views/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/CMakeLists.txt
+++ b/fft/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/Benchmark_Context.hpp
+++ b/fft/perf_test/Benchmark_Context.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/CMakeLists.txt
+++ b/fft/perf_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/PerfTest_FFT1.cpp
+++ b/fft/perf_test/PerfTest_FFT1.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/PerfTest_FFT1.hpp
+++ b/fft/perf_test/PerfTest_FFT1.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/PerfTest_FFT2.cpp
+++ b/fft/perf_test/PerfTest_FFT2.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/perf_test/PerfTest_FFT2.hpp
+++ b/fft/perf_test/PerfTest_FFT2.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/CMakeLists.txt
+++ b/fft/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT.hpp
+++ b/fft/src/KokkosFFT.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_SYCL_transform.hpp
+++ b/fft/src/KokkosFFT_SYCL_transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/src/KokkosFFT_default_types.hpp
+++ b/fft/src/KokkosFFT_default_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/unit_test/CMakeLists.txt
+++ b/fft/unit_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/unit_test/Test_Plans.cpp
+++ b/fft/unit_test/Test_Plans.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/unit_test/Test_Types.hpp
+++ b/fft/unit_test/Test_Types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/fft/unit_test/Test_Utils.hpp
+++ b/fft/unit_test/Test_Utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/install_test/as_library/CMakeLists.txt
+++ b/install_test/as_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/install_test/as_library/hello.cpp
+++ b/install_test/as_library/hello.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/install_test/as_subdirectory/CMakeLists.txt
+++ b/install_test/as_subdirectory/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 

--- a/install_test/as_subdirectory/hello.cpp
+++ b/install_test/as_subdirectory/hello.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 


### PR DESCRIPTION
This PR aims at harmonizing the library name as `kokkos-fft`. 
Because of the Copyright on the top of each file, this PR seems extremely big. 
So, I would like to finish this first and update the docs in the other PR.