### PR TITLE
Add check to ensure complex alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,9 @@ if (NOT KokkosFFT_ENABLE_INTERNAL_KOKKOS)
     # First check, Kokkos is added as subdirectory or not
     if(NOT TARGET Kokkos::kokkos)
         find_package(Kokkos ${KOKKOS_REQUIRED_VERSION} REQUIRED)
+        # Check the alignment of complex numbers
+        kokkos_check(OPTIONS COMPLEX_ALIGN)
     endif()
-    # Check the alignment of complex numbers
-    kokkos_check(OPTIONS COMPLEX_ALIGN)
 else ()
     add_subdirectory(tpls/kokkos)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if (NOT KokkosFFT_ENABLE_INTERNAL_KOKKOS)
     if(NOT TARGET Kokkos::kokkos)
         find_package(Kokkos ${KOKKOS_REQUIRED_VERSION} REQUIRED)
     endif()
+    # Check the alignment of complex numbers
+    kokkos_check(OPTIONS COMPLEX_ALIGN)
 else ()
     add_subdirectory(tpls/kokkos)
 endif ()

--- a/fft/src/KokkosFFT_default_types.hpp
+++ b/fft/src/KokkosFFT_default_types.hpp
@@ -7,6 +7,12 @@
 
 #include <Kokkos_Core.hpp>
 
+#if !defined(KOKKOS_ENABLE_COMPLEX_ALIGN)
+static_assert(false,
+              "KokkosFFT requires option -DKokkos_ENABLE_COMPLEX_ALIGN=ON to "
+              "build Kokkos");
+#endif
+
 #if defined(KOKKOS_ENABLE_CUDA)
 #include "KokkosFFT_Cuda_types.hpp"
 #elif defined(KOKKOS_ENABLE_HIP)


### PR DESCRIPTION
Resolves #226 

In kokkos-fft, we strongly assume the 32 bit alignment of `Kokkos::complex` type. 
This PR checks whether `KOKKOS_ENABLE_COMPLEX_ALIGN` is enabled in `CMake` and `cpp` code.