### PR TITLE
Cleanup implementation details

### DIFF
--- a/examples/08_inplace_FFT/08_inplace_FFT.cpp
+++ b/examples/08_inplace_FFT/08_inplace_FFT.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
     RightView2D<double> xr2c(reinterpret_cast<double *>(xr2c_hat.data()), n0,
                              n1),
         xr2c_padded(reinterpret_cast<double *>(xr2c_hat.data()), n0,
-                    (n0 / 2 + 1) * 2);
+                    (n1 / 2 + 1) * 2);
 
     // Fill the input view with random data in real space through xr2c_padded
     auto sub_xr2c_padded =

--- a/fft/src/KokkosFFT_SYCL_transform.hpp
+++ b/fft/src/KokkosFFT_SYCL_transform.hpp
@@ -11,45 +11,45 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, float* idata, std::complex<float>* odata,
-               int /*direction*/, Args...) {
+               int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecR2C]");
   oneapi::mkl::dft::compute_forward(plan, idata,
                                     reinterpret_cast<float*>(odata));
 }
 
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, double* idata, std::complex<double>* odata,
-               int /*direction*/, Args...) {
+               int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecD2Z]");
   oneapi::mkl::dft::compute_forward(plan, idata,
                                     reinterpret_cast<double*>(odata));
 }
 
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, std::complex<float>* idata, float* odata,
-               int /*direction*/, Args...) {
+               int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecC2R]");
   oneapi::mkl::dft::compute_backward(plan, reinterpret_cast<float*>(idata),
                                      odata);
 }
 
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, std::complex<double>* idata, double* odata,
-               int /*direction*/, Args...) {
+               int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecZ2D]");
   oneapi::mkl::dft::compute_backward(plan, reinterpret_cast<double*>(idata),
                                      odata);
 }
 
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, std::complex<float>* idata,
-               std::complex<float>* odata, int direction, Args...) {
+               std::complex<float>* odata, int direction) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecC2C]");
   if (direction == 1) {
@@ -59,9 +59,9 @@ void exec_plan(PlanType& plan, std::complex<float>* idata,
   }
 }
 
-template <typename PlanType, typename... Args>
+template <typename PlanType>
 void exec_plan(PlanType& plan, std::complex<double>* idata,
-               std::complex<double>* odata, int direction, Args...) {
+               std::complex<double>* odata, int direction) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_oneMKLExecZ2Z]");
   if (direction == 1) {

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -143,7 +143,9 @@ void rfft(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::rfft");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
-  fft(exec_space, in, out, norm, axis, n);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axis,
+                       n);
+  plan.execute_impl(in, out, norm);
 }
 
 /// \brief Inverse of rfft
@@ -186,7 +188,9 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::irfft");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
-  ifft(exec_space, in, out, norm, axis, n);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axis, n);
+  plan.execute_impl(in, out, norm);
 }
 
 /// \brief One dimensional FFT of a signal that has Hermitian symmetry
@@ -397,7 +401,9 @@ void rfft2(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::rfft2");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  fft2(exec_space, in, out, norm, axes, s);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
+                       s);
+  plan.execute_impl(in, out, norm);
 }
 
 /// \brief Inverse of rfft2
@@ -439,7 +445,9 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::irfft2");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  ifft2(exec_space, in, out, norm, axes, s);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axes, s);
+  plan.execute_impl(in, out, norm);
 }
 
 // ND FFT
@@ -595,7 +603,9 @@ void rfftn(
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::rfftn");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  fftn(exec_space, in, out, axes, norm, s);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
+                       s);
+  plan.execute_impl(in, out, norm);
 }
 
 /// \brief Inverse of rfftn
@@ -651,9 +661,10 @@ void irfftn(
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::irfftn");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  ifftn(exec_space, in, out, axes, norm, s);
+  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::backward,
+                       axes, s);
+  plan.execute_impl(in, out, norm);
 }
-
 }  // namespace KokkosFFT
 
 #endif

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -1627,7 +1627,7 @@ void test_fft2_2dfft_2dview_inplace([[maybe_unused]] T atol = 1.0e-12) {
       inv_xr_hat_unpadded("inv_xr_hat_unpadded", n0, n1),
       inv_xr_hat_ref("inv_xr_hat_ref", n0, n1);
 
-  // Unmanged views for in-place transforms
+  // Unmanaged views for in-place transforms
   RealView2DType xr(reinterpret_cast<T*>(xr_hat.data()), n0, n1),
       inv_xr_hat(reinterpret_cast<T*>(xr_hat.data()), n0, n1);
   RealView2DType xr_padded(reinterpret_cast<T*>(xr_hat.data()), n0,


### PR DESCRIPTION
This PR aims at cleaning up the implementation details.

- [x] Fix the data shape in inplace transform example
- [x] Remove unused variadic template arguments
- [x] Do not call fft/ifft inside rfft/irfft for better profiling
- [x] Fix typo in the unit-test 