### PR TITLE
allow to continue run tests even if ruche CI fails

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -313,7 +313,6 @@ jobs:
     strategy:
       matrix:
         backend:
-          unstable: [false]
           # run CUDA tests on Ruche supercomputer with Singularity
           - name: cuda
             image: nvcc
@@ -325,16 +324,19 @@ jobs:
             image: gcc
             runner: ubuntu-latest
             use_singularity: false
+            unstable: false
           # run Threads tests on Azure server
           - name: threads
             image: gcc
             runner: ubuntu-latest
             use_singularity: false
+            unstable: false
           # run Serial tests on Azure server
           - name: serial
             image: gcc
             runner: ubuntu-latest
             use_singularity: false
+            unstable: false
 
     steps:
       - name: Get artifacts

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -311,6 +311,7 @@ jobs:
     if: ${{ ! cancelled() && needs.build.result == 'success' }}
 
     strategy:
+      fail-fast: false
       matrix:
         unstable: [false]
         backend:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -301,6 +301,7 @@ jobs:
   # test the project
   test:
     runs-on: ${{ matrix.backend.runner }}
+    continue-on-error: ${{ matrix.unstable }}
 
     needs:
       - check_docker_files
@@ -311,12 +312,14 @@ jobs:
 
     strategy:
       matrix:
+        unstable: [false]
         backend:
           # run CUDA tests on Ruche supercomputer with Singularity
           - name: cuda
             image: nvcc
             runner: [self-hosted, cuda]
             use_singularity: true
+            unstable: true
           # run OpenMP tests on Azure server
           - name: openmp
             image: gcc

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -301,7 +301,7 @@ jobs:
   # test the project
   test:
     runs-on: ${{ matrix.backend.runner }}
-    continue-on-error: ${{ matrix.unstable }}
+    continue-on-error: ${{ matrix.backend.unstable }}
 
     needs:
       - check_docker_files
@@ -311,10 +311,9 @@ jobs:
     if: ${{ ! cancelled() && needs.build.result == 'success' }}
 
     strategy:
-      fail-fast: false
       matrix:
-        unstable: [false]
         backend:
+          unstable: [false]
           # run CUDA tests on Ruche supercomputer with Singularity
           - name: cuda
             image: nvcc


### PR DESCRIPTION
In this RP, we allow to continue run tests even if ruche CI fails. 