### PR TITLE
Fix RAII issue by introducing wrapper classes for backend plans

### DIFF
--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -33,13 +33,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan = std::make_unique<PlanType>();
-
-  cudaStream_t stream  = exec_space.cuda_stream();
-  cufftResult cufft_rt = cufftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
@@ -47,12 +40,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  cufft_rt = cufftPlan1d(&((*plan).plan()), nx, type, howmany);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan1d failed");
-
-  cudaStream_t stream = exec_space.cuda_stream();
-  cufft_rt            = cufftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, type, howmany);
 
   return fft_size;
 }
@@ -77,13 +65,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan = std::make_unique<PlanType>();
-
-  cudaStream_t stream  = exec_space.cuda_stream();
-  cufftResult cufft_rt = cufftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -91,13 +72,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  cufft_rt = cufftPlan2d(&((*plan).plan()), nx, ny, type);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan2d failed");
-
-  cudaStream_t stream = exec_space.cuda_stream();
-  cufft_rt            = cufftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, ny, type);
 
   return fft_size;
 }
@@ -122,13 +97,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan = std::make_unique<PlanType>();
-
-  cudaStream_t stream  = exec_space.cuda_stream();
-  cufftResult cufft_rt = cufftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -138,13 +106,7 @@ auto create_plan(const ExecutionSpace& exec_space,
             nz = fft_extents.at(2);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  cufft_rt = cufftPlan3d(&((*plan).plan()), nx, ny, nz, type);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan3d failed");
-
-  cudaStream_t stream = exec_space.cuda_stream();
-  cufft_rt            = cufftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, ny, nz, type);
 
   return fft_size;
 }
@@ -189,21 +151,9 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-  plan = std::make_unique<PlanType>();
-
-  cudaStream_t stream  = exec_space.cuda_stream();
-  cufftResult cufft_rt = cufftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
-
-  cufft_rt = cufftPlanMany(&((*plan).plan()), rank, fft_extents.data(),
-                           in_extents.data(), istride, idist,
-                           out_extents.data(), ostride, odist, type, howmany);
-
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlanMany failed");
-
-  cudaStream_t stream = exec_space.cuda_stream();
-  cufft_rt            = cufftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
+  plan = std::make_unique<PlanType>(
+      exec_space, rank, fft_extents.data(), in_extents.data(), istride, idist,
+      out_extents.data(), ostride, odist, type, howmany);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -15,15 +15,14 @@ namespace KokkosFFT {
 namespace Impl {
 // 1D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 1 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<1> axes, shape_type<1> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -60,15 +59,14 @@ auto create_plan(const ExecutionSpace& exec_space,
 
 // 2D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 2 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<2> axes, shape_type<2> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -106,15 +104,14 @@ auto create_plan(const ExecutionSpace& exec_space,
 
 // 3D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 3 &&
                                std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<3> axes, shape_type<3> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -154,15 +151,14 @@ auto create_plan(const ExecutionSpace& exec_space,
 
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
-          std::size_t fft_rank             = 1,
+          typename OutViewType, std::size_t fft_rank = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -40,7 +40,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, type, howmany);
+  plan         = std::make_unique<PlanType>(nx, type, howmany);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -72,7 +73,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, ny, type);
+  plan         = std::make_unique<PlanType>(nx, ny, type);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -106,7 +108,8 @@ auto create_plan(const ExecutionSpace& exec_space,
             nz = fft_extents.at(2);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, ny, nz, type);
+  plan         = std::make_unique<PlanType>(nx, ny, nz, type);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -151,9 +154,10 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-  plan = std::make_unique<PlanType>(
-      exec_space, rank, fft_extents.data(), in_extents.data(), istride, idist,
-      out_extents.data(), ostride, odist, type, howmany);
+  plan = std::make_unique<PlanType>(rank, fft_extents.data(), in_extents.data(),
+                                    istride, idist, out_extents.data(), ostride,
+                                    odist, type, howmany);
+  plan->commit(exec_space);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -189,8 +189,7 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-
-  plan                 = std::make_unique<PlanType>();
+  plan = std::make_unique<PlanType>();
 
   cudaStream_t stream  = exec_space.cuda_stream();
   cufftResult cufft_rt = cufftSetStream((*plan).plan(), stream);

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -10,45 +10,47 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftReal* idata, cufftComplex* odata,
-                      int /*direction*/, Args...) {
-  cufftResult cufft_rt = cufftExecR2C(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftReal* idata,
+                      cufftComplex* odata, int /*direction*/) {
+  cufftResult cufft_rt = cufftExecR2C(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecR2C failed");
 }
 
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftDoubleReal* idata,
-                      cufftDoubleComplex* odata, int /*direction*/, Args...) {
-  cufftResult cufft_rt = cufftExecD2Z(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleReal* idata,
+                      cufftDoubleComplex* odata, int /*direction*/) {
+  cufftResult cufft_rt = cufftExecD2Z(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecD2Z failed");
 }
 
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftComplex* idata, cufftReal* odata,
-                      int /*direction*/, Args...) {
-  cufftResult cufft_rt = cufftExecC2R(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftComplex* idata,
+                      cufftReal* odata, int /*direction*/) {
+  cufftResult cufft_rt = cufftExecC2R(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2R failed");
 }
 
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
-                      cufftDoubleReal* odata, int /*direction*/, Args...) {
-  cufftResult cufft_rt = cufftExecZ2D(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleComplex* idata,
+                      cufftDoubleReal* odata, int /*direction*/) {
+  cufftResult cufft_rt = cufftExecZ2D(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2D failed");
 }
 
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftComplex* idata,
-                      cufftComplex* odata, int direction, Args...) {
-  cufftResult cufft_rt = cufftExecC2C(plan, idata, odata, direction);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftComplex* idata,
+                      cufftComplex* odata, int direction) {
+  cufftResult cufft_rt =
+      cufftExecC2C(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2C failed");
 }
 
-template <typename... Args>
-inline void exec_plan(cufftHandle& plan, cufftDoubleComplex* idata,
-                      cufftDoubleComplex* odata, int direction, Args...) {
-  cufftResult cufft_rt = cufftExecZ2Z(plan, idata, odata, direction);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleComplex* idata,
+                      cufftDoubleComplex* odata, int direction) {
+  cufftResult cufft_rt =
+      cufftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2Z failed");
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -10,45 +10,45 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftReal* idata,
+
+struct ScopedCufftPlan;
+
+inline void exec_plan(const ScopedCufftPlan& scoped_plan, cufftReal* idata,
                       cufftComplex* odata, int /*direction*/) {
   cufftResult cufft_rt = cufftExecR2C(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecR2C failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleReal* idata,
-                      cufftDoubleComplex* odata, int /*direction*/) {
+inline void exec_plan(const ScopedCufftPlan& scoped_plan,
+                      cufftDoubleReal* idata, cufftDoubleComplex* odata,
+                      int /*direction*/) {
   cufftResult cufft_rt = cufftExecD2Z(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecD2Z failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftComplex* idata,
+inline void exec_plan(const ScopedCufftPlan& scoped_plan, cufftComplex* idata,
                       cufftReal* odata, int /*direction*/) {
   cufftResult cufft_rt = cufftExecC2R(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2R failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleComplex* idata,
-                      cufftDoubleReal* odata, int /*direction*/) {
+inline void exec_plan(const ScopedCufftPlan& scoped_plan,
+                      cufftDoubleComplex* idata, cufftDoubleReal* odata,
+                      int /*direction*/) {
   cufftResult cufft_rt = cufftExecZ2D(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2D failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftComplex* idata,
+inline void exec_plan(const ScopedCufftPlan& scoped_plan, cufftComplex* idata,
                       cufftComplex* odata, int direction) {
   cufftResult cufft_rt =
       cufftExecC2C(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecC2C failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, cufftDoubleComplex* idata,
-                      cufftDoubleComplex* odata, int direction) {
+inline void exec_plan(const ScopedCufftPlan& scoped_plan,
+                      cufftDoubleComplex* idata, cufftDoubleComplex* odata,
+                      int direction) {
   cufftResult cufft_rt =
       cufftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftExecZ2Z failed");

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -6,12 +6,10 @@
 #define KOKKOSFFT_CUDA_TRANSFORM_HPP
 
 #include <cufft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Cuda_types.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-
-struct ScopedCufftPlan;
 
 inline void exec_plan(const ScopedCufftPlan& scoped_plan, cufftReal* idata,
                       cufftComplex* odata, int /*direction*/) {

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -6,6 +6,7 @@
 #define KOKKOSFFT_CUDA_TRANSFORM_HPP
 
 #include <cufft.h>
+#include "KokkosFFT_asserts.hpp"
 #include "KokkosFFT_Cuda_types.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -24,7 +24,6 @@ namespace Impl {
 using FFTDirectionType = int;
 
 /// \brief A class that wraps cufft for RAII
-template <typename ExecutionSpace, typename T1, typename T2>
 struct ScopedCufftPlanType {
   cufftHandle m_plan;
 
@@ -129,7 +128,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftw_plan_type  = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
-  using cufft_plan_type = ScopedCufftPlanType<ExecutionSpace, T1, T2>;
+  using cufft_plan_type = ScopedCufftPlanType;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                                   cufft_plan_type, fftw_plan_type>;
 };
@@ -192,7 +191,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedCufftPlanType<ExecutionSpace, T1, T2>;
+  using type = ScopedCufftPlanType;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -67,7 +67,7 @@ struct ScopedCufftPlan {
   ScopedCufftPlan(ScopedCufftPlan &&)                 = delete;
 
   cufftHandle plan() const noexcept { return m_plan; }
-  void commit(const Kokkos::Cuda &exec_space) {
+  void commit(const Kokkos::Cuda &exec_space) const {
     cufftResult cufft_rt = cufftSetStream(m_plan, exec_space.cuda_stream());
     KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
   }

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -73,7 +73,6 @@ struct ScopedCufftPlan {
   ScopedCufftPlan &operator=(ScopedCufftPlan &&)      = delete;
   ScopedCufftPlan(ScopedCufftPlan &&)                 = delete;
 
-  // cufftHandle &plan() { return m_plan; }
   cufftHandle plan() const noexcept { return m_plan; }
 
  private:

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -8,6 +8,10 @@
 #include <cufft.h>
 #include "KokkosFFT_common_types.hpp"
 
+#if defined(ENABLE_HOST_AND_DEVICE)
+#include "KokkosFFT_FFTW_Types.hpp"
+#endif
+
 // Check the size of complex type
 static_assert(sizeof(cufftComplex) == sizeof(Kokkos::complex<float>));
 static_assert(alignof(cufftComplex) <= alignof(Kokkos::complex<float>));
@@ -15,23 +19,9 @@ static_assert(alignof(cufftComplex) <= alignof(Kokkos::complex<float>));
 static_assert(sizeof(cufftDoubleComplex) == sizeof(Kokkos::complex<double>));
 static_assert(alignof(cufftDoubleComplex) <= alignof(Kokkos::complex<double>));
 
-#if defined(ENABLE_HOST_AND_DEVICE)
-#include <fftw3.h>
-#include "KokkosFFT_utils.hpp"
-static_assert(sizeof(fftwf_complex) == sizeof(Kokkos::complex<float>));
-static_assert(alignof(fftwf_complex) <= alignof(Kokkos::complex<float>));
-
-static_assert(sizeof(fftw_complex) == sizeof(Kokkos::complex<double>));
-static_assert(alignof(fftw_complex) <= alignof(Kokkos::complex<double>));
-#endif
-
 namespace KokkosFFT {
 namespace Impl {
 using FFTDirectionType = int;
-
-// Unused
-template <typename ExecutionSpace>
-using FFTInfoType = int;
 
 /// \brief A class that wraps cufft for RAII
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -45,8 +35,6 @@ struct ScopedCufftPlanType {
 };
 
 #if defined(ENABLE_HOST_AND_DEVICE)
-enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
-
 template <typename ExecutionSpace>
 struct FFTDataType {
   using float32 =
@@ -135,93 +123,6 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
     } else {
       return m_cpu_type;
     }
-  }
-};
-
-/// \brief A class that wraps fftw_plan and fftwf_plan for RAII
-template <typename ExecutionSpace, typename T1, typename T2>
-struct ScopedFFTWPlanType {
-  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T1>;
-  using plan_type =
-      std::conditional_t<std::is_same_v<floating_point_type, float>, fftwf_plan,
-                         fftw_plan>;
-  plan_type m_plan;
-  bool m_is_created = false;
-
-  ScopedFFTWPlanType() {}
-  ~ScopedFFTWPlanType() {
-    cleanup_threads<floating_point_type>();
-    if constexpr (std::is_same_v<floating_point_type, float>) {
-      if (m_is_created) fftwf_destroy_plan(m_plan);
-    } else {
-      if (m_is_created) fftw_destroy_plan(m_plan);
-    }
-  }
-
-  const plan_type &plan() const { return m_plan; }
-
-  template <typename InScalarType, typename OutScalarType>
-  void create(const ExecutionSpace &exec_space, int rank, const int *n,
-              int howmany, InScalarType *in, const int *inembed, int istride,
-              int idist, OutScalarType *out, const int *onembed, int ostride,
-              int odist, [[maybe_unused]] int sign, unsigned flags) {
-    init_threads<floating_point_type>(exec_space);
-
-    constexpr auto type =
-        KokkosFFT::Impl::transform_type<ExecutionSpace, T1, T2>::type();
-
-    if constexpr (type == KokkosFFT::Impl::FFTWTransformType::R2C) {
-      m_plan =
-          fftwf_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::D2Z) {
-      m_plan =
-          fftw_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
-                                 out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2R) {
-      m_plan =
-          fftwf_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2D) {
-      m_plan =
-          fftw_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
-                                 out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2C) {
-      m_plan =
-          fftwf_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
-                              out, onembed, ostride, odist, sign, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2Z) {
-      m_plan = fftw_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, sign, flags);
-    }
-    m_is_created = true;
-  }
-
- private:
-  template <typename T>
-  void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
-#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
-    int nthreads = exec_space.concurrency();
-
-    if constexpr (std::is_same_v<T, float>) {
-      fftwf_init_threads();
-      fftwf_plan_with_nthreads(nthreads);
-    } else {
-      fftw_init_threads();
-      fftw_plan_with_nthreads(nthreads);
-    }
-#endif
-  }
-
-  template <typename T>
-  void cleanup_threads() {
-#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
-    if constexpr (std::is_same_v<T, float>) {
-      fftwf_cleanup_threads();
-    } else {
-      fftw_cleanup_threads();
-    }
-#endif
   }
 };
 

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -32,59 +32,28 @@ struct ScopedCufftPlan {
   cufftHandle m_plan;
 
  public:
-  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, cufftType type,
+  ScopedCufftPlan(int nx, cufftType type, int batch) {
+    cufftResult cufft_rt = cufftPlan1d(&m_plan, nx, type, batch);
+    KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan1d failed");
+  }
+
+  ScopedCufftPlan(int nx, int ny, cufftType type) {
+    cufftResult cufft_rt = cufftPlan2d(&m_plan, nx, ny, type);
+    KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan2d failed");
+  }
+
+  ScopedCufftPlan(int nx, int ny, int nz, cufftType type) {
+    cufftResult cufft_rt = cufftPlan3d(&m_plan, nx, ny, nz, type);
+    KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan3d failed");
+  }
+
+  ScopedCufftPlan(int rank, int *n, int *inembed, int istride, int idist,
+                  int *onembed, int ostride, int odist, cufftType type,
                   int batch) {
-    try {
-      cufftResult cufft_rt = cufftPlan1d(&m_plan, nx, type, batch);
-      KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan1d failed");
-      set_stream(exec_space);
-    } catch (const std::runtime_error &e) {
-      std::cerr << e.what() << std::endl;
-      cleanup();
-      throw;
-    }
-  }
-
-  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, int ny,
-                  cufftType type) {
-    try {
-      cufftResult cufft_rt = cufftPlan2d(&m_plan, nx, ny, type);
-      KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan2d failed");
-      set_stream(exec_space);
-    } catch (const std::runtime_error &e) {
-      std::cerr << e.what() << std::endl;
-      cleanup();
-      throw;
-    }
-  }
-
-  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, int ny, int nz,
-                  cufftType type) {
-    try {
-      cufftResult cufft_rt = cufftPlan3d(&m_plan, nx, ny, nz, type);
-      KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan3d failed");
-      set_stream(exec_space);
-    } catch (const std::runtime_error &e) {
-      std::cerr << e.what() << std::endl;
-      cleanup();
-      throw;
-    }
-  }
-
-  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int rank, int *n,
-                  int *inembed, int istride, int idist, int *onembed,
-                  int ostride, int odist, cufftType type, int batch) {
-    try {
-      cufftResult cufft_rt =
-          cufftPlanMany(&m_plan, rank, n, inembed, istride, idist, onembed,
-                        ostride, odist, type, batch);
-      KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlanMany failed");
-      set_stream(exec_space);
-    } catch (const std::runtime_error &e) {
-      std::cerr << e.what() << std::endl;
-      cleanup();
-      throw;
-    }
+    cufftResult cufft_rt =
+        cufftPlanMany(&m_plan, rank, n, inembed, istride, idist, onembed,
+                      ostride, odist, type, batch);
+    KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlanMany failed");
   }
 
   ~ScopedCufftPlan() noexcept { cleanup(); }
@@ -96,17 +65,22 @@ struct ScopedCufftPlan {
   ScopedCufftPlan(ScopedCufftPlan &&)                 = delete;
 
   cufftHandle plan() const noexcept { return m_plan; }
+  void commit(const Kokkos::Cuda &exec_space) {
+    cudaStream_t stream = exec_space.cuda_stream();
+    try {
+      cufftResult cufft_rt = cufftSetStream(m_plan, stream);
+      KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
+    } catch (const std::runtime_error &e) {
+      std::cerr << e.what() << std::endl;
+      cleanup();
+      throw;
+    }
+  }
 
  private:
   void cleanup() {
     cufftResult cufft_rt = cufftDestroy(m_plan);
     if (cufft_rt != CUFFT_SUCCESS) Kokkos::abort("cufftDestroy failed");
-  }
-
-  void set_stream(const Kokkos::Cuda &exec_space) {
-    cudaStream_t stream  = exec_space.cuda_stream();
-    cufftResult cufft_rt = cufftSetStream(m_plan, stream);
-    KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
   }
 };
 

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -26,34 +26,33 @@ namespace Impl {
 using FFTDirectionType = int;
 
 /// \brief A class that wraps cufft for RAII
-template <typename ExecutionSpace>
 struct ScopedCufftPlan {
  private:
   cufftHandle m_plan;
 
  public:
-  ScopedCufftPlan(const ExecutionSpace &exec_space, int nx, cufftType type,
+  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, cufftType type,
                   int batch) {
     cufftResult cufft_rt = cufftPlan1d(&m_plan, nx, type, batch);
     KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan1d failed");
     set_stream(exec_space);
   }
 
-  ScopedCufftPlan(const ExecutionSpace &exec_space, int nx, int ny,
+  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, int ny,
                   cufftType type) {
     cufftResult cufft_rt = cufftPlan2d(&m_plan, nx, ny, type);
     KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan2d failed");
     set_stream(exec_space);
   }
 
-  ScopedCufftPlan(const ExecutionSpace &exec_space, int nx, int ny, int nz,
+  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int nx, int ny, int nz,
                   cufftType type) {
     cufftResult cufft_rt = cufftPlan3d(&m_plan, nx, ny, nz, type);
     KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftPlan3d failed");
     set_stream(exec_space);
   }
 
-  ScopedCufftPlan(const ExecutionSpace &exec_space, int rank, int *n,
+  ScopedCufftPlan(const Kokkos::Cuda &exec_space, int rank, int *n,
                   int *inembed, int istride, int idist, int *onembed,
                   int ostride, int odist, cufftType type, int batch) {
     cufftResult cufft_rt =
@@ -74,10 +73,11 @@ struct ScopedCufftPlan {
   ScopedCufftPlan &operator=(ScopedCufftPlan &&)      = delete;
   ScopedCufftPlan(ScopedCufftPlan &&)                 = delete;
 
-  cufftHandle &plan() { return m_plan; }
+  // cufftHandle &plan() { return m_plan; }
+  cufftHandle plan() const noexcept { return m_plan; }
 
  private:
-  void set_stream(const ExecutionSpace &exec_space) {
+  void set_stream(const Kokkos::Cuda &exec_space) {
     cudaStream_t stream  = exec_space.cuda_stream();
     cufftResult cufft_rt = cufftSetStream(m_plan, stream);
     KOKKOSFFT_THROW_IF(cufft_rt != CUFFT_SUCCESS, "cufftSetStream failed");
@@ -179,7 +179,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftw_plan_type  = ScopedFFTWPlan<ExecutionSpace, T1, T2>;
-  using cufft_plan_type = ScopedCufftPlan<ExecutionSpace>;
+  using cufft_plan_type = ScopedCufftPlan;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::Cuda>,
                                   cufft_plan_type, fftw_plan_type>;
 };
@@ -242,7 +242,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedCufftPlan<ExecutionSpace>;
+  using type = ScopedCufftPlan;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -5,7 +5,6 @@
 #ifndef KOKKOSFFT_FFTW_TYPES_HPP
 #define KOKKOSFFT_FFTW_TYPES_HPP
 
-#include <mutex>
 #include <fftw3.h>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -121,7 +121,7 @@ struct ScopedFFTWPlan {
   plan_type plan() const noexcept { return m_plan; }
 
  private:
-  void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
+  static void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
     if constexpr (std::is_same_v<ExecutionSpace,
                                  Kokkos::DefaultHostExecutionSpace>) {
@@ -138,7 +138,7 @@ struct ScopedFFTWPlan {
 #endif
   }
 
-  void cleanup_threads() {
+  static void cleanup_threads() {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
     if constexpr (std::is_same_v<ExecutionSpace,
                                  Kokkos::DefaultHostExecutionSpace>) {

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -68,7 +68,6 @@ struct ScopedFFTWPlan {
       std::conditional_t<std::is_same_v<floating_point_type, float>, fftwf_plan,
                          fftw_plan>;
   plan_type m_plan;
-  bool m_is_created = false;
 
  public:
   template <typename InScalarType, typename OutScalarType>
@@ -102,15 +101,14 @@ struct ScopedFFTWPlan {
       m_plan = fftw_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
                                   out, onembed, ostride, odist, sign, flags);
     }
-    m_is_created = true;
   }
 
   ~ScopedFFTWPlan() noexcept {
     cleanup_threads();
     if constexpr (std::is_same_v<plan_type, fftwf_plan>) {
-      if (m_is_created) fftwf_destroy_plan(m_plan);
+      fftwf_destroy_plan(m_plan);
     } else {
-      if (m_is_created) fftw_destroy_plan(m_plan);
+      fftw_destroy_plan(m_plan);
     }
   }
 

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -131,7 +131,7 @@ struct ScopedFFTWPlan {
     return global_id++;
   }
 
-  static void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
+  void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
     if constexpr (std::is_same_v<ExecutionSpace,
                                  Kokkos::DefaultHostExecutionSpace>) {
@@ -148,7 +148,7 @@ struct ScopedFFTWPlan {
 #endif
   }
 
-  static void cleanup_threads() {
+  void cleanup_threads() {
 #if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
     if constexpr (std::is_same_v<ExecutionSpace,
                                  Kokkos::DefaultHostExecutionSpace>) {

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_FFTW_TYPES_HPP
+#define KOKKOSFFT_FFTW_TYPES_HPP
+
+#include <fftw3.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_utils.hpp"
+
+// Check the size of complex type
+static_assert(sizeof(fftwf_complex) == sizeof(Kokkos::complex<float>));
+static_assert(alignof(fftwf_complex) <= alignof(Kokkos::complex<float>));
+
+static_assert(sizeof(fftw_complex) == sizeof(Kokkos::complex<double>));
+static_assert(alignof(fftw_complex) <= alignof(Kokkos::complex<double>));
+
+namespace KokkosFFT {
+namespace Impl {
+
+enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
+
+// Define fft transform types
+template <typename ExecutionSpace, typename T1, typename T2>
+struct fftw_transform_type {
+  static_assert(std::is_same_v<T1, T2>,
+                "Real to real transform is unavailable");
+};
+
+template <typename ExecutionSpace, typename T1, typename T2>
+struct fftw_transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
+  static_assert(std::is_same_v<T1, T2>,
+                "T1 and T2 should have the same precision");
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::R2C
+                                                  : FFTWTransformType::D2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
+};
+
+template <typename ExecutionSpace, typename T1, typename T2>
+struct fftw_transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
+  static_assert(std::is_same_v<T1, T2>,
+                "T1 and T2 should have the same precision");
+  static constexpr FFTWTransformType m_type = std::is_same_v<T2, float>
+                                                  ? FFTWTransformType::C2R
+                                                  : FFTWTransformType::Z2D;
+  static constexpr FFTWTransformType type() { return m_type; };
+};
+
+template <typename ExecutionSpace, typename T1, typename T2>
+struct fftw_transform_type<ExecutionSpace, Kokkos::complex<T1>,
+                           Kokkos::complex<T2>> {
+  static_assert(std::is_same_v<T1, T2>,
+                "T1 and T2 should have the same precision");
+  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
+                                                  ? FFTWTransformType::C2C
+                                                  : FFTWTransformType::Z2Z;
+  static constexpr FFTWTransformType type() { return m_type; };
+};
+
+/// \brief A class that wraps fftw_plan and fftwf_plan for RAII
+template <typename ExecutionSpace, typename T1, typename T2>
+struct ScopedFFTWPlanType {
+  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T1>;
+  using plan_type =
+      std::conditional_t<std::is_same_v<floating_point_type, float>, fftwf_plan,
+                         fftw_plan>;
+  plan_type m_plan;
+  bool m_is_created = false;
+
+  ScopedFFTWPlanType() {}
+  ~ScopedFFTWPlanType() {
+    cleanup_threads<floating_point_type>();
+    if constexpr (std::is_same_v<floating_point_type, float>) {
+      if (m_is_created) fftwf_destroy_plan(m_plan);
+    } else {
+      if (m_is_created) fftw_destroy_plan(m_plan);
+    }
+  }
+
+  const plan_type &plan() const { return m_plan; }
+
+  template <typename InScalarType, typename OutScalarType>
+  void create(const ExecutionSpace &exec_space, int rank, const int *n,
+              int howmany, InScalarType *in, const int *inembed, int istride,
+              int idist, OutScalarType *out, const int *onembed, int ostride,
+              int odist, [[maybe_unused]] int sign, unsigned flags) {
+    init_threads<floating_point_type>(exec_space);
+
+    constexpr auto type = fftw_transform_type<ExecutionSpace, T1, T2>::type();
+
+    if constexpr (type == KokkosFFT::Impl::FFTWTransformType::R2C) {
+      m_plan =
+          fftwf_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
+                                  out, onembed, ostride, odist, flags);
+    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::D2Z) {
+      m_plan =
+          fftw_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
+                                 out, onembed, ostride, odist, flags);
+    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2R) {
+      m_plan =
+          fftwf_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
+                                  out, onembed, ostride, odist, flags);
+    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2D) {
+      m_plan =
+          fftw_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
+                                 out, onembed, ostride, odist, flags);
+    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2C) {
+      m_plan =
+          fftwf_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
+                              out, onembed, ostride, odist, sign, flags);
+    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2Z) {
+      m_plan = fftw_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
+                                  out, onembed, ostride, odist, sign, flags);
+    }
+    m_is_created = true;
+  }
+
+ private:
+  template <typename T>
+  void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
+#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
+    int nthreads = exec_space.concurrency();
+
+    if constexpr (std::is_same_v<T, float>) {
+      fftwf_init_threads();
+      fftwf_plan_with_nthreads(nthreads);
+    } else {
+      fftw_init_threads();
+      fftw_plan_with_nthreads(nthreads);
+    }
+#endif
+  }
+
+  template <typename T>
+  void cleanup_threads() {
+#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
+    if constexpr (std::is_same_v<T, float>) {
+      fftwf_cleanup_threads();
+    } else {
+      fftw_cleanup_threads();
+    }
+#endif
+  }
+};
+
+}  // namespace Impl
+}  // namespace KokkosFFT
+
+#endif

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -84,6 +84,7 @@ struct ScopedFFTWPlanType {
   }
 
   const plan_type &plan() const { return m_plan; }
+  void set_is_created() { m_is_created = true; }
 
  private:
   template <typename T>

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -80,7 +80,7 @@ struct ScopedFFTWPlanType {
     }
   }
 
-  plan_type &plan() const { return m_plan; }
+  plan_type &plan() { return m_plan; }
 
   template <typename InScalarType, typename OutScalarType>
   void create(const ExecutionSpace &exec_space, int rank, const int *n,

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -80,7 +80,7 @@ struct ScopedFFTWPlanType {
     }
   }
 
-  const plan_type &plan() const { return m_plan; }
+  plan_type &plan() const { return m_plan; }
 
   template <typename InScalarType, typename OutScalarType>
   void create(const ExecutionSpace &exec_space, int rank, const int *n,

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -74,7 +74,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  plan                   = std::make_unique<PlanType>();
+  plan = std::make_unique<PlanType>();
+  hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -40,7 +40,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, type, howmany);
+  plan         = std::make_unique<PlanType>(nx, type, howmany);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -72,7 +73,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, ny, type);
+  plan         = std::make_unique<PlanType>(nx, ny, type);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -106,7 +108,8 @@ auto create_plan(const ExecutionSpace& exec_space,
             nz = fft_extents.at(2);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-  plan         = std::make_unique<PlanType>(exec_space, nx, ny, nz, type);
+  plan         = std::make_unique<PlanType>(nx, ny, nz, type);
+  plan->commit(exec_space);
 
   return fft_size;
 }
@@ -151,9 +154,10 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-  plan = std::make_unique<PlanType>(
-      exec_space, rank, fft_extents.data(), in_extents.data(), istride, idist,
-      out_extents.data(), ostride, odist, type, howmany);
+  plan = std::make_unique<PlanType>(rank, fft_extents.data(), in_extents.data(),
+                                    istride, idist, out_extents.data(), ostride,
+                                    odist, type, howmany);
+  plan->commit(exec_space);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -33,12 +33,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan                   = std::make_unique<PlanType>();
-  hipStream_t stream     = exec_space.hip_stream();
-  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
@@ -46,9 +40,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  hipfft_rt = hipfftPlan1d(&((*plan).plan()), nx, type, howmany);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan1d failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, type, howmany);
 
   return fft_size;
 }
@@ -73,12 +65,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan                   = std::make_unique<PlanType>();
-  hipStream_t stream     = exec_space.hip_stream();
-  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -86,9 +72,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   const int nx = fft_extents.at(0), ny = fft_extents.at(1);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  hipfft_rt = hipfftPlan2d(&((*plan).plan()), nx, ny, type);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan2d failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, ny, type);
 
   return fft_size;
 }
@@ -113,12 +97,6 @@ auto create_plan(const ExecutionSpace& exec_space,
       "InViewType and OutViewType.");
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-
-  plan                   = std::make_unique<PlanType>();
-  hipStream_t stream     = exec_space.hip_stream();
-  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
-
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -128,9 +106,7 @@ auto create_plan(const ExecutionSpace& exec_space,
             nz = fft_extents.at(2);
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
-
-  hipfft_rt = hipfftPlan3d(&((*plan).plan()), nx, ny, nz, type);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan3d failed");
+  plan         = std::make_unique<PlanType>(exec_space, nx, ny, nz, type);
 
   return fft_size;
 }
@@ -175,17 +151,9 @@ auto create_plan(const ExecutionSpace& exec_space,
 
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
-
-  plan                   = std::make_unique<PlanType>();
-  hipStream_t stream     = exec_space.hip_stream();
-  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
-
-  hipfft_rt = hipfftPlanMany(&((*plan).plan()), rank, fft_extents.data(),
-                             in_extents.data(), istride, idist,
-                             out_extents.data(), ostride, odist, type, howmany);
-
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
+  plan = std::make_unique<PlanType>(
+      exec_space, rank, fft_extents.data(), in_extents.data(), istride, idist,
+      out_extents.data(), ostride, odist, type, howmany);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -15,13 +15,13 @@ namespace KokkosFFT {
 namespace Impl {
 // 1D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 1 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
+                 const OutViewType& out,
                  Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
                  bool is_inplace) {
   static_assert(
@@ -35,6 +35,12 @@ auto create_plan(const ExecutionSpace& exec_space,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
+  plan                   = std::make_unique<PlanType>();
+
+  hipStream_t stream = exec_space.hip_stream();
+  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
+
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
@@ -43,26 +49,21 @@ auto create_plan(const ExecutionSpace& exec_space,
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
 
-  plan                   = std::make_unique<PlanType>();
-  hipfftResult hipfft_rt = hipfftPlan1d(&(*plan), nx, type, howmany);
+  hipfft_rt = hipfftPlan1d(&((*plan).plan()), nx, type, howmany);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan1d failed");
-
-  hipStream_t stream = exec_space.hip_stream();
-  hipfft_rt          = hipfftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 
   return fft_size;
 }
 
 // 2D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 2 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
+                 const OutViewType& out,
                  Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
                  bool is_inplace) {
   static_assert(
@@ -76,6 +77,10 @@ auto create_plan(const ExecutionSpace& exec_space,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
+  plan                   = std::make_unique<PlanType>();
+  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
+
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -84,26 +89,21 @@ auto create_plan(const ExecutionSpace& exec_space,
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
 
-  plan                   = std::make_unique<PlanType>();
-  hipfftResult hipfft_rt = hipfftPlan2d(&(*plan), nx, ny, type);
+  hipfft_rt = hipfftPlan2d(&((*plan).plan()), nx, ny, type);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan2d failed");
-
-  hipStream_t stream = exec_space.hip_stream();
-  hipfft_rt          = hipfftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 
   return fft_size;
 }
 
 // 3D transform
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::enable_if_t<InViewType::rank() == 3 &&
                                std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
+                 const OutViewType& out,
                  Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
                  bool is_inplace) {
   static_assert(
@@ -117,6 +117,12 @@ auto create_plan(const ExecutionSpace& exec_space,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
+  plan                   = std::make_unique<PlanType>();
+
+  hipStream_t stream = exec_space.hip_stream();
+  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
+
   auto type = KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
                                               out_value_type>::type();
   [[maybe_unused]] auto [in_extents, out_extents, fft_extents, howmany] =
@@ -127,26 +133,21 @@ auto create_plan(const ExecutionSpace& exec_space,
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
                                  std::multiplies<>());
 
-  plan                   = std::make_unique<PlanType>();
-  hipfftResult hipfft_rt = hipfftPlan3d(&(*plan), nx, ny, nz, type);
+  hipfft_rt = hipfftPlan3d(&((*plan).plan()), nx, ny, nz, type);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan3d failed");
-
-  hipStream_t stream = exec_space.hip_stream();
-  hipfft_rt          = hipfftSetStream((*plan), stream);
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 
   return fft_size;
 }
 
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
+          typename OutViewType,
           std::size_t fft_rank             = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
+                 const OutViewType& out,
                  Direction /*direction*/, axis_type<fft_rank> axes,
                  shape_type<fft_rank> s, bool is_inplace) {
   static_assert(
@@ -181,25 +182,20 @@ auto create_plan(const ExecutionSpace& exec_space,
   int istride = 1, ostride = 1;
 
   plan                   = std::make_unique<PlanType>();
-  hipfftResult hipfft_rt = hipfftPlanMany(
-      &(*plan), rank, fft_extents.data(), in_extents.data(), istride, idist,
-      out_extents.data(), ostride, odist, type, howmany);
-
-  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
 
   hipStream_t stream = exec_space.hip_stream();
-  hipfft_rt          = hipfftSetStream((*plan), stream);
+  hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
+
+  hipfft_rt = hipfftPlanMany(&((*plan).plan()), rank, fft_extents.data(),
+                             in_extents.data(), istride, idist,
+                             out_extents.data(), ostride, odist, type, howmany);
+
+  KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
 
   return fft_size;
 }
 
-template <typename ExecutionSpace, typename PlanType, typename InfoType,
-          std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                           std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>& plan, InfoType&) {
-  hipfftDestroy(*plan);
-}
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -21,9 +21,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out,
-                 Direction /*direction*/, axis_type<1> axes, shape_type<1> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<1> axes, shape_type<1> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -36,8 +35,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   using out_value_type = typename OutViewType::non_const_value_type;
 
   plan                   = std::make_unique<PlanType>();
-
-  hipStream_t stream = exec_space.hip_stream();
+  hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 
@@ -63,9 +61,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out,
-                 Direction /*direction*/, axis_type<2> axes, shape_type<2> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<2> axes, shape_type<2> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -103,9 +100,8 @@ template <typename ExecutionSpace, typename PlanType, typename InViewType,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out,
-                 Direction /*direction*/, axis_type<3> axes, shape_type<3> s,
-                 bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<3> axes, shape_type<3> s, bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -118,8 +114,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   using out_value_type = typename OutViewType::non_const_value_type;
 
   plan                   = std::make_unique<PlanType>();
-
-  hipStream_t stream = exec_space.hip_stream();
+  hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 
@@ -141,15 +136,14 @@ auto create_plan(const ExecutionSpace& exec_space,
 
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType,
-          std::size_t fft_rank             = 1,
+          typename OutViewType, std::size_t fft_rank = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out,
-                 Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -181,9 +175,8 @@ auto create_plan(const ExecutionSpace& exec_space,
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
 
-  plan                   = std::make_unique<PlanType>();
-
-  hipStream_t stream = exec_space.hip_stream();
+  plan = std::make_unique<PlanType>();
+  hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -74,7 +74,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 
-  plan = std::make_unique<PlanType>();
+  plan                   = std::make_unique<PlanType>();
   hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
@@ -176,7 +176,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   // For the moment, considering the contiguous layout only
   int istride = 1, ostride = 1;
 
-  plan = std::make_unique<PlanType>();
+  plan                   = std::make_unique<PlanType>();
   hipStream_t stream     = exec_space.hip_stream();
   hipfftResult hipfft_rt = hipfftSetStream((*plan).plan(), stream);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -10,45 +10,45 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftReal* idata,
-                      hipfftComplex* odata, int /*direction*/, Args...) {
-  hipfftResult hipfft_rt = hipfftExecR2C(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftReal* idata,
+                      hipfftComplex* odata, int /*direction*/) {
+  hipfftResult hipfft_rt = hipfftExecR2C(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecR2C failed");
 }
 
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftDoubleReal* idata,
-                      hipfftDoubleComplex* odata, int /*direction*/, Args...) {
-  hipfftResult hipfft_rt = hipfftExecD2Z(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleReal* idata,
+                      hipfftDoubleComplex* odata, int /*direction*/) {
+  hipfftResult hipfft_rt = hipfftExecD2Z(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecD2Z failed");
 }
 
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
-                      hipfftReal* odata, int /*direction*/, Args...) {
-  hipfftResult hipfft_rt = hipfftExecC2R(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftComplex* idata,
+                      hipfftReal* odata, int /*direction*/) {
+  hipfftResult hipfft_rt = hipfftExecC2R(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2R failed");
 }
 
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                      hipfftDoubleReal* odata, int /*direction*/, Args...) {
-  hipfftResult hipfft_rt = hipfftExecZ2D(plan, idata, odata);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
+                      hipfftDoubleReal* odata, int /*direction*/) {
+  hipfftResult hipfft_rt = hipfftExecZ2D(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2D failed");
 }
 
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftComplex* idata,
-                      hipfftComplex* odata, int direction, Args...) {
-  hipfftResult hipfft_rt = hipfftExecC2C(plan, idata, odata, direction);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftComplex* idata,
+                      hipfftComplex* odata, int direction) {
+  hipfftResult hipfft_rt = hipfftExecC2C(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2C failed");
 }
 
-template <typename... Args>
-inline void exec_plan(hipfftHandle& plan, hipfftDoubleComplex* idata,
-                      hipfftDoubleComplex* odata, int direction, Args...) {
-  hipfftResult hipfft_rt = hipfftExecZ2Z(plan, idata, odata, direction);
+template <typename ScopedPlanType>
+inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
+                      hipfftDoubleComplex* odata, int direction) {
+  hipfftResult hipfft_rt = hipfftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2Z failed");
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -41,14 +41,16 @@ inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
 template <typename ScopedPlanType>
 inline void exec_plan(ScopedPlanType& scoped_plan, hipfftComplex* idata,
                       hipfftComplex* odata, int direction) {
-  hipfftResult hipfft_rt = hipfftExecC2C(scoped_plan.plan(), idata, odata, direction);
+  hipfftResult hipfft_rt =
+      hipfftExecC2C(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2C failed");
 }
 
 template <typename ScopedPlanType>
 inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
                       hipfftDoubleComplex* odata, int direction) {
-  hipfftResult hipfft_rt = hipfftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
+  hipfftResult hipfft_rt =
+      hipfftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2Z failed");
 }
 }  // namespace Impl

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -6,6 +6,7 @@
 #define KOKKOSFFT_HIP_TRANSFORM_HPP
 
 #include <hipfft/hipfft.h>
+#include "KokkosFFT_asserts.hpp"
 #include "KokkosFFT_HIP_types.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -10,45 +10,45 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftReal* idata,
+
+struct ScopedHIPfftPlan;
+
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan, hipfftReal* idata,
                       hipfftComplex* odata, int /*direction*/) {
   hipfftResult hipfft_rt = hipfftExecR2C(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecR2C failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleReal* idata,
-                      hipfftDoubleComplex* odata, int /*direction*/) {
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan,
+                      hipfftDoubleReal* idata, hipfftDoubleComplex* odata,
+                      int /*direction*/) {
   hipfftResult hipfft_rt = hipfftExecD2Z(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecD2Z failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftComplex* idata,
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan, hipfftComplex* idata,
                       hipfftReal* odata, int /*direction*/) {
   hipfftResult hipfft_rt = hipfftExecC2R(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2R failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
-                      hipfftDoubleReal* odata, int /*direction*/) {
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan,
+                      hipfftDoubleComplex* idata, hipfftDoubleReal* odata,
+                      int /*direction*/) {
   hipfftResult hipfft_rt = hipfftExecZ2D(scoped_plan.plan(), idata, odata);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2D failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftComplex* idata,
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan, hipfftComplex* idata,
                       hipfftComplex* odata, int direction) {
   hipfftResult hipfft_rt =
       hipfftExecC2C(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecC2C failed");
 }
 
-template <typename ScopedPlanType>
-inline void exec_plan(ScopedPlanType& scoped_plan, hipfftDoubleComplex* idata,
-                      hipfftDoubleComplex* odata, int direction) {
+inline void exec_plan(const ScopedHIPfftPlan& scoped_plan,
+                      hipfftDoubleComplex* idata, hipfftDoubleComplex* odata,
+                      int direction) {
   hipfftResult hipfft_rt =
       hipfftExecZ2Z(scoped_plan.plan(), idata, odata, direction);
   KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftExecZ2Z failed");

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -6,12 +6,10 @@
 #define KOKKOSFFT_HIP_TRANSFORM_HPP
 
 #include <hipfft/hipfft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_HIP_types.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-
-struct ScopedHIPfftPlan;
 
 inline void exec_plan(const ScopedHIPfftPlan& scoped_plan, hipfftReal* idata,
                       hipfftComplex* odata, int /*direction*/) {

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -67,7 +67,7 @@ struct ScopedHIPfftPlan {
   ScopedHIPfftPlan(ScopedHIPfftPlan &&)                 = delete;
 
   hipfftHandle plan() const noexcept { return m_plan; }
-  void commit(const Kokkos::HIP &exec_space) {
+  void commit(const Kokkos::HIP &exec_space) const {
     hipfftResult hipfft_rt = hipfftSetStream(m_plan, exec_space.hip_stream());
     KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftSetStream failed");
   }

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -31,7 +31,7 @@ struct ScopedHIPfftPlanType {
   ScopedHIPfftPlanType() { hipfftCreate(&m_plan); }
   ~ScopedHIPfftPlanType() { hipfftDestroy(m_plan); }
 
-  ScopedHIPfftPlanType &plan() { return m_plan; }
+  hipfftHandle &plan() { return m_plan; }
 };
 
 #if defined(ENABLE_HOST_AND_DEVICE)

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -24,7 +24,6 @@ namespace Impl {
 using FFTDirectionType = int;
 
 /// \brief A class that wraps hipfft for RAII
-template <typename ExecutionSpace, typename T1, typename T2>
 struct ScopedHIPfftPlanType {
   hipfftHandle m_plan;
 
@@ -129,7 +128,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftw_plan_type   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
-  using hipfft_plan_type = ScopedHIPfftPlanType<ExecutionSpace, T1, T2>;
+  using hipfft_plan_type = ScopedHIPfftPlanType;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   hipfft_plan_type, fftw_plan_type>;
 };
@@ -192,7 +191,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedHIPfftPlanType<ExecutionSpace, T1, T2>;
+  using type = ScopedHIPfftPlanType;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -5,6 +5,7 @@
 #ifndef KOKKOSFFT_HIP_TYPES_HPP
 #define KOKKOSFFT_HIP_TYPES_HPP
 
+#include <iostream>
 #include <hipfft/hipfft.h>
 #include <Kokkos_Abort.hpp>
 #include "KokkosFFT_common_types.hpp"
@@ -33,39 +34,60 @@ struct ScopedHIPfftPlan {
  public:
   ScopedHIPfftPlan(const Kokkos::HIP &exec_space, int nx, hipfftType type,
                    int batch) {
-    hipfftResult hipfft_rt = hipfftPlan1d(&m_plan, nx, type, batch);
-    KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan1d failed");
-    set_stream(exec_space);
+    try {
+      hipfftResult hipfft_rt = hipfftPlan1d(&m_plan, nx, type, batch);
+      KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan1d failed");
+      set_stream(exec_space);
+    } catch (const std::runtime_error &e) {
+      std::cerr << e.what() << std::endl;
+      cleanup();
+      throw;
+    }
   }
 
   ScopedHIPfftPlan(const Kokkos::HIP &exec_space, int nx, int ny,
                    hipfftType type) {
-    hipfftResult hipfft_rt = hipfftPlan2d(&m_plan, nx, ny, type);
-    KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan2d failed");
-    set_stream(exec_space);
+    try {
+      hipfftResult hipfft_rt = hipfftPlan2d(&m_plan, nx, ny, type);
+      KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan2d failed");
+      set_stream(exec_space);
+    } catch (const std::runtime_error &e) {
+      std::cerr << e.what() << std::endl;
+      cleanup();
+      throw;
+    }
   }
 
   ScopedHIPfftPlan(const Kokkos::HIP &exec_space, int nx, int ny, int nz,
                    hipfftType type) {
-    hipfftResult hipfft_rt = hipfftPlan3d(&m_plan, nx, ny, nz, type);
-    KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan3d failed");
-    set_stream(exec_space);
+    try {
+      hipfftResult hipfft_rt = hipfftPlan3d(&m_plan, nx, ny, nz, type);
+      KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlan3d failed");
+      set_stream(exec_space);
+    } catch (const std::runtime_error &e) {
+      std::cerr << e.what() << std::endl;
+      cleanup();
+      throw;
+    }
   }
 
   ScopedHIPfftPlan(const Kokkos::HIP &exec_space, int rank, int *n,
                    int *inembed, int istride, int idist, int *onembed,
                    int ostride, int odist, hipfftType type, int batch) {
-    hipfftResult hipfft_rt =
-        hipfftPlanMany(&m_plan, rank, n, inembed, istride, idist, onembed,
-                       ostride, odist, type, batch);
-    KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
-    set_stream(exec_space);
+    try {
+      hipfftResult hipfft_rt =
+          hipfftPlanMany(&m_plan, rank, n, inembed, istride, idist, onembed,
+                         ostride, odist, type, batch);
+      KOKKOSFFT_THROW_IF(hipfft_rt != HIPFFT_SUCCESS, "hipfftPlanMany failed");
+      set_stream(exec_space);
+    } catch (const std::runtime_error &e) {
+      std::cerr << e.what() << std::endl;
+      cleanup();
+      throw;
+    }
   }
 
-  ~ScopedHIPfftPlan() noexcept {
-    hipfftResult hipfft_rt = hipfftDestroy(m_plan);
-    if (hipfft_rt != HIPFFT_SUCCESS) Kokkos::abort("hipfftDestroy failed");
-  }
+  ~ScopedHIPfftPlan() noexcept { cleanup(); }
 
   ScopedHIPfftPlan()                                    = delete;
   ScopedHIPfftPlan(const ScopedHIPfftPlan &)            = delete;
@@ -76,6 +98,11 @@ struct ScopedHIPfftPlan {
   hipfftHandle plan() const noexcept { return m_plan; }
 
  private:
+  void cleanup() {
+    hipfftResult hipfft_rt = hipfftDestroy(m_plan);
+    if (hipfft_rt != HIPFFT_SUCCESS) Kokkos::abort("hipfftDestroy failed");
+  }
+
   void set_stream(const Kokkos::HIP &exec_space) {
     hipStream_t stream     = exec_space.hip_stream();
     hipfftResult hipfft_rt = hipfftSetStream(m_plan, stream);

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -128,7 +128,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using fftw_plan_type  = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using fftw_plan_type   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
   using hipfft_plan_type = ScopedHIPfftPlanType<ExecutionSpace, T1, T2>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   hipfft_plan_type, fftw_plan_type>;

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -87,7 +87,7 @@ auto create_plan(const ExecutionSpace& exec_space,
         rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
         idist, odata, out_extents.data(), ostride, odist, sign, FFTW_ESTIMATE);
   }
-  plan->m_is_created;
+  plan->set_is_created();
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -58,36 +58,10 @@ auto create_plan(const ExecutionSpace& exec_space,
   [[maybe_unused]] auto sign =
       KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
 
-  plan = std::make_unique<PlanType>(exec_space);
-  constexpr auto type =
-      KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
-                                      out_value_type>::type();
-  if constexpr (type == KokkosFFT::Impl::FFTWTransformType::R2C) {
-    plan->m_plan = fftwf_plan_many_dft_r2c(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, FFTW_ESTIMATE);
-  } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::D2Z) {
-    plan->m_plan = fftw_plan_many_dft_r2c(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, FFTW_ESTIMATE);
-  } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2R) {
-    plan->m_plan = fftwf_plan_many_dft_c2r(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, FFTW_ESTIMATE);
-  } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2D) {
-    plan->m_plan = fftw_plan_many_dft_c2r(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, FFTW_ESTIMATE);
-  } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2C) {
-    plan->m_plan = fftwf_plan_many_dft(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, sign, FFTW_ESTIMATE);
-  } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2Z) {
-    plan->m_plan = fftw_plan_many_dft(
-        rank, fft_extents.data(), howmany, idata, in_extents.data(), istride,
-        idist, odata, out_extents.data(), ostride, odist, sign, FFTW_ESTIMATE);
-  }
-  plan->set_is_created();
+  plan = std::make_unique<PlanType>(exec_space, rank, fft_extents.data(),
+                                    howmany, idata, in_extents.data(), istride,
+                                    idist, odata, out_extents.data(), ostride,
+                                    odist, sign, FFTW_ESTIMATE);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -39,9 +39,6 @@ auto create_plan(const ExecutionSpace& exec_space,
   using out_value_type = typename OutViewType::non_const_value_type;
   const int rank       = fft_rank;
 
-  constexpr auto type =
-      KokkosFFT::Impl::transform_type<ExecutionSpace, in_value_type,
-                                      out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
       KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
   int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -14,15 +14,14 @@ namespace KokkosFFT {
 namespace Impl {
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType, typename InfoType,
-          std::size_t fft_rank = 1,
+          typename OutViewType, std::size_t fft_rank = 1,
           std::enable_if_t<is_AnyHostSpace_v<ExecutionSpace>, std::nullptr_t> =
               nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction direction, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_inplace) {
+                 const OutViewType& out, Direction direction,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -9,40 +9,40 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType& plan, float* idata, fftwf_complex* odata,
-               int /*direction*/, Args...) {
-  fftwf_execute_dft_r2c(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, float* idata, fftwf_complex* odata,
+               int /*direction*/) {
+  fftwf_execute_dft_r2c(scoped_plan.plan(), idata, odata);
 }
 
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType& plan, double* idata, fftw_complex* odata,
-               int /*direction*/, Args...) {
-  fftw_execute_dft_r2c(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, double* idata, fftw_complex* odata,
+               int /*direction*/) {
+  fftw_execute_dft_r2c(scoped_plan.plan(), idata, odata);
 }
 
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType& plan, fftwf_complex* idata, float* odata,
-               int /*direction*/, Args...) {
-  fftwf_execute_dft_c2r(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, fftwf_complex* idata, float* odata,
+               int /*direction*/) {
+  fftwf_execute_dft_c2r(scoped_plan.plan(), idata, odata);
 }
 
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType& plan, fftw_complex* idata, double* odata,
-               int /*direction*/, Args...) {
-  fftw_execute_dft_c2r(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, fftw_complex* idata, double* odata,
+               int /*direction*/) {
+  fftw_execute_dft_c2r(scoped_plan.plan(), idata, odata);
 }
 
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType& plan, fftwf_complex* idata, fftwf_complex* odata,
-               int /*direction*/, Args...) {
-  fftwf_execute_dft(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, fftwf_complex* idata,
+               fftwf_complex* odata, int /*direction*/) {
+  fftwf_execute_dft(scoped_plan.plan(), idata, odata);
 }
 
-template <typename PlanType, typename... Args>
-void exec_plan(PlanType plan, fftw_complex* idata, fftw_complex* odata,
-               int /*direction*/, Args...) {
-  fftw_execute_dft(plan, idata, odata);
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType scoped_plan, fftw_complex* idata,
+               fftw_complex* odata, int /*direction*/) {
+  fftw_execute_dft(scoped_plan.plan(), idata, odata);
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -11,37 +11,37 @@ namespace KokkosFFT {
 namespace Impl {
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, float* idata, fftwf_complex* odata,
-               int /*direction*/) {
+void exec_plan(const ScopedPlanType& scoped_plan, float* idata,
+               fftwf_complex* odata, int /*direction*/) {
   fftwf_execute_dft_r2c(scoped_plan.plan(), idata, odata);
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, double* idata, fftw_complex* odata,
-               int /*direction*/) {
+void exec_plan(const ScopedPlanType& scoped_plan, double* idata,
+               fftw_complex* odata, int /*direction*/) {
   fftw_execute_dft_r2c(scoped_plan.plan(), idata, odata);
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, fftwf_complex* idata, float* odata,
-               int /*direction*/) {
+void exec_plan(const ScopedPlanType& scoped_plan, fftwf_complex* idata,
+               float* odata, int /*direction*/) {
   fftwf_execute_dft_c2r(scoped_plan.plan(), idata, odata);
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, fftw_complex* idata, double* odata,
-               int /*direction*/) {
+void exec_plan(const ScopedPlanType& scoped_plan, fftw_complex* idata,
+               double* odata, int /*direction*/) {
   fftw_execute_dft_c2r(scoped_plan.plan(), idata, odata);
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, fftwf_complex* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, fftwf_complex* idata,
                fftwf_complex* odata, int /*direction*/) {
   fftwf_execute_dft(scoped_plan.plan(), idata, odata);
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, fftw_complex* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, fftw_complex* idata,
                fftw_complex* odata, int /*direction*/) {
   fftw_execute_dft(scoped_plan.plan(), idata, odata);
 }

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -40,7 +40,7 @@ void exec_plan(ScopedPlanType& scoped_plan, fftwf_complex* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType scoped_plan, fftw_complex* idata,
+void exec_plan(ScopedPlanType& scoped_plan, fftw_complex* idata,
                fftw_complex* odata, int /*direction*/) {
   fftw_execute_dft(scoped_plan.plan(), idata, odata);
 }

--- a/fft/src/KokkosFFT_Host_transform.hpp
+++ b/fft/src/KokkosFFT_Host_transform.hpp
@@ -9,6 +9,7 @@
 
 namespace KokkosFFT {
 namespace Impl {
+
 template <typename ScopedPlanType>
 void exec_plan(ScopedPlanType& scoped_plan, float* idata, fftwf_complex* odata,
                int /*direction*/) {

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -23,7 +23,7 @@ template <typename ExecutionSpace>
 using TransformType = FFTWTransformType;
 
 template <typename ExecutionSpace, typename T1, typename T2>
-using transform_type = fftw_transform_type<ExecutionSpace, T1, T2>;
+using transform_type = fftw_transform_type<T1, T2>;
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -5,28 +5,11 @@
 #ifndef KOKKOSFFT_HOST_TYPES_HPP
 #define KOKKOSFFT_HOST_TYPES_HPP
 
-#include <fftw3.h>
-#include <Kokkos_Core.hpp>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_utils.hpp"
-
-// Check the size of complex type
-static_assert(sizeof(fftwf_complex) == sizeof(Kokkos::complex<float>));
-static_assert(alignof(fftwf_complex) <= alignof(Kokkos::complex<float>));
-
-static_assert(sizeof(fftw_complex) == sizeof(Kokkos::complex<double>));
-static_assert(alignof(fftw_complex) <= alignof(Kokkos::complex<double>));
+#include "KokkosFFT_FFTW_Types.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-
 using FFTDirectionType = int;
-
-// Unused
-template <typename ExecutionSpace>
-using FFTInfoType = int;
-
-enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
 
 template <typename ExecutionSpace>
 struct FFTDataType {
@@ -39,6 +22,7 @@ struct FFTDataType {
 template <typename ExecutionSpace>
 using TransformType = FFTWTransformType;
 
+/*
 // Define fft transform types
 template <typename ExecutionSpace, typename T1, typename T2>
 struct transform_type {
@@ -76,93 +60,10 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
                                                   : FFTWTransformType::Z2Z;
   static constexpr FFTWTransformType type() { return m_type; };
 };
+*/
 
-/// \brief A class that wraps fftw_plan and fftwf_plan for RAII
 template <typename ExecutionSpace, typename T1, typename T2>
-struct ScopedFFTWPlanType {
-  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T1>;
-  using plan_type =
-      std::conditional_t<std::is_same_v<floating_point_type, float>, fftwf_plan,
-                         fftw_plan>;
-  plan_type m_plan;
-  bool m_is_created = false;
-
-  ScopedFFTWPlanType() {}
-  ~ScopedFFTWPlanType() {
-    cleanup_threads<floating_point_type>();
-    if constexpr (std::is_same_v<floating_point_type, float>) {
-      if (m_is_created) fftwf_destroy_plan(m_plan);
-    } else {
-      if (m_is_created) fftw_destroy_plan(m_plan);
-    }
-  }
-
-  const plan_type &plan() const { return m_plan; }
-
-  template <typename InScalarType, typename OutScalarType>
-  void create(const ExecutionSpace &exec_space, int rank, const int *n,
-              int howmany, InScalarType *in, const int *inembed, int istride,
-              int idist, OutScalarType *out, const int *onembed, int ostride,
-              int odist, [[maybe_unused]] int sign, unsigned flags) {
-    init_threads<floating_point_type>(exec_space);
-
-    constexpr auto type =
-        KokkosFFT::Impl::transform_type<ExecutionSpace, T1, T2>::type();
-
-    if constexpr (type == KokkosFFT::Impl::FFTWTransformType::R2C) {
-      m_plan =
-          fftwf_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::D2Z) {
-      m_plan =
-          fftw_plan_many_dft_r2c(rank, n, howmany, in, inembed, istride, idist,
-                                 out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2R) {
-      m_plan =
-          fftwf_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2D) {
-      m_plan =
-          fftw_plan_many_dft_c2r(rank, n, howmany, in, inembed, istride, idist,
-                                 out, onembed, ostride, odist, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::C2C) {
-      m_plan =
-          fftwf_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
-                              out, onembed, ostride, odist, sign, flags);
-    } else if constexpr (type == KokkosFFT::Impl::FFTWTransformType::Z2Z) {
-      m_plan = fftw_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
-                                  out, onembed, ostride, odist, sign, flags);
-    }
-    m_is_created = true;
-  }
-
- private:
-  template <typename T>
-  void init_threads([[maybe_unused]] const ExecutionSpace &exec_space) {
-#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
-    int nthreads = exec_space.concurrency();
-
-    if constexpr (std::is_same_v<T, float>) {
-      fftwf_init_threads();
-      fftwf_plan_with_nthreads(nthreads);
-    } else {
-      fftw_init_threads();
-      fftw_plan_with_nthreads(nthreads);
-    }
-#endif
-  }
-
-  template <typename T>
-  void cleanup_threads() {
-#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS)
-    if constexpr (std::is_same_v<T, float>) {
-      fftwf_cleanup_threads();
-    } else {
-      fftw_cleanup_threads();
-    }
-#endif
-  }
-};
+using transform_type = fftw_transform_type<ExecutionSpace, T1, T2>;
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -22,46 +22,6 @@ struct FFTDataType {
 template <typename ExecutionSpace>
 using TransformType = FFTWTransformType;
 
-/*
-// Define fft transform types
-template <typename ExecutionSpace, typename T1, typename T2>
-struct transform_type {
-  static_assert(std::is_same_v<T1, T2>,
-                "Real to real transform is unavailable");
-};
-
-template <typename ExecutionSpace, typename T1, typename T2>
-struct transform_type<ExecutionSpace, T1, Kokkos::complex<T2>> {
-  static_assert(std::is_same_v<T1, T2>,
-                "T1 and T2 should have the same precision");
-  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
-                                                  ? FFTWTransformType::R2C
-                                                  : FFTWTransformType::D2Z;
-  static constexpr FFTWTransformType type() { return m_type; };
-};
-
-template <typename ExecutionSpace, typename T1, typename T2>
-struct transform_type<ExecutionSpace, Kokkos::complex<T1>, T2> {
-  static_assert(std::is_same_v<T1, T2>,
-                "T1 and T2 should have the same precision");
-  static constexpr FFTWTransformType m_type = std::is_same_v<T2, float>
-                                                  ? FFTWTransformType::C2R
-                                                  : FFTWTransformType::Z2D;
-  static constexpr FFTWTransformType type() { return m_type; };
-};
-
-template <typename ExecutionSpace, typename T1, typename T2>
-struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
-                      Kokkos::complex<T2>> {
-  static_assert(std::is_same_v<T1, T2>,
-                "T1 and T2 should have the same precision");
-  static constexpr FFTWTransformType m_type = std::is_same_v<T1, float>
-                                                  ? FFTWTransformType::C2C
-                                                  : FFTWTransformType::Z2Z;
-  static constexpr FFTWTransformType type() { return m_type; };
-};
-*/
-
 template <typename ExecutionSpace, typename T1, typename T2>
 using transform_type = fftw_transform_type<ExecutionSpace, T1, T2>;
 

--- a/fft/src/KokkosFFT_Host_types.hpp
+++ b/fft/src/KokkosFFT_Host_types.hpp
@@ -27,7 +27,7 @@ using transform_type = fftw_transform_type<ExecutionSpace, T1, T2>;
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using type = ScopedFFTWPlan<ExecutionSpace, T1, T2>;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -5,7 +5,7 @@
 /// \file KokkosFFT_Plans.hpp
 /// \brief Wrapping fft plans of different fft libraries
 ///
-/// This file provides KokkosFFT::Impl::Plan.
+/// This file provides KokkosFFT::Plan.
 /// This implements a local (no MPI) interface for fft plans
 
 #ifndef KOKKOSFFT_PLANS_HPP
@@ -22,7 +22,7 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 #include "KokkosFFT_Cuda_plans.hpp"
 #include "KokkosFFT_Cuda_transform.hpp"
-#ifdef ENABLE_HOST_AND_DEVICE
+#if defined(ENABLE_HOST_AND_DEVICE)
 #include "KokkosFFT_Host_plans.hpp"
 #include "KokkosFFT_Host_transform.hpp"
 #endif
@@ -34,14 +34,14 @@
 #include "KokkosFFT_HIP_plans.hpp"
 #include "KokkosFFT_HIP_transform.hpp"
 #endif
-#ifdef ENABLE_HOST_AND_DEVICE
+#if defined(ENABLE_HOST_AND_DEVICE)
 #include "KokkosFFT_Host_plans.hpp"
 #include "KokkosFFT_Host_transform.hpp"
 #endif
 #elif defined(KOKKOS_ENABLE_SYCL)
 #include "KokkosFFT_SYCL_plans.hpp"
 #include "KokkosFFT_SYCL_transform.hpp"
-#ifdef ENABLE_HOST_AND_DEVICE
+#if defined(ENABLE_HOST_AND_DEVICE)
 #include "KokkosFFT_Host_plans.hpp"
 #include "KokkosFFT_Host_transform.hpp"
 #endif
@@ -88,18 +88,11 @@ class Plan {
       typename KokkosFFT::Impl::FFTPlanType<ExecutionSpace, in_value_type,
                                             out_value_type>::type;
 
-  //! The type of fft info (used for rocfft only)
-  using fft_info_type = typename KokkosFFT::Impl::FFTInfoType<ExecutionSpace>;
-
   //! The type of fft size
   using fft_size_type = std::size_t;
 
   //! The type of map for transpose
   using map_type = axis_type<InViewType::rank()>;
-
-  //! Naive 1D View for work buffer
-  using BufferViewType =
-      Kokkos::View<Kokkos::complex<float_type>*, layout_type, execSpace>;
 
   //! The type of extents of input/output views
   using extents_type = shape_type<InViewType::rank()>;
@@ -110,9 +103,6 @@ class Plan {
 
   //! Dynamically allocatable fft plan.
   std::unique_ptr<fft_plan_type> m_plan;
-
-  //! fft info
-  fft_info_type m_info;
 
   //! fft size
   fft_size_type m_fft_size = 1;
@@ -142,9 +132,6 @@ class Plan {
   //! extents of input/output views
   extents_type m_in_extents, m_out_extents;
   ///@}
-
-  //! Internal work buffer (for rocfft)
-  BufferViewType m_buffer;
 
  public:
   /// \brief Constructor
@@ -209,9 +196,9 @@ class Plan {
     KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
-    m_fft_size = KokkosFFT::Impl::create_plan(exec_space, m_plan, in, out,
-                                              m_buffer, m_info, direction,
-                                              m_axes, s, m_is_inplace);
+
+    m_fft_size = KokkosFFT::Impl::create_plan(
+        exec_space, m_plan, in, out, direction, m_axes, s, m_is_inplace);
   }
 
   /// \brief Constructor for multidimensional FFT
@@ -272,9 +259,9 @@ class Plan {
     KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
-    m_fft_size =
-        KokkosFFT::Impl::create_plan(exec_space, m_plan, in, out, m_buffer,
-                                     m_info, direction, axes, s, m_is_inplace);
+
+    m_fft_size = KokkosFFT::Impl::create_plan(exec_space, m_plan, in, out,
+                                              direction, axes, s, m_is_inplace);
   }
 
   ~Plan() {}
@@ -355,8 +342,7 @@ class Plan {
 
     auto const direction =
         KokkosFFT::Impl::direction_type<execSpace>(m_direction);
-    KokkosFFT::Impl::exec_plan((*m_plan).plan(), idata, odata, direction,
-                               m_info);
+    KokkosFFT::Impl::exec_plan(*m_plan, idata, odata, direction);
 
     if constexpr (KokkosFFT::Impl::is_complex_v<in_value_type> &&
                   KokkosFFT::Impl::is_real_v<out_value_type>) {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -264,7 +264,7 @@ class Plan {
                                               direction, axes, s, m_is_inplace);
   }
 
-  ~Plan() {}
+  ~Plan() noexcept = default;
 
   Plan()                       = delete;
   Plan(const Plan&)            = delete;

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -84,15 +84,14 @@ auto compute_strides(const std::vector<InType>& extents)
 
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
-          typename OutViewType, typename BufferViewType,
-          std::size_t fft_rank             = 1,
+          typename OutViewType, std::size_t fft_rank = 1,
           std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                            std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType& buffer,
-                 Direction direction, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_inplace) {
+                 const OutViewType& out, Direction direction,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -15,72 +15,6 @@
 
 namespace KokkosFFT {
 namespace Impl {
-// Helper to get input and output array type and direction from transform type
-template <typename TransformType>
-auto get_in_out_array_type(TransformType type, Direction direction) {
-  rocfft_array_type in_array_type, out_array_type;
-  rocfft_transform_type fft_direction;
-
-  if (type == FFTWTransformType::C2C || type == FFTWTransformType::Z2Z) {
-    in_array_type  = rocfft_array_type_complex_interleaved;
-    out_array_type = rocfft_array_type_complex_interleaved;
-    fft_direction  = direction == Direction::forward
-                         ? rocfft_transform_type_complex_forward
-                         : rocfft_transform_type_complex_inverse;
-  } else if (type == FFTWTransformType::R2C || type == FFTWTransformType::D2Z) {
-    in_array_type  = rocfft_array_type_real;
-    out_array_type = rocfft_array_type_hermitian_interleaved;
-    fft_direction  = rocfft_transform_type_real_forward;
-  } else if (type == FFTWTransformType::C2R || type == FFTWTransformType::Z2D) {
-    in_array_type  = rocfft_array_type_hermitian_interleaved;
-    out_array_type = rocfft_array_type_real;
-    fft_direction  = rocfft_transform_type_real_inverse;
-  }
-
-  return std::tuple<rocfft_array_type, rocfft_array_type,
-                    rocfft_transform_type>(
-      {in_array_type, out_array_type, fft_direction});
-};
-
-template <typename ValueType>
-rocfft_precision get_in_out_array_type() {
-  return std::is_same_v<KokkosFFT::Impl::base_floating_point_type<ValueType>,
-                        float>
-             ? rocfft_precision_single
-             : rocfft_precision_double;
-}
-
-// Helper to convert the integer type of vectors
-template <typename InType, typename OutType>
-auto convert_int_type_and_reverse(std::vector<InType>& in)
-    -> std::vector<OutType> {
-  std::vector<OutType> out(in.size());
-  std::transform(
-      in.begin(), in.end(), out.begin(),
-      [](const InType v) -> OutType { return static_cast<OutType>(v); });
-
-  std::reverse(out.begin(), out.end());
-  return out;
-}
-
-// Helper to compute strides from extents
-// (n0, n1, n2) -> (1, n0, n0*n1)
-// (n0, n1) -> (1, n0)
-// (n0) -> (1)
-template <typename InType, typename OutType>
-auto compute_strides(const std::vector<InType>& extents)
-    -> std::vector<OutType> {
-  std::vector<OutType> out = {1};
-  auto reversed_extents    = extents;
-  std::reverse(reversed_extents.begin(), reversed_extents.end());
-
-  for (std::size_t i = 1; i < reversed_extents.size(); i++) {
-    out.push_back(static_cast<OutType>(reversed_extents.at(i - 1)) *
-                  out.at(i - 1));
-  }
-
-  return out;
-}
 
 // batched transform, over ND Views
 template <typename ExecutionSpace, typename PlanType, typename InViewType,
@@ -112,92 +46,11 @@ auto create_plan(const ExecutionSpace& exec_space,
                                       out_value_type>::type();
   auto [in_extents, out_extents, fft_extents, howmany] =
       KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
-  int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
-                                 std::multiplies<>());
-  int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
-                                 std::multiplies<>());
-  int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
-                                 std::multiplies<>());
-
-  // For the moment, considering the contiguous layout only
-  // Create plan
-  auto in_strides  = compute_strides<int, std::size_t>(in_extents);
-  auto out_strides = compute_strides<int, std::size_t>(out_extents);
-  auto reversed_fft_extents =
-      convert_int_type_and_reverse<int, std::size_t>(fft_extents);
-
-  // Create the description
-  std::unique_ptr<rocfft_plan_description,
-                  std::function<void(rocfft_plan_description*)>> const
-      description(new rocfft_plan_description,
-                  [](rocfft_plan_description* desc) {
-                    rocfft_plan_description_destroy(*desc);
-                  });
-  rocfft_status status = rocfft_plan_description_create(&(*description));
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_plan_description_create failed");
-
-  auto [in_array_type, out_array_type, fft_direction] =
-      get_in_out_array_type(type, direction);
-  rocfft_precision precision = get_in_out_array_type<in_value_type>();
-
-  status = rocfft_plan_description_set_data_layout(
-      *description,        // description handle
-      in_array_type,       // input array type
-      out_array_type,      // output array type
-      nullptr,             // offsets to start of input data
-      nullptr,             // offsets to start of output data
-      in_strides.size(),   // input stride length
-      in_strides.data(),   // input stride data
-      idist,               // input batch distance
-      out_strides.size(),  // output stride length
-      out_strides.data(),  // output stride data
-      odist);              // output batch distance
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_plan_description_set_data_layout failed");
-
-  // Out-of-place transform
-  const rocfft_result_placement place =
-      is_inplace ? rocfft_placement_inplace : rocfft_placement_notinplace;
 
   // Create a plan
-  plan   = std::make_unique<PlanType>();
-  status = rocfft_plan_create(&(plan->plan()), place, fft_direction, precision,
-                              reversed_fft_extents.size(),  // Dimension
-                              reversed_fft_extents.data(),  // Lengths
-                              howmany,      // Number of transforms
-                              *description  // Description
-  );
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_plan_create failed");
-  plan->set_is_plan_created();
-
-  // Prepare workbuffer and set execution information
-  status = rocfft_execution_info_create(&(plan->execution_info()));
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_execution_info_create failed");
-  plan->set_is_info_created();
-
-  // set stream
-  // NOTE: The stream must be of type hipStream_t.
-  // It is an error to pass the address of a hipStream_t object.
-  hipStream_t stream = exec_space.hip_stream();
-  status = rocfft_execution_info_set_stream(plan->execution_info(), stream);
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_execution_info_set_stream failed");
-
-  std::size_t workbuffersize = 0;
-  status = rocfft_plan_get_work_buffer_size(plan->plan(), &workbuffersize);
-  KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                     "rocfft_plan_get_work_buffer_size failed");
-
-  if (workbuffersize > 0) {
-    plan->allocate_work_buffer(workbuffersize);
-    status = rocfft_execution_info_set_work_buffer(
-        plan->execution_info(), (void*)plan->buffer_data(), workbuffersize);
-    KOKKOSFFT_THROW_IF(status != rocfft_status_success,
-                       "rocfft_execution_info_set_work_buffer failed");
-  }
+  plan =
+      std::make_unique<PlanType>(exec_space, type, in_extents, out_extents,
+                                 fft_extents, howmany, direction, is_inplace);
 
   return fft_size;
 }

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -170,13 +170,13 @@ auto create_plan(const ExecutionSpace& exec_space,
   );
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_plan_create failed");
-  plan->m_is_plan_created = true;
+  plan->set_is_plan_created();
 
   // Prepare workbuffer and set execution information
   status = rocfft_execution_info_create(&(plan->execution_info()));
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execution_info_create failed");
-  plan->m_is_info_created = true;
+  plan->set_is_info_created();
 
   // set stream
   // NOTE: The stream must be of type hipStream_t.
@@ -194,7 +194,7 @@ auto create_plan(const ExecutionSpace& exec_space,
   if (workbuffersize > 0) {
     plan->allocate_work_buffer(workbuffersize);
     status = rocfft_execution_info_set_work_buffer(
-        plan->execution_info(), (void*)plan->m_buffer.data(), workbuffersize);
+        plan->execution_info(), (void*)plan->buffer_data(), workbuffersize);
     KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                        "rocfft_execution_info_set_work_buffer failed");
   }

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -52,6 +52,10 @@ auto create_plan(const ExecutionSpace& exec_space,
       std::make_unique<PlanType>(exec_space, type, in_extents, out_extents,
                                  fft_extents, howmany, direction, is_inplace);
 
+  // Calculate the total size of the FFT
+  int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
+                                 std::multiplies<>());
+
   return fft_size;
 }
 

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -5,8 +5,6 @@
 #ifndef KOKKOSFFT_ROCM_PLANS_HPP
 #define KOKKOSFFT_ROCM_PLANS_HPP
 
-#include <numeric>
-#include <algorithm>
 #include "KokkosFFT_ROCM_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -192,8 +192,8 @@ auto create_plan(const ExecutionSpace& exec_space,
                      "rocfft_plan_get_work_buffer_size failed");
 
   if (workbuffersize > 0) {
-    plan->m_buffer = BufferViewType("work_buffer", workbuffersize);
-    status         = rocfft_execution_info_set_work_buffer(
+    plan->allocate_work_buffer(workbuffersize);
+    status = rocfft_execution_info_set_work_buffer(
         plan->execution_info(), (void*)plan->m_buffer.data(), workbuffersize);
     KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                        "rocfft_execution_info_set_work_buffer failed");

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -46,9 +46,9 @@ auto create_plan(const ExecutionSpace& exec_space,
       KokkosFFT::Impl::get_extents(in, out, axes, s, is_inplace);
 
   // Create a plan
-  plan =
-      std::make_unique<PlanType>(exec_space, type, in_extents, out_extents,
-                                 fft_extents, howmany, direction, is_inplace);
+  plan = std::make_unique<PlanType>(type, in_extents, out_extents, fft_extents,
+                                    howmany, direction, is_inplace);
+  plan->commit(exec_space);
 
   // Calculate the total size of the FFT
   int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -12,7 +12,7 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, float* idata,
+void exec_plan(ScopedPlanType& scoped_plan, float* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -22,7 +22,7 @@ void exec_plan(const ScopedPlanType& scoped_plan, float* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, double* idata,
+void exec_plan(ScopedPlanType& scoped_plan, double* idata,
                std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -32,7 +32,7 @@ void exec_plan(const ScopedPlanType& scoped_plan, double* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
                float* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -42,7 +42,7 @@ void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, std::complex<double>* idata,
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
                double* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -52,7 +52,7 @@ void exec_plan(const ScopedPlanType& scoped_plan, std::complex<double>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -62,7 +62,7 @@ void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(const ScopedPlanType& scoped_plan, std::complex<double>* idata,
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
                std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -7,12 +7,11 @@
 
 #include <complex>
 #include <rocfft/rocfft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_ROCM_types.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, float* idata,
+void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -21,8 +20,7 @@ void exec_plan(ScopedPlanType& scoped_plan, float* idata,
                      "rocfft_execute for R2C failed");
 }
 
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, double* idata,
+void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
                std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -31,8 +29,7 @@ void exec_plan(ScopedPlanType& scoped_plan, double* idata,
                      "rocfft_execute for D2Z failed");
 }
 
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
                float* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -41,9 +38,8 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
                      "rocfft_execute for C2R failed");
 }
 
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
-               double* odata, int /*direction*/) {
+void exec_plan(ScopedRocfftPlan<double>& scoped_plan,
+               std::complex<double>* idata, double* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -51,8 +47,7 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
                      "rocfft_execute for Z2D failed");
 }
 
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -61,9 +56,9 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
                      "rocfft_execute for C2C failed");
 }
 
-template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
-               std::complex<double>* odata, int /*direction*/) {
+void exec_plan(ScopedRocfftPlan<double>& scoped_plan,
+               std::complex<double>* idata, std::complex<double>* odata,
+               int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -11,8 +11,8 @@
 
 namespace KokkosFFT {
 namespace Impl {
-void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
-               std::complex<float>* odata, int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
+                      std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -20,8 +20,8 @@ void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
                      "rocfft_execute for R2C failed");
 }
 
-void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
-               std::complex<double>* odata, int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
+                      std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -29,8 +29,9 @@ void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
                      "rocfft_execute for D2Z failed");
 }
 
-void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
-               float* odata, int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
+                      std::complex<float>* idata, float* odata,
+                      int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -38,8 +39,9 @@ void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
                      "rocfft_execute for C2R failed");
 }
 
-void exec_plan(ScopedRocfftPlan<double>& scoped_plan,
-               std::complex<double>* idata, double* odata, int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
+                      std::complex<double>* idata, double* odata,
+                      int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -47,8 +49,9 @@ void exec_plan(ScopedRocfftPlan<double>& scoped_plan,
                      "rocfft_execute for Z2D failed");
 }
 
-void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
-               std::complex<float>* odata, int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
+                      std::complex<float>* idata, std::complex<float>* odata,
+                      int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -56,9 +59,9 @@ void exec_plan(ScopedRocfftPlan<float>& scoped_plan, std::complex<float>* idata,
                      "rocfft_execute for C2C failed");
 }
 
-void exec_plan(ScopedRocfftPlan<double>& scoped_plan,
-               std::complex<double>* idata, std::complex<double>* odata,
-               int /*direction*/) {
+inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
+                      std::complex<double>* idata, std::complex<double>* odata,
+                      int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -12,7 +12,7 @@
 namespace KokkosFFT {
 namespace Impl {
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, float* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, float* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -22,7 +22,7 @@ void exec_plan(ScopedPlanType& scoped_plan, float* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, double* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, double* idata,
                std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -32,7 +32,7 @@ void exec_plan(ScopedPlanType& scoped_plan, double* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
                float* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -42,7 +42,7 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, std::complex<double>* idata,
                double* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -52,7 +52,7 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, std::complex<float>* idata,
                std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -62,7 +62,7 @@ void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
 }
 
 template <typename ScopedPlanType>
-void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
+void exec_plan(const ScopedPlanType& scoped_plan, std::complex<double>* idata,
                std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -11,60 +11,65 @@
 
 namespace KokkosFFT {
 namespace Impl {
-inline void exec_plan(rocfft_plan& plan, float* idata,
-                      std::complex<float>* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, float* idata,
+               std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for R2C failed");
 }
 
-inline void exec_plan(rocfft_plan& plan, double* idata,
-                      std::complex<double>* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, double* idata,
+               std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for D2Z failed");
 }
 
-inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
-                      float* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+               float* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for C2R failed");
 }
 
-inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
-                      double* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
+               double* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for Z2D failed");
 }
 
-inline void exec_plan(rocfft_plan& plan, std::complex<float>* idata,
-                      std::complex<float>* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<float>* idata,
+               std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for C2C failed");
 }
 
-inline void exec_plan(rocfft_plan& plan, std::complex<double>* idata,
-                      std::complex<double>* odata, int /*direction*/,
-                      const rocfft_execution_info& execution_info) {
+template <typename ScopedPlanType>
+void exec_plan(ScopedPlanType& scoped_plan, std::complex<double>* idata,
+               std::complex<double>* odata, int /*direction*/) {
   rocfft_status status =
-      rocfft_execute(plan, (void**)&idata, (void**)&odata, execution_info);
+      rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
+                     scoped_plan.execution_info());
   KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                      "rocfft_execute for Z2Z failed");
 }
-
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -11,7 +11,7 @@
 
 namespace KokkosFFT {
 namespace Impl {
-inline void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
+inline void exec_plan(const ScopedRocfftPlan<float>& scoped_plan, float* idata,
                       std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
@@ -20,8 +20,9 @@ inline void exec_plan(ScopedRocfftPlan<float>& scoped_plan, float* idata,
                      "rocfft_execute for R2C failed");
 }
 
-inline void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
-                      std::complex<double>* odata, int /*direction*/) {
+inline void exec_plan(const ScopedRocfftPlan<double>& scoped_plan,
+                      double* idata, std::complex<double>* odata,
+                      int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -29,9 +30,9 @@ inline void exec_plan(ScopedRocfftPlan<double>& scoped_plan, double* idata,
                      "rocfft_execute for D2Z failed");
 }
 
-inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
-                      std::complex<float>* idata, float* odata,
-                      int /*direction*/) {
+inline void exec_plan(
+    const ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
+    std::complex<float>* idata, float* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -39,9 +40,9 @@ inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
                      "rocfft_execute for C2R failed");
 }
 
-inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
-                      std::complex<double>* idata, double* odata,
-                      int /*direction*/) {
+inline void exec_plan(
+    const ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
+    std::complex<double>* idata, double* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -49,9 +50,9 @@ inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
                      "rocfft_execute for Z2D failed");
 }
 
-inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
-                      std::complex<float>* idata, std::complex<float>* odata,
-                      int /*direction*/) {
+inline void exec_plan(
+    const ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
+    std::complex<float>* idata, std::complex<float>* odata, int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());
@@ -59,9 +60,10 @@ inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<float>>& scoped_plan,
                      "rocfft_execute for C2C failed");
 }
 
-inline void exec_plan(ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
-                      std::complex<double>* idata, std::complex<double>* odata,
-                      int /*direction*/) {
+inline void exec_plan(
+    const ScopedRocfftPlan<Kokkos::complex<double>>& scoped_plan,
+    std::complex<double>* idata, std::complex<double>* odata,
+    int /*direction*/) {
   rocfft_status status =
       rocfft_execute(scoped_plan.plan(), (void**)&idata, (void**)&odata,
                      scoped_plan.execution_info());

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -7,6 +7,7 @@
 
 #include <complex>
 #include <rocfft/rocfft.h>
+#include "KokkosFFT_asserts.hpp"
 #include "KokkosFFT_ROCM_types.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -180,7 +180,7 @@ struct ScopedRocfftPlan {
     if (status != rocfft_status_success)
       Kokkos::abort("rocfft_plan_destroy failed");
 
-    rocfft_status status = rocfft_execution_info_destroy(m_execution_info);
+    status = rocfft_execution_info_destroy(m_execution_info);
     if (status != rocfft_status_success)
       Kokkos::abort("rocfft_execution_info_destroy failed");
   }

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -85,8 +85,6 @@ struct ScopedRocfftPlan {
                    const std::vector<int> &out_extents,
                    const std::vector<int> &fft_extents, int howmany,
                    Direction direction, bool is_inplace) {
-    ScopedRocfftPlanDescription scoped_description;
-
     auto [in_array_type, out_array_type, fft_direction] =
         get_in_out_array_type(transform_type, direction);
 
@@ -101,6 +99,8 @@ struct ScopedRocfftPlan {
     auto reversed_fft_extents =
         convert_int_type_and_reverse<int, std::size_t>(fft_extents);
 
+    // Create a plan description
+    ScopedRocfftPlanDescription scoped_description;
     rocfft_status status = rocfft_plan_description_set_data_layout(
         scoped_description.description(),  // description handle
         in_array_type,                     // input array type

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -8,7 +8,6 @@
 #include <numeric>
 #include <algorithm>
 #include <complex>
-#include <iostream>
 #include <rocfft/rocfft.h>
 #include <Kokkos_Abort.hpp>
 #include "KokkosFFT_common_types.hpp"
@@ -56,6 +55,14 @@ struct ScopedRocfftPlanDescription {
       Kokkos::abort("rocfft_plan_description_destroy failed");
   }
 
+  ScopedRocfftPlanDescription()                                    = delete;
+  ScopedRocfftPlanDescription(const ScopedRocfftPlanDescription &) = delete;
+  ScopedRocfftPlanDescription &operator=(const ScopedRocfftPlanDescription &) =
+      delete;
+  ScopedRocfftPlanDescription &operator=(ScopedRocfftPlanDescription &&) =
+      delete;
+  ScopedRocfftPlanDescription(ScopedRocfftPlanDescription &&) = delete;
+
   rocfft_plan_description description() const noexcept { return m_description; }
 };
 
@@ -82,6 +89,13 @@ struct ScopedRocfftExecutionInfo {
     if (status != rocfft_status_success)
       Kokkos::abort("rocfft_execution_info_destroy failed");
   }
+
+  ScopedRocfftExecutionInfo()                                  = delete;
+  ScopedRocfftExecutionInfo(const ScopedRocfftExecutionInfo &) = delete;
+  ScopedRocfftExecutionInfo &operator=(const ScopedRocfftExecutionInfo &) =
+      delete;
+  ScopedRocfftExecutionInfo &operator=(ScopedRocfftExecutionInfo &&) = delete;
+  ScopedRocfftExecutionInfo(ScopedRocfftExecutionInfo &&)            = delete;
 
   rocfft_execution_info execution_info() const noexcept {
     return m_execution_info;

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -5,6 +5,8 @@
 #ifndef KOKKOSFFT_ROCM_TYPES_HPP
 #define KOKKOSFFT_ROCM_TYPES_HPP
 
+#include <numeric>
+#include <algorithm>
 #include <complex>
 #include <rocfft/rocfft.h>
 #include <Kokkos_Abort.hpp>

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -55,7 +55,6 @@ struct ScopedRocfftPlanDescription {
       Kokkos::abort("rocfft_plan_description_destroy failed");
   }
 
-  ScopedRocfftPlanDescription()                                    = delete;
   ScopedRocfftPlanDescription(const ScopedRocfftPlanDescription &) = delete;
   ScopedRocfftPlanDescription &operator=(const ScopedRocfftPlanDescription &) =
       delete;
@@ -90,7 +89,6 @@ struct ScopedRocfftExecutionInfo {
       Kokkos::abort("rocfft_execution_info_destroy failed");
   }
 
-  ScopedRocfftExecutionInfo()                                  = delete;
   ScopedRocfftExecutionInfo(const ScopedRocfftExecutionInfo &) = delete;
   ScopedRocfftExecutionInfo &operator=(const ScopedRocfftExecutionInfo &) =
       delete;

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -203,11 +203,11 @@ struct ScopedRocfftPlan {
 
   // Helper to convert the integer type of vectors
   template <typename InType, typename OutType>
-  auto convert_int_type_and_reverse(std::vector<InType> &in)
+  auto convert_int_type_and_reverse(const std::vector<InType> &in)
       -> std::vector<OutType> {
     std::vector<OutType> out(in.size());
     std::transform(
-        in.begin(), in.end(), out.begin(),
+        in.cbegin(), in.cend(), out.begin(),
         [](const InType v) -> OutType { return static_cast<OutType>(v); });
 
     std::reverse(out.begin(), out.end());

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -56,7 +56,7 @@ struct ScopedRocfftPlanDescription {
       Kokkos::abort("rocfft_plan_description_destroy failed");
   }
 
-  rocfft_plan_description &description() { return m_description; }
+  rocfft_plan_description description() const noexcept { return m_description; }
 };
 
 /// \brief A class that wraps rocfft for RAII
@@ -172,7 +172,9 @@ struct ScopedRocfftPlan {
   ScopedRocfftPlan(ScopedRocfftPlan &&)                 = delete;
 
   rocfft_plan plan() const noexcept { return m_plan; }
-  rocfft_execution_info &execution_info() { return m_execution_info; }
+  rocfft_execution_info execution_info() const noexcept {
+    return m_execution_info;
+  }
 
  private:
   void cleanup() {

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -8,6 +8,9 @@
 #include <complex>
 #include <rocfft/rocfft.h>
 #include "KokkosFFT_common_types.hpp"
+#if defined(ENABLE_HOST_AND_DEVICE)
+#include "KokkosFFT_FFTW_Types.hpp"
+#endif
 
 // Check the size of complex type
 static_assert(sizeof(std::complex<float>) == sizeof(Kokkos::complex<float>));
@@ -17,26 +20,44 @@ static_assert(sizeof(std::complex<double>) == sizeof(Kokkos::complex<double>));
 static_assert(alignof(std::complex<double>) <=
               alignof(Kokkos::complex<double>));
 
-#ifdef ENABLE_HOST_AND_DEVICE
-#include <fftw3.h>
-#include "KokkosFFT_utils.hpp"
-static_assert(sizeof(fftwf_complex) == sizeof(Kokkos::complex<float>));
-static_assert(alignof(fftwf_complex) <= alignof(Kokkos::complex<float>));
-
-static_assert(sizeof(fftw_complex) == sizeof(Kokkos::complex<double>));
-static_assert(alignof(fftw_complex) <= alignof(Kokkos::complex<double>));
-#endif
-
 namespace KokkosFFT {
 namespace Impl {
 using FFTDirectionType                     = int;
 constexpr FFTDirectionType ROCFFT_FORWARD  = 1;
 constexpr FFTDirectionType ROCFFT_BACKWARD = -1;
 
+#if !defined(ENABLE_HOST_AND_DEVICE)
 enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
+#endif
 
 template <typename ExecutionSpace>
 using TransformType = FFTWTransformType;
+
+/// \brief A class that wraps rocfft for RAII
+template <typename ExecutionSpace, typename T1, typename T2>
+struct ScopedRocfftPlanType {
+  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T1>;
+  rocfft_plan m_plan;
+  rocfft_execution_info m_execution_info;
+
+  using BufferViewType =
+      Kokkos::View<Kokkos::complex<floating_point_type> *, ExecutionSpace>;
+
+  bool m_is_info_created = false;
+  bool m_is_plan_created = false;
+
+  //! Internal work buffer
+  BufferViewType m_buffer;
+
+  ScopedRocfftPlanType() {}
+  ~ScopedRocfftPlanType() {
+    if (m_is_info_created) rocfft_execution_info_destroy(m_execution_info);
+    if (m_is_plan_created) rocfft_plan_destroy(m_plan);
+  }
+
+  rocfft_plan &plan() { return m_plan; }
+  rocfft_execution_info &execution_info() { return m_execution_info; }
+};
 
 // Define fft transform types
 template <typename ExecutionSpace, typename T1, typename T2>
@@ -76,7 +97,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
   static constexpr FFTWTransformType type() { return m_type; };
 };
 
-#ifdef ENABLE_HOST_AND_DEVICE
+#if defined(ENABLE_HOST_AND_DEVICE)
 
 template <typename ExecutionSpace>
 struct FFTDataType {
@@ -92,17 +113,11 @@ struct FFTDataType {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using fftwHandle = std::conditional_t<
-      std::is_same_v<KokkosFFT::Impl::base_floating_point_type<T1>, float>,
-      fftwf_plan, fftw_plan>;
+  using fftw_plan_type   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using rocfft_plan_type = ScopedRocfftPlanType<ExecutionSpace, T1, T2>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                                  rocfft_plan, fftwHandle>;
+                                  rocfft_plan_type, fftw_plan_type>;
 };
-
-template <typename ExecutionSpace>
-using FFTInfoType =
-    std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
-                       rocfft_execution_info, int>;
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {
@@ -126,11 +141,8 @@ struct FFTDataType {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = rocfft_plan;
+  using type = ScopedRocfftPlanType<ExecutionSpace, T1, T2>;
 };
-
-template <typename ExecutionSpace>
-using FFTInfoType = rocfft_execution_info;
 
 template <typename ExecutionSpace>
 auto direction_type(Direction direction) {

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -79,12 +79,10 @@ struct ScopedRocfftPlan {
         get_in_out_array_type(transform_type, direction);
 
     // Compute dist and strides from extents
-    int idist    = std::accumulate(in_extents.begin(), in_extents.end(), 1,
-                                   std::multiplies<>());
-    int odist    = std::accumulate(out_extents.begin(), out_extents.end(), 1,
-                                   std::multiplies<>());
-    int fft_size = std::accumulate(fft_extents.begin(), fft_extents.end(), 1,
-                                   std::multiplies<>());
+    int idist = std::accumulate(in_extents.begin(), in_extents.end(), 1,
+                                std::multiplies<>());
+    int odist = std::accumulate(out_extents.begin(), out_extents.end(), 1,
+                                std::multiplies<>());
 
     auto in_strides  = compute_strides<int, std::size_t>(in_extents);
     auto out_strides = compute_strides<int, std::size_t>(out_extents);
@@ -151,8 +149,6 @@ struct ScopedRocfftPlan {
       KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                          "rocfft_execution_info_set_work_buffer failed");
     }
-
-    return fft_size;
   }
   ~ScopedRocfftPlan() noexcept {
     if (m_is_info_created) {

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -34,9 +34,9 @@ template <typename ExecutionSpace>
 using TransformType = FFTWTransformType;
 
 /// \brief A class that wraps rocfft for RAII
-template <typename ExecutionSpace, typename T1, typename T2>
+template <typename ExecutionSpace, typename T>
 struct ScopedRocfftPlanType {
-  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T1>;
+  using floating_point_type = KokkosFFT::Impl::base_floating_point_type<T>;
   rocfft_plan m_plan;
   rocfft_execution_info m_execution_info;
 
@@ -55,6 +55,9 @@ struct ScopedRocfftPlanType {
     if (m_is_plan_created) rocfft_plan_destroy(m_plan);
   }
 
+  void allocate_work_buffer(std::size_t workbuffersize) {
+    m_buffer = BufferViewType("work buffer", workbuffersize);
+  }
   rocfft_plan &plan() { return m_plan; }
   rocfft_execution_info &execution_info() { return m_execution_info; }
 };
@@ -114,7 +117,7 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftw_plan_type   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
-  using rocfft_plan_type = ScopedRocfftPlanType<ExecutionSpace, T1, T2>;
+  using rocfft_plan_type = ScopedRocfftPlanType<ExecutionSpace, T1>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   rocfft_plan_type, fftw_plan_type>;
 };
@@ -141,7 +144,7 @@ struct FFTDataType {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedRocfftPlanType<ExecutionSpace, T1, T2>;
+  using type = ScopedRocfftPlanType<ExecutionSpace, T1>;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -138,7 +138,7 @@ struct FFTDataType {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using fftw_plan_type   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using fftw_plan_type   = ScopedFFTWPlan<ExecutionSpace, T1, T2>;
   using rocfft_plan_type = ScopedRocfftPlan<ExecutionSpace, T1>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   rocfft_plan_type, fftw_plan_type>;

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -144,7 +144,7 @@ struct ScopedRocfftPlan {
   void commit(const Kokkos::HIP &exec_space) {
     try {
       // Prepare workbuffer and set execution information
-      status = rocfft_execution_info_create(&m_execution_info);
+      rocfft_status status = rocfft_execution_info_create(&m_execution_info);
       KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                          "rocfft_execution_info_create failed");
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -192,7 +192,8 @@ struct ScopedRocfftPlan {
 
   void commit(const Kokkos::HIP &exec_space) {
     std::size_t workbuffersize = 0;
-    status = rocfft_plan_get_work_buffer_size(m_plan, &workbuffersize);
+    rocfft_status status =
+        rocfft_plan_get_work_buffer_size(m_plan, &workbuffersize);
     KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                        "rocfft_plan_get_work_buffer_size failed");
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -197,7 +197,7 @@ struct ScopedRocfftPlan {
     KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                        "rocfft_plan_get_work_buffer_size failed");
 
-    m_execution_info = std::make_unique<ScopedRocfftExecutionInfo>();
+    m_execution_info = std::make_unique<ScopedRocfftExecutionInfoType>();
     m_execution_info->setup(exec_space, workbuffersize);
   }
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -56,7 +56,7 @@ struct ScopedRocfftPlanDescription {
   }
 
   rocfft_plan_description &description() { return m_description; }
-}
+};
 
 /// \brief A class that wraps rocfft for RAII
 template <typename T>
@@ -101,7 +101,7 @@ struct ScopedRocfftPlan {
     auto reversed_fft_extents =
         convert_int_type_and_reverse<int, std::size_t>(fft_extents);
 
-    status = rocfft_plan_description_set_data_layout(
+    rocfft_status status = rocfft_plan_description_set_data_layout(
         scoped_description.description(),  // description handle
         in_array_type,                     // input array type
         out_array_type,                    // output array type

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -8,6 +8,7 @@
 #include <complex>
 #include <rocfft/rocfft.h>
 #include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_traits.hpp"
 #if defined(ENABLE_HOST_AND_DEVICE)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -58,7 +58,7 @@ struct ScopedRocfftPlan {
 
  public:
   ScopedRocfftPlan(const Kokkos::HIP &exec_space,
-                   const TransformType transform_type,
+                   const FFTWTransformType transform_type,
                    const std::vector<int> &in_extents,
                    const std::vector<int> &out_extents,
                    const std::vector<int> &fft_extents, int howmany,
@@ -151,6 +151,8 @@ struct ScopedRocfftPlan {
       KOKKOSFFT_THROW_IF(status != rocfft_status_success,
                          "rocfft_execution_info_set_work_buffer failed");
     }
+
+    return fft_size;
   }
   ~ScopedRocfftPlan() noexcept {
     if (m_is_info_created) {
@@ -176,7 +178,7 @@ struct ScopedRocfftPlan {
 
  private:
   // Helper to get input and output array type and direction from transform type
-  auto get_in_out_array_type(TransformType type, Direction direction) {
+  auto get_in_out_array_type(FFTWTransformType type, Direction direction) {
     rocfft_array_type in_array_type, out_array_type;
     rocfft_transform_type fft_direction;
 
@@ -291,7 +293,7 @@ struct FFTDataType {
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
   using fftw_plan_type   = ScopedFFTWPlan<ExecutionSpace, T1, T2>;
-  using rocfft_plan_type = ScopedRocfftPlan<ExecutionSpace, T1>;
+  using rocfft_plan_type = ScopedRocfftPlan<T1>;
   using type = std::conditional_t<std::is_same_v<ExecutionSpace, Kokkos::HIP>,
                                   rocfft_plan_type, fftw_plan_type>;
 };
@@ -318,7 +320,7 @@ struct FFTDataType {
 
 template <typename ExecutionSpace, typename T1, typename T2>
 struct FFTPlanType {
-  using type = ScopedRocfftPlan<ExecutionSpace, T1>;
+  using type = ScopedRocfftPlan<T1>;
 };
 
 template <typename ExecutionSpace>

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -46,15 +46,14 @@ auto compute_strides(std::vector<InType>& extents) -> std::vector<OutType> {
 // batched transform, over ND Views
 template <
     typename ExecutionSpace, typename PlanType, typename InViewType,
-    typename OutViewType, typename BufferViewType, typename InfoType,
-    std::size_t fft_rank             = 1,
+    typename OutViewType, std::size_t fft_rank = 1,
     std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
                      std::nullptr_t> = nullptr>
 auto create_plan(const ExecutionSpace& exec_space,
                  std::unique_ptr<PlanType>& plan, const InViewType& in,
-                 const OutViewType& out, BufferViewType&, InfoType&,
-                 Direction /*direction*/, axis_type<fft_rank> axes,
-                 shape_type<fft_rank> s, bool is_inplace) {
+                 const OutViewType& out, Direction /*direction*/,
+                 axis_type<fft_rank> axes, shape_type<fft_rank> s,
+                 bool is_inplace) {
   static_assert(
       KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
                                               OutViewType>,
@@ -108,14 +107,6 @@ auto create_plan(const ExecutionSpace& exec_space,
   plan->commit(q);
 
   return fft_size;
-}
-
-template <
-    typename ExecutionSpace, typename PlanType, typename InfoType,
-    std::enable_if_t<std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>,
-                     std::nullptr_t> = nullptr>
-void destroy_plan_and_info(std::unique_ptr<PlanType>&, InfoType&) {
-  // In oneMKL, plans are destroyed by destructor
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -108,8 +108,7 @@ struct FFTPlanType<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
-  using fftwHandle =
-      ScopedFFTWPlanType<ExecutionSpace, T1, Kokkos::complex<T2>>;
+  using fftwHandle   = ScopedFFTWPlan<ExecutionSpace, T1, Kokkos::complex<T2>>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,
@@ -127,8 +126,7 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
-  using fftwHandle =
-      ScopedFFTWPlanType<ExecutionSpace, Kokkos::complex<T1>, T2>;
+  using fftwHandle   = ScopedFFTWPlan<ExecutionSpace, Kokkos::complex<T1>, T2>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,
@@ -146,8 +144,8 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::COMPLEX;
 
-  using fftwHandle   = ScopedFFTWPlanType<ExecutionSpace, Kokkos::complex<T1>,
-                                        Kokkos::complex<T2>>;
+  using fftwHandle =
+      ScopedFFTWPlan<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -108,7 +108,8 @@ struct FFTPlanType<ExecutionSpace, T1, Kokkos::complex<T2>> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
-  using fftwHandle   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using fftwHandle =
+      ScopedFFTWPlanType<ExecutionSpace, T1, Kokkos::complex<T2>>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,
@@ -126,7 +127,8 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, T2> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::REAL;
 
-  using fftwHandle   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using fftwHandle =
+      ScopedFFTWPlanType<ExecutionSpace, Kokkos::complex<T1>, T2>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,
@@ -144,7 +146,8 @@ struct FFTPlanType<ExecutionSpace, Kokkos::complex<T1>, Kokkos::complex<T2>> {
   static constexpr oneapi::mkl::dft::domain dom =
       oneapi::mkl::dft::domain::COMPLEX;
 
-  using fftwHandle   = ScopedFFTWPlanType<ExecutionSpace, T1, T2>;
+  using fftwHandle   = ScopedFFTWPlanType<ExecutionSpace, Kokkos::complex<T1>,
+                                        Kokkos::complex<T2>>;
   using onemklHandle = oneapi::mkl::dft::descriptor<prec, dom>;
   using type         = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>, onemklHandle,


### PR DESCRIPTION
Resolves #197 

In this PR, we try to resolve RAII issues by introducing a thin wrapper for backend fft plans.
Following modifications are made,

- [x] Introducing a `KokkosFFT_FFTW_Types.hpp` file including the `FFTW` plan wrapper class and common code bases related fftw
- [x] Introducing a wrapper class for automatic deallocation. Wrappers are added for `FFTW`, `cufft`, `hipfft`, and `rocfft` (`Scoped***Plan`) 
For CUDA, we have

```C++
struct ScopedCufftPlanType {
   cufftHandle m_plan;
   // Should we raise an error here, if it fails?
   ScopedCufftPlanType() { cufftCreate(&m_plan); }
   
   // Should we abort here, if it fails?
   ~ScopedCufftPlanType() { cufftDestroy(m_plan); }

   cufftHandle &plan() { return m_plan; }
};
```

- [x] `Info` and `Buffer` that are required only for rocfft are moved inside `rocfft` helper class
- [x] Add missing `cleanup_threads()` in the destructor of FFTW helper class
- [x] Remove `destroy_plan_and_info` since it is automatically done in destructors of helper classes

Questions
1. We are creating plans inside a constructor for `cufft` and `hipfft`. Should we raise assertions in constructor if it fails?
2. What should we do if destroy functions in destructor fails. Should we abort?