### PR TITLE
rename KokkosFFT_layouts.hpp to KokkosFFT_Extents.hpp

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#ifndef KOKKOSFFT_LAYOUTS_HPP
-#define KOKKOSFFT_LAYOUTS_HPP
+#ifndef KOKKOSFFT_EXTENTS_HPP
+#define KOKKOSFFT_EXTENTS_HPP
 
 #include <vector>
 #include <tuple>
@@ -19,6 +19,20 @@ namespace Impl {
 /* Input and output extents exposed to the fft library
    i.e extents are converted into Layout Right
 */
+/// \brief Compute input, output and fft extents required for FFT
+/// libraries based on the input view, output view, axes and shape.
+/// Extents are converted into Layout Right
+///
+/// \tparam InViewType The input view type
+/// \tparam OutViewType The output view type
+/// \tparam DIM         The dimensionality of the axes
+///
+/// \param in [in] Input view
+/// \param out [in] Output view
+/// \param axes [in] Axes over which the FFT operations are performed.
+/// \param shape [in] The new shape of the input view. If the shape is zero,
+/// no modifications are made.
+/// \param is_inplace [in] Whether the FFT is inplace or not
 template <typename InViewType, typename OutViewType, std::size_t DIM = 1>
 auto get_extents(const InViewType& in, const OutViewType& out,
                  axis_type<DIM> axes, shape_type<DIM> shape = {},

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -16,9 +16,6 @@
 
 namespace KokkosFFT {
 namespace Impl {
-/* Input and output extents exposed to the fft library
-   i.e extents are converted into Layout Right
-*/
 /// \brief Compute input, output and fft extents required for FFT
 /// libraries based on the input view, output view, axes and shape.
 /// Extents are converted into Layout Right

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(unit-tests-kokkos-fft-common
     Test_Traits.cpp
     Test_Normalization.cpp
     Test_Transpose.cpp
-    Test_Layouts.cpp
+    Test_Extents.cpp
     Test_Padding.cpp
     Test_Helpers.cpp
 )

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
 #include <vector>
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "Test_Types.hpp"
 #include "Test_Utils.hpp"
 
@@ -13,21 +13,21 @@ using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 
 // Basically the same fixtures, used for labeling tests
 template <typename T>
-struct Layouts1D : public ::testing::Test {
+struct Extents1D : public ::testing::Test {
   using layout_type = T;
 };
 
 template <typename T>
-struct Layouts2D : public ::testing::Test {
+struct Extents2D : public ::testing::Test {
   using layout_type = T;
 };
 
-TYPED_TEST_SUITE(Layouts1D, test_types);
-TYPED_TEST_SUITE(Layouts2D, test_types);
+TYPED_TEST_SUITE(Extents1D, test_types);
+TYPED_TEST_SUITE(Extents2D, test_types);
 
 // Tests for 1D FFT
 template <typename LayoutType>
-void test_layouts_1d() {
+void test_extents_1d() {
   const int n0         = 6;
   using axes_type      = KokkosFFT::axis_type<1>;
   using RealView1Dtype = Kokkos::View<double*, LayoutType, execution_space>;
@@ -90,7 +90,7 @@ void test_layouts_1d() {
 }
 
 template <typename LayoutType>
-void test_layouts_1d_batched_FFT_2d() {
+void test_extents_1d_batched_FFT_2d() {
   const int n0 = 6, n1 = 10;
   using axes_type      = KokkosFFT::axis_type<1>;
   using RealView2Dtype = Kokkos::View<double**, LayoutType, execution_space>;
@@ -179,7 +179,7 @@ void test_layouts_1d_batched_FFT_2d() {
 }
 
 template <typename LayoutType>
-void test_layouts_1d_batched_FFT_3d() {
+void test_extents_1d_batched_FFT_3d() {
   const int n0 = 6, n1 = 10, n2 = 8;
   using axes_type      = KokkosFFT::axis_type<1>;
   using RealView3Dtype = Kokkos::View<double***, LayoutType, execution_space>;
@@ -308,27 +308,27 @@ void test_layouts_1d_batched_FFT_3d() {
   EXPECT_EQ(howmany_c2c_axis2, ref_howmany_r2c_axis2);
 }
 
-TYPED_TEST(Layouts1D, 1DFFT_1DView) {
+TYPED_TEST(Extents1D, 1DFFT_1DView) {
   using layout_type = typename TestFixture::layout_type;
 
-  test_layouts_1d<layout_type>();
+  test_extents_1d<layout_type>();
 }
 
-TYPED_TEST(Layouts1D, 1DFFT_batched_2DView) {
+TYPED_TEST(Extents1D, 1DFFT_batched_2DView) {
   using layout_type = typename TestFixture::layout_type;
 
-  test_layouts_1d_batched_FFT_2d<layout_type>();
+  test_extents_1d_batched_FFT_2d<layout_type>();
 }
 
-TYPED_TEST(Layouts1D, 1DFFT_batched_3DView) {
+TYPED_TEST(Extents1D, 1DFFT_batched_3DView) {
   using layout_type = typename TestFixture::layout_type;
 
-  test_layouts_1d_batched_FFT_3d<layout_type>();
+  test_extents_1d_batched_FFT_3d<layout_type>();
 }
 
 // Tests for 2D FFT
 template <typename LayoutType>
-void test_layouts_2d() {
+void test_extents_2d() {
   const int n0 = 6, n1 = 10;
   using axes_type      = KokkosFFT::axis_type<2>;
   using RealView2Dtype = Kokkos::View<double**, LayoutType, execution_space>;
@@ -432,7 +432,7 @@ void test_layouts_2d() {
 }
 
 template <typename LayoutType>
-void test_layouts_2d_batched_FFT_3d() {
+void test_extents_2d_batched_FFT_3d() {
   const int n0 = 6, n1 = 10, n2 = 8;
   using axes_type      = KokkosFFT::axis_type<2>;
   using RealView3Dtype = Kokkos::View<double***, LayoutType, execution_space>;
@@ -711,14 +711,14 @@ void test_layouts_2d_batched_FFT_3d() {
   EXPECT_EQ(howmany_c2c_axis_21, ref_howmany_r2c_axis_21);
 }
 
-TYPED_TEST(Layouts2D, 2DFFT_2DView) {
+TYPED_TEST(Extents2D, 2DFFT_2DView) {
   using layout_type = typename TestFixture::layout_type;
 
-  test_layouts_2d<layout_type>();
+  test_extents_2d<layout_type>();
 }
 
-TYPED_TEST(Layouts2D, 2DFFT_3DView) {
+TYPED_TEST(Extents2D, 2DFFT_3DView) {
   using layout_type = typename TestFixture::layout_type;
 
-  test_layouts_2d_batched_FFT_3d<layout_type>();
+  test_extents_2d_batched_FFT_3d<layout_type>();
 }

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -7,7 +7,7 @@
 
 #include <numeric>
 #include "KokkosFFT_Cuda_types.hpp"
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_asserts.hpp"
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -7,7 +7,7 @@
 
 #include <numeric>
 #include "KokkosFFT_HIP_types.hpp"
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_asserts.hpp"
 

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -7,7 +7,7 @@
 
 #include <numeric>
 #include "KokkosFFT_default_types.hpp"
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <algorithm>
 #include "KokkosFFT_ROCM_types.hpp"
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_asserts.hpp"
 #include "KokkosFFT_utils.hpp"

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <algorithm>
 #include "KokkosFFT_SYCL_types.hpp"
-#include "KokkosFFT_layouts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_utils.hpp"
 


### PR DESCRIPTION
In this PR, `KokkosFFT_layouts.hpp` is renamed as `KokkosFFT_Extents.hpp`.
All the header files are planned to be renamed in this manner (`KokkosFFT_` + name in Uppercase).