### PR TITLE
fix: add the write permission to cleanup base images CI

### DIFF
--- a/.github/workflows/cleanup_base.yaml
+++ b/.github/workflows/cleanup_base.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Cleanup old images


### PR DESCRIPTION
Fixes the issue encountered in the [cleanup base CI](https://github.com/kokkos/kokkos-fft/actions/runs/13095011204), by adding the write permission.