### PR TITLE
Add unit testing tools

### DIFF
--- a/.github/workflows/__clang-format-check.yaml
+++ b/.github/workflows/__clang-format-check.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73  # v0.20
       with:
-        source: 'common/ fft/ examples/ install_test/'
+        source: 'common/ fft/ examples/ install_test/ testing/'
         exclude: ''
         extensions: 'hpp,cpp'
         clangFormatVersion: 17

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: crate-ci/typos@b1a1ef3893ff35ade0cfa71523852a49bfd05d19  # v1.31.1
       with:
-        files: ./cmake/ ./CMakeLists.txt ./docs/ ./README.md ./common/ ./fft/ ./examples/ ./install_test/
+        files: ./cmake/ ./CMakeLists.txt ./docs/ ./README.md ./common/ ./fft/ ./examples/ ./install_test/ ./testing/
         config: ./.typos.toml
 
   # build project
@@ -77,7 +77,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
               benchmark: ON
             cmake_build_type: Release
           - name: serial
@@ -121,7 +121,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
               benchmark: ON
             cmake_build_type: Release
           - name: sycl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ if(KokkosFFT_ENABLE_TESTS)
   if(NOT GTest_FOUND)
     add_subdirectory(tpls/googletest)
   endif()
+  if(KokkosFFT_ENABLE_TESTING_TOOLS)
+    add_subdirectory(testing)
+  endif()
 endif()
 
 # Build documentation with Doxygen and Sphinx

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+add_subdirectory(src)
+add_subdirectory(unit_test)

--- a/testing/src/CMakeLists.txt
+++ b/testing/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+add_library(testing INTERFACE)
+
+target_link_libraries(testing INTERFACE Kokkos::kokkos GTest::gtest GTest::gmock)
+
+target_include_directories(
+    testing INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>
+)
+add_library(KokkosFFT::testing ALIAS testing)

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -23,7 +23,8 @@ namespace Impl {
 /// \tparam BViewType The type of the second Kokkos view.
 ///
 /// \param listener [out] The testing match result listener.
-/// \param exec_space [in] The execution space used to launch the parallel kernel.
+/// \param exec_space [in] The execution space used to launch the parallel
+/// kernel.
 /// \param actual [in] The actual Kokkos view.
 /// \param expected [in] The expected (reference) Kokkos view.
 /// \param rtol [in]  Relative tolerance for comparing the view elements

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -29,11 +29,11 @@ MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
       exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
-  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
       exec_space, arg, expected, errors, rtol, atol);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error, verbose);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *result_listener << error_str;
@@ -54,11 +54,11 @@ MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
       exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
-  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
       exec_space, arg, expected, errors, rtol, atol);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *result_listener << error_str;
@@ -80,11 +80,11 @@ MATCHER_P3(allclose, exec_space, expected, rtol, "") {
       exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
-  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
       exec_space, arg, expected, errors, rtol, atol);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *result_listener << error_str;
@@ -106,11 +106,11 @@ MATCHER_P2(allclose, exec_space, expected, "") {
       exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
-  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
       exec_space, arg, expected, errors, rtol, atol);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *result_listener << error_str;

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -14,107 +14,75 @@
 
 namespace KokkosFFT {
 namespace Testing {
-
-MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
-  const std::size_t rank = arg.rank();
+namespace Impl {
+/// \brief Compares two Kokkos views element-wise and checks if they are close
+///        within specified relative and absolute tolerances.
+///
+/// \tparam ExecutionSpace The type of the Kokkos execution space.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+///
+/// \param listener [out] The testing match result listener.
+/// \param exec_space [in] The execution space used to launch the parallel kernel.
+/// \param actual [in] The actual Kokkos view.
+/// \param expected [in] The expected (reference) Kokkos view.
+/// \param rtol [in]  Relative tolerance for comparing the view elements
+/// (default 1.e-5).
+/// \param atol [in] Absolute tolerance for comparing the view elements
+/// (default 1.e-8).
+/// \param verbose [in] How many elements to be reported (default: 3)
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType>
+  requires KokkosViewAccessible<ExecutionSpace, AViewType> &&
+           KokkosViewAccessible<ExecutionSpace, BViewType>
+inline bool allclose_impl(testing::MatchResultListener* listener,
+                          const ExecutionSpace& exec_space,
+                          const AViewType& actual, const BViewType& expected,
+                          double rtol, double atol, std::size_t verbose) {
+  const std::size_t rank = actual.rank();
   for (std::size_t i = 0; i < rank; i++) {
-    if (arg.extent(i) != expected.extent(i)) {
-      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
-                       << arg.label() + ".extent(" + std::to_string(i) + ")";
+    if (actual.extent(i) != expected.extent(i)) {
+      *listener << actual.label() + ".extent(" + std::to_string(i) + ") != "
+                << expected.label() + ".extent(" + std::to_string(i) + ")";
       return false;
     }
   }
 
   std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
-      exec_space, arg, expected, rtol, atol);
+      exec_space, actual, expected, rtol, atol);
   if (errors == 0) return true;
 
   auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
-      exec_space, arg, expected, errors, rtol, atol);
+      exec_space, actual, expected, errors, rtol, atol);
 
+  exec_space.fence();
   auto error_map =
       KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error, verbose);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
-  *result_listener << error_str;
+  *listener << error_str;
   return false;
+}
+}  // namespace Impl
+
+MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
+  return Impl::allclose_impl(result_listener, exec_space, arg, expected, rtol,
+                             atol, verbose);
 }
 
 MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
-  const std::size_t rank = arg.rank();
-  for (std::size_t i = 0; i < rank; i++) {
-    if (arg.extent(i) != expected.extent(i)) {
-      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
-                       << arg.label() + ".extent(" + std::to_string(i) + ")";
-      return false;
-    }
-  }
-
-  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
-      exec_space, arg, expected, rtol, atol);
-  if (errors == 0) return true;
-
-  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
-      exec_space, arg, expected, errors, rtol, atol);
-
-  auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
-  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
-
-  *result_listener << error_str;
-  return false;
+  return Impl::allclose_impl(result_listener, exec_space, arg, expected, rtol,
+                             atol, 3);
 }
 
 MATCHER_P3(allclose, exec_space, expected, rtol, "") {
-  double atol            = 1.0e-8;
-  const std::size_t rank = arg.rank();
-  for (std::size_t i = 0; i < rank; i++) {
-    if (arg.extent(i) != expected.extent(i)) {
-      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
-                       << arg.label() + ".extent(" + std::to_string(i) + ")";
-      return false;
-    }
-  }
-
-  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
-      exec_space, arg, expected, rtol, atol);
-  if (errors == 0) return true;
-
-  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
-      exec_space, arg, expected, errors, rtol, atol);
-
-  auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
-  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
-
-  *result_listener << error_str;
-  return false;
+  return Impl::allclose_impl(result_listener, exec_space, arg, expected, rtol,
+                             1.0e-8, 3);
 }
 
 MATCHER_P2(allclose, exec_space, expected, "") {
-  const double rtol = 1.0e-5, atol = 1.0e-8;
-  const std::size_t rank = arg.rank();
-  for (std::size_t i = 0; i < rank; i++) {
-    if (arg.extent(i) != expected.extent(i)) {
-      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
-                       << arg.label() + ".extent(" + std::to_string(i) + ")";
-      return false;
-    }
-  }
-
-  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
-      exec_space, arg, expected, rtol, atol);
-  if (errors == 0) return true;
-
-  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
-      exec_space, arg, expected, errors, rtol, atol);
-
-  auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error);
-  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
-
-  *result_listener << error_str;
-  return false;
+  return Impl::allclose_impl(result_listener, exec_space, arg, expected, 1.0e-5,
+                             1.0e-8, 3);
 }
 
 }  // namespace Testing

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -17,7 +17,7 @@ namespace Testing {
 
 MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
   const std::size_t rank = arg.rank();
-  for (int i = 0; i < rank; i++) {
+  for (std::size_t i = 0; i < rank; i++) {
     if (arg.extent(i) != expected.extent(i)) {
       *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
                        << arg.label() + ".extent(" + std::to_string(i) + ")";
@@ -25,8 +25,8 @@ MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
     }
   }
 
-  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
-                                                      rtol, atol);
+  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
+      exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
   auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
@@ -42,7 +42,7 @@ MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
 
 MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
   const std::size_t rank = arg.rank();
-  for (int i = 0; i < rank; i++) {
+  for (std::size_t i = 0; i < rank; i++) {
     if (arg.extent(i) != expected.extent(i)) {
       *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
                        << arg.label() + ".extent(" + std::to_string(i) + ")";
@@ -50,8 +50,8 @@ MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
     }
   }
 
-  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
-                                                      rtol, atol);
+  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
+      exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
   auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
@@ -68,7 +68,7 @@ MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
 MATCHER_P3(allclose, exec_space, expected, rtol, "") {
   double atol            = 1.0e-8;
   const std::size_t rank = arg.rank();
-  for (int i = 0; i < rank; i++) {
+  for (std::size_t i = 0; i < rank; i++) {
     if (arg.extent(i) != expected.extent(i)) {
       *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
                        << arg.label() + ".extent(" + std::to_string(i) + ")";
@@ -76,8 +76,8 @@ MATCHER_P3(allclose, exec_space, expected, rtol, "") {
     }
   }
 
-  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
-                                                      rtol, atol);
+  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
+      exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
   auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
@@ -94,7 +94,7 @@ MATCHER_P3(allclose, exec_space, expected, rtol, "") {
 MATCHER_P2(allclose, exec_space, expected, "") {
   const double rtol = 1.0e-5, atol = 1.0e-8;
   const std::size_t rank = arg.rank();
-  for (int i = 0; i < rank; i++) {
+  for (std::size_t i = 0; i < rank; i++) {
     if (arg.extent(i) != expected.extent(i)) {
       *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
                        << arg.label() + ".extent(" + std::to_string(i) + ")";
@@ -102,8 +102,8 @@ MATCHER_P2(allclose, exec_space, expected, "") {
     }
   }
 
-  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
-                                                      rtol, atol);
+  std::size_t errors = KokkosFFT::Testing::Impl::count_errors(
+      exec_space, arg, expected, rtol, atol);
   if (errors == 0) return true;
 
   auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_ALLCLOSE_HPP
+#define KOKKOSFFT_ALLCLOSE_HPP
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Concepts.hpp"
+#include "KokkosFFT_CountErrors.hpp"
+#include "KokkosFFT_PrintErrors.hpp"
+
+namespace KokkosFFT {
+namespace Testing {
+
+MATCHER_P5(allclose, exec_space, expected, rtol, atol, verbose, "") {
+  const std::size_t rank = arg.rank();
+  for (int i = 0; i < rank; i++) {
+    if (arg.extent(i) != expected.extent(i)) {
+      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
+                       << arg.label() + ".extent(" + std::to_string(i) + ")";
+      return false;
+    }
+  }
+
+  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
+                                                      rtol, atol);
+  if (errors == 0) return true;
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      exec_space, arg, expected, errors, rtol, atol);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  *result_listener << error_str;
+  return false;
+}
+
+MATCHER_P4(allclose, exec_space, expected, rtol, atol, "") {
+  const std::size_t rank = arg.rank();
+  for (int i = 0; i < rank; i++) {
+    if (arg.extent(i) != expected.extent(i)) {
+      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
+                       << arg.label() + ".extent(" + std::to_string(i) + ")";
+      return false;
+    }
+  }
+
+  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
+                                                      rtol, atol);
+  if (errors == 0) return true;
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      exec_space, arg, expected, errors, rtol, atol);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  *result_listener << error_str;
+  return false;
+}
+
+MATCHER_P3(allclose, exec_space, expected, rtol, "") {
+  double atol            = 1.0e-8;
+  const std::size_t rank = arg.rank();
+  for (int i = 0; i < rank; i++) {
+    if (arg.extent(i) != expected.extent(i)) {
+      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
+                       << arg.label() + ".extent(" + std::to_string(i) + ")";
+      return false;
+    }
+  }
+
+  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
+                                                      rtol, atol);
+  if (errors == 0) return true;
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      exec_space, arg, expected, errors, rtol, atol);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  *result_listener << error_str;
+  return false;
+}
+
+MATCHER_P2(allclose, exec_space, expected, "") {
+  const double rtol = 1.0e-5, atol = 1.0e-8;
+  const std::size_t rank = arg.rank();
+  for (int i = 0; i < rank; i++) {
+    if (arg.extent(i) != expected.extent(i)) {
+      *result_listener << arg.label() + ".extent(" + std::to_string(i) + ") != "
+                       << arg.label() + ".extent(" + std::to_string(i) + ")";
+      return false;
+    }
+  }
+
+  int errors = KokkosFFT::Testing::Impl::count_errors(exec_space, arg, expected,
+                                                      rtol, atol);
+  if (errors == 0) return true;
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      exec_space, arg, expected, errors, rtol, atol);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  *result_listener << error_str;
+  return false;
+}
+
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -43,8 +43,8 @@ inline bool allclose_impl(testing::MatchResultListener* listener,
   const std::size_t rank = actual.rank();
   for (std::size_t i = 0; i < rank; i++) {
     if (actual.extent(i) != expected.extent(i)) {
-      *listener << actual.label() + ".extent(" + std::to_string(i) + ") != "
-                << expected.label() + ".extent(" + std::to_string(i) + ")";
+      *listener << actual.label() << ".extent(" << i
+                << ") != " << expected.label() << ".extent(" << i << ")";
       return false;
     }
   }

--- a/testing/src/KokkosFFT_Concepts.hpp
+++ b/testing/src/KokkosFFT_Concepts.hpp
@@ -32,7 +32,7 @@ template <typename T>
 concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
 
 template <typename ExecutionSpace, typename ViewType>
-concept KokkosViewAccesible = (bool)Kokkos::SpaceAccessibility<
+concept KokkosViewAccessible = (bool)Kokkos::SpaceAccessibility<
     ExecutionSpace, typename ViewType::memory_space>::accessible;
 }  // namespace KokkosFFT
 

--- a/testing/src/KokkosFFT_Concepts.hpp
+++ b/testing/src/KokkosFFT_Concepts.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_CONCEPTS_HPP
+#define KOKKOSFFT_CONCEPTS_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace KokkosFFT {
+namespace Impl {
+template <class>
+struct is_kokkos_array : public std::false_type {};
+
+template <class T, std::size_t N>
+struct is_kokkos_array<Kokkos::Array<T, N>> : public std::true_type {};
+
+template <class T, std::size_t N>
+struct is_kokkos_array<const Kokkos::Array<T, N>> : public std::true_type {};
+}  // namespace Impl
+
+template <typename T>
+concept KokkosArray = Impl::is_kokkos_array<T>::value;
+
+template <typename T>
+concept KokkosLayout = Kokkos::is_array_layout_v<T>;
+
+template <typename T>
+concept KokkosView = Kokkos::is_view_v<T>;
+
+template <typename T>
+concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
+
+template <typename ExecutionSpace, typename ViewType>
+concept KokkosViewAccesible = (bool)Kokkos::SpaceAccessibility<
+    ExecutionSpace, typename ViewType::memory_space>::accessible;
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -108,7 +108,7 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
   /// \brief Retrieves the computed error count.
   ///
   /// \return The total number of mismatches detected.
-  const auto error() const { return m_error; }
+  auto error() const { return m_error; }
 };
 
 /// \brief Computes the number of error mismatches between two 2D Kokkos views.
@@ -182,7 +182,7 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
   /// \brief Retrieves the computed error count.
   ///
   /// \return The total number of mismatches detected.
-  const auto error() const { return m_error; }
+  auto error() const { return m_error; }
 };
 
 /// \brief Finds errors in 1D Kokkos views by comparing two views element-wise.
@@ -275,7 +275,7 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
   ///
   ///\return A tuple containing the error view of the first input, the error
   /// view of the second input, and the error locations.
-  const auto error_info() const {
+  auto error_info() const {
     return std::make_tuple(m_a_error, m_b_error, m_loc_error);
   }
 };
@@ -383,7 +383,7 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
   ///
   /// \return A tuple containing the error view of the first input, the error
   /// view of the second input, and the error locations.
-  const auto error_info() const {
+  auto error_info() const {
     return std::make_tuple(m_a_error, m_b_error, m_loc_error);
   }
 };
@@ -406,8 +406,8 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
 /// \return The total number of mismatches detected.
 template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
           KokkosView BViewType>
-  requires KokkosViewAccesible<ExecutionSpace, AViewType> &&
-           KokkosViewAccesible<ExecutionSpace, BViewType>
+  requires KokkosViewAccessible<ExecutionSpace, AViewType> &&
+           KokkosViewAccessible<ExecutionSpace, BViewType>
 std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
                          const BViewType& b, double rtol = 1.e-5,
                          double atol = 1.e-8) {
@@ -418,12 +418,12 @@ std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
       (b.span() >= size_t(std::numeric_limits<int>::max()))) {
     if (iterate == Kokkos::Iterate::Right) {
       Impl::ViewErrors<ExecutionSpace, AViewType, BViewType,
-                       Kokkos::LayoutRight, AViewType::rank(), std::size_t>
+                       Kokkos::LayoutRight, AViewType::rank(), int64_t>
           view_errors(a, b, rtol, atol, exec);
       return view_errors.error();
     } else {
       Impl::ViewErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
-                       AViewType::rank(), std::size_t>
+                       AViewType::rank(), int64_t>
           view_errors(a, b, rtol, atol, exec);
       return view_errors.error();
     }
@@ -467,8 +467,8 @@ std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
 ///         - The Kokkos view of error location indices.
 template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
           KokkosView BViewType>
-  requires KokkosViewAccesible<ExecutionSpace, AViewType> &&
-           KokkosViewAccesible<ExecutionSpace, BViewType>
+  requires KokkosViewAccessible<ExecutionSpace, AViewType> &&
+           KokkosViewAccessible<ExecutionSpace, BViewType>
 auto find_errors(const ExecutionSpace& exec, const AViewType& a,
                  const BViewType& b, const std::size_t nb_errors,
                  double rtol = 1.e-5, double atol = 1.e-8) {
@@ -479,12 +479,12 @@ auto find_errors(const ExecutionSpace& exec, const AViewType& a,
       (b.span() >= size_t(std::numeric_limits<int>::max()))) {
     if (iterate == Kokkos::Iterate::Right) {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType,
-                       Kokkos::LayoutRight, AViewType::rank(), std::size_t>
+                       Kokkos::LayoutRight, AViewType::rank(), int64_t>
           view_errors(a, b, nb_errors, rtol, atol, exec);
       return view_errors.error_info();
     } else {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
-                       AViewType::rank(), std::size_t>
+                       AViewType::rank(), int64_t>
           view_errors(a, b, nb_errors, rtol, atol, exec);
       return view_errors.error_info();
     }

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -266,12 +266,11 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
     auto tmp_b     = m_b(i0);
     bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     if (not_close) {
-      std::size_t count     = Kokkos::atomic_load(m_count.data());
+      std::size_t count     = Kokkos::atomic_fetch_add(m_count.data(), 1);
       m_a_error(count)      = tmp_a;
       m_b_error(count)      = tmp_b;
       m_loc_error(count, 0) = i0;
       m_loc_error(count, 1) = i0;
-      Kokkos::atomic_fetch_add(m_count.data(), 1);
     }
   }
 
@@ -373,13 +372,12 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
     auto tmp_b     = m_b(i0, i1);
     bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     if (not_close) {
-      std::size_t count     = Kokkos::atomic_load(m_count.data());
+      std::size_t count     = Kokkos::atomic_fetch_add(m_count.data(), 1);
       m_a_error(count)      = tmp_a;
       m_b_error(count)      = tmp_b;
       m_loc_error(count, 0) = i0 + i1 * m_a.extent(0);
       m_loc_error(count, 1) = i0;
       m_loc_error(count, 2) = i1;
-      Kokkos::atomic_fetch_add(m_count.data(), 1);
     }
   }
 

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_COUNT_ERRORS_HPP
+#define KOKKOSFFT_COUNT_ERRORS_HPP
+
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Concepts.hpp"
+
+namespace KokkosFFT {
+namespace Testing {
+namespace Impl {
+
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, std::size_t Rank,
+          typename iType>
+struct ViewErrors;
+
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, std::size_t Rank,
+          typename iType>
+struct FindErrors;
+
+template <KokkosView ViewType>
+Kokkos::Iterate get_iteration_order(const ViewType& view) {
+  int64_t strides[ViewType::rank + 1];
+  view.stride(strides);
+  Kokkos::Iterate iterate;
+  if (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>) {
+    iterate = Kokkos::Iterate::Right;
+  } else if (std::is_same_v<typename ViewType::array_layout,
+                            Kokkos::LayoutLeft>) {
+    iterate = Kokkos::Iterate::Left;
+  } else if (std::is_same_v<typename ViewType::array_layout,
+                            Kokkos::LayoutStride>) {
+    if (strides[0] > strides[ViewType::rank - 1])
+      iterate = Kokkos::Iterate::Right;
+    else
+      iterate = Kokkos::Iterate::Left;
+  } else {
+    if (std::is_same_v<typename ViewType::execution_space::array_layout,
+                       Kokkos::LayoutRight>)
+      iterate = Kokkos::Iterate::Right;
+    else
+      iterate = Kokkos::Iterate::Left;
+  }
+  return iterate;
+}
+
+/// \brief Computes the number of error mismatches between two 1D Kokkos views.
+/// This structure performs an element-by-element comparison of two 1D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce. \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  using policy_type =
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<iType>>;
+
+  ///
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-1D", policy_type(space, 0, m_a.extent(0)), *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index of the element in the views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, std::size_t& err) const {
+    auto tmp_a = m_a(i0);
+    auto tmp_b = m_b(i0);
+    bool not_close =
+        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    err += static_cast<std::size_t>(not_close);
+  }
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  const auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 2D Kokkos views.
+/// This structure performs an element-by-element comparison of two 2D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce. \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<2, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-2D", policy_type(space, {0, 0}, {a.extent(0), a.extent(1)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, std::size_t& err) const {
+    auto tmp_a = m_a(i0, i1);
+    auto tmp_b = m_b(i0, i1);
+    bool not_close =
+        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  const auto error() const { return m_error; }
+};
+
+/// \brief Finds errors in 1D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 1D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+
+  double m_rtol;
+  double m_atol;
+
+  using policy_type =
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  /// \param a [in] The first Kokkos view containing data.
+  /// \param b [in] The second Kokkos view containing data to compare against.
+  /// \param nb_errors [in] The maximum number of errors expected.
+  /// \param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  /// \param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 2),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-1D", policy_type(space, 0, m_a.extent(0)),
+                         *this);
+  }
+
+  ///\brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  ///\param i0 [in] The index of the element in the views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0) const {
+    iType err  = 0;
+    auto tmp_a = m_a(i0);
+    auto tmp_b = m_b(i0);
+    bool not_close =
+        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    iType tmp_error = static_cast<iType>(not_close);
+    Kokkos::atomic_add(&tmp_error, err);
+
+    if (not_close) {
+      m_a_error(err)      = tmp_a;
+      m_b_error(err)      = tmp_b;
+      m_loc_error(err, 0) = i0;
+      m_loc_error(err, 1) = i0;
+    }
+  }
+
+  ///\brief Retrieves the error information.
+  ///
+  ///\return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  const auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 2D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 2D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<2, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 3),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-2D",
+                         policy_type(space, {0, 0}, {a.extent(0), a.extent(1)}),
+                         *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1) const {
+    iType err  = 0;
+    auto tmp_a = m_a(i0, i1);
+    auto tmp_b = m_b(i0, i1);
+    bool not_close =
+        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    iType tmp_error = static_cast<iType>(not_close);
+    Kokkos::atomic_add(&tmp_error, err);
+
+    if (not_close) {
+      m_a_error(err)      = tmp_a;
+      m_b_error(err)      = tmp_b;
+      m_loc_error(err, 0) = i0 + i1 * m_a.extent(0);
+      m_loc_error(err, 1) = i0;
+      m_loc_error(err, 2) = i1;
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  const auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Computes the number of mismatch errors between two Kokkos views.
+/// This function performs an element-wise comparison between two Kokkos views
+/// and counts the number of mismatches where the absolute difference exceeds
+/// the combined absolute and relative tolerances.
+///
+/// \tparam ExecutionSpace The type of the Kokkos execution space.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \param exec [in] The execution space used to launch the parallel reduction.
+/// \param a [in] The first Kokkos view containing data to compare.
+/// \param b [in] The second Kokkos view containing data to compare against.
+/// \param rtol [in] Relative tolerance for comparing the view elements
+/// (default 1.e-5).
+/// \param atol [in] Absolute tolerance for comparing the view elements
+/// (default 1.e-8).
+/// \return The total number of mismatches detected.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType>
+  requires KokkosViewAccesible<ExecutionSpace, AViewType> &&
+           KokkosViewAccesible<ExecutionSpace, BViewType>
+std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
+                         const BViewType& b, double rtol = 1.e-5,
+                         double atol = 1.e-8) {
+  // Figure out iteration order in case we need it
+  Kokkos::Iterate iterate = get_iteration_order(a);
+
+  if ((a.span() >= size_t(std::numeric_limits<int>::max())) ||
+      (b.span() >= size_t(std::numeric_limits<int>::max()))) {
+    if (iterate == Kokkos::Iterate::Right) {
+      Impl::ViewErrors<ExecutionSpace, AViewType, BViewType,
+                       Kokkos::LayoutRight, AViewType::rank(), std::size_t>
+          view_errors(a, b, rtol, atol, exec);
+      return view_errors.error();
+    } else {
+      Impl::ViewErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
+                       AViewType::rank(), std::size_t>
+          view_errors(a, b, rtol, atol, exec);
+      return view_errors.error();
+    }
+  } else {
+    if (iterate == Kokkos::Iterate::Right) {
+      Impl::ViewErrors<ExecutionSpace, AViewType, BViewType,
+                       Kokkos::LayoutRight, AViewType::rank(), int>
+          view_errors(a, b, rtol, atol, exec);
+      return view_errors.error();
+    } else {
+      Impl::ViewErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
+                       AViewType::rank(), int>
+          view_errors(a, b, rtol, atol, exec);
+      return view_errors.error();
+    }
+  }
+}
+
+/// \brief Finds error information between two Kokkos views using element-wise
+/// comparison. This function creates an instance of the appropriate FindErrors
+/// structure (based on the rank of the input view) and launches a parallel
+/// kernel to compare the elements of the two provided Kokkos views. It then
+/// returns a tuple containing the error view for the first input, the error
+/// view for the second input, and the locations of the errors.
+///
+/// \tparam ExecutionSpace The Kokkos execution space type used for the parallel
+/// operation.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \param exec [in] The execution space used to launch the parallel kernel.
+/// \param a [in] The first Kokkos view containing data.
+/// \param b [in] The second Kokkos view containing data to compare against.
+/// \param nb_errors [in] The maximum number of errors expected.
+/// \param rtol [in] Relative tolerance for the element-wise comparison
+/// (default 1.e-5).
+/// \param atol [in] Absolute tolerance for the element-wise comparison
+/// (default 1.e-8).
+/// \return A tuple containing:
+///         - The Kokkos view of error values from the first view.
+///         - The Kokkos view of error values from the second view.
+///         - The Kokkos view of error location indices.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType>
+  requires KokkosViewAccesible<ExecutionSpace, AViewType> &&
+           KokkosViewAccesible<ExecutionSpace, BViewType>
+auto find_errors(const ExecutionSpace& exec, const AViewType& a,
+                 const BViewType& b, const std::size_t nb_errors,
+                 double rtol = 1.e-5, double atol = 1.e-8) {
+  // Figure out iteration order in case we need it
+  Kokkos::Iterate iterate = get_iteration_order(a);
+
+  if ((a.span() >= size_t(std::numeric_limits<int>::max())) ||
+      (b.span() >= size_t(std::numeric_limits<int>::max()))) {
+    if (iterate == Kokkos::Iterate::Right) {
+      Impl::FindErrors<ExecutionSpace, AViewType, BViewType,
+                       Kokkos::LayoutRight, AViewType::rank(), std::size_t>
+          view_errors(a, b, nb_errors, rtol, atol, exec);
+      return view_errors.error_info();
+    } else {
+      Impl::FindErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
+                       AViewType::rank(), std::size_t>
+          view_errors(a, b, nb_errors, rtol, atol, exec);
+      return view_errors.error_info();
+    }
+  } else {
+    if (iterate == Kokkos::Iterate::Right) {
+      Impl::FindErrors<ExecutionSpace, AViewType, BViewType,
+                       Kokkos::LayoutRight, AViewType::rank(), int>
+          view_errors(a, b, nb_errors, rtol, atol, exec);
+      return view_errors.error_info();
+    } else {
+      Impl::FindErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
+                       AViewType::rank(), int>
+          view_errors(a, b, nb_errors, rtol, atol, exec);
+      return view_errors.error_info();
+    }
+  }
+}
+
+}  // namespace Impl
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -48,6 +48,12 @@ Kokkos::Iterate get_iteration_order(const ViewType& view) {
   return iterate;
 }
 
+template <typename ScalarA, typename ScalarB, typename ScalarTol>
+KOKKOS_INLINE_FUNCTION bool are_not_close(ScalarA a, ScalarB b, ScalarTol rtol,
+                                          ScalarTol atol) {
+  return Kokkos::abs(a - b) > (atol + rtol * Kokkos::abs(b));
+}
+
 /// \brief Computes the number of error mismatches between two 1D Kokkos views.
 /// This structure performs an element-by-element comparison of two 1D views. It
 /// counts the number of elements where the difference exceeds a specified
@@ -98,10 +104,9 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
   /// detected.
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType i0, std::size_t& err) const {
-    auto tmp_a = m_a(i0);
-    auto tmp_b = m_b(i0);
-    bool not_close =
-        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    auto tmp_a     = m_a(i0);
+    auto tmp_b     = m_b(i0);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     err += static_cast<std::size_t>(not_close);
   }
 
@@ -172,10 +177,9 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
   /// detected.
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, std::size_t& err) const {
-    auto tmp_a = m_a(i0, i1);
-    auto tmp_b = m_b(i0, i1);
-    bool not_close =
-        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    auto tmp_a     = m_a(i0, i1);
+    auto tmp_b     = m_b(i0, i1);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     err += static_cast<std::size_t>(not_close);
   };
 
@@ -258,10 +262,9 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
   ///\param i0 [in] The index of the element in the views.
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType i0) const {
-    auto tmp_a = m_a(i0);
-    auto tmp_b = m_b(i0);
-    bool not_close =
-        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    auto tmp_a     = m_a(i0);
+    auto tmp_b     = m_b(i0);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     if (not_close) {
       std::size_t count     = Kokkos::atomic_load(m_count.data());
       m_a_error(count)      = tmp_a;
@@ -366,10 +369,9 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
   /// views.
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType i0, const iType i1) const {
-    auto tmp_a = m_a(i0, i1);
-    auto tmp_b = m_b(i0, i1);
-    bool not_close =
-        Kokkos::abs(tmp_a - tmp_b) > (m_atol + m_rtol * Kokkos::abs(tmp_b));
+    auto tmp_a     = m_a(i0, i1);
+    auto tmp_b     = m_b(i0, i1);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     if (not_close) {
       std::size_t count     = Kokkos::atomic_load(m_count.data());
       m_a_error(count)      = tmp_a;

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_PRINT_ERRORS_HPP
+#define KOKKOSFFT_PRINT_ERRORS_HPP
+
+#include <tuple>
+#include <map>
+#include <sstream>
+#include <string>
+#include <iomanip>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Concepts.hpp"
+
+namespace KokkosFFT {
+namespace Testing {
+namespace Impl {
+
+/// \brief Sorts error information based on global indices. This function
+/// processes error data from Kokkos error views and organizes them into a map
+/// where the key is the global index and the value is a tuple containing a
+/// vector of additional index information, the error value from the first view,
+/// and the error value from the second view.
+///
+/// \tparam AErrorViewType The type of the Kokkos view storing error values from
+/// the first data set.
+/// \tparam BErrorViewType The type of the Kokkos view storing error values from
+/// the second data set.
+/// \tparam CountViewType The type of the Kokkos view storing index information
+/// for each error.
+/// \param a_error [in] A Kokkos view containing error values from the first
+/// set.
+/// \param b_error [in] A Kokkos view containing error values from the second
+/// set.
+/// \param loc_error [in] A Kokkos view containing index/location information
+/// for each error.
+/// \return A std::map where the key is the global index and the value is a
+/// tuple consisting of a vector of additional indices, the corresponding error
+/// value from the first view, and the error value from the second view.
+template <typename AErrorViewType, typename BErrorViewType,
+          typename CountViewType>
+auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
+                 const CountViewType &loc_error) {
+  // Key: global idx
+  // Value: tuple (vector of error idx, a, b)
+  using a_value_type     = typename AErrorViewType::non_const_value_type;
+  using b_value_type     = typename BErrorViewType::non_const_value_type;
+  using iType            = typename CountViewType::non_const_value_type;
+  using coord_type       = std::vector<iType>;
+  using error_value_type = std::tuple<coord_type, a_value_type, b_value_type>;
+
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  using error_map_type = std::map<iType, error_value_type>;
+  error_map_type error_map;
+  const std::size_t nb_errors = h_a_error.extent(0);
+  const int rank              = h_loc_error.extent(1);
+
+  for (std::size_t err = 0; err < nb_errors; ++err) {
+    iType global_idx = h_loc_error(err, 0);  // global idx -> key
+
+    coord_type loc;
+    for (std::size_t d = 1; d < rank; ++d) {
+      loc.push_back(h_loc_error(err, d));
+    }
+
+    error_map[global_idx] =
+        error_value_type({loc, h_a_error(err), h_b_error(err)});
+  }
+
+  return error_map;
+}
+
+/// \brief Converts sorted error information into a formatted string.
+/// This function iterates over an error map containing error information and
+/// builds a formatted string reporting each error's location, along with the
+/// actual and expected error values and their difference.
+///
+/// \tparam ErrorMapType The type of the error map containing error information.
+/// \param error_map [in] A constant reference to a map that stores error
+/// details.
+/// \param labelA [in] A label for the first error value (default is "actual").
+/// \param labelB [in] A label for the second error value (default is
+/// "expected").
+/// \return A std::string containing the formatted error report.
+template <typename ErrorMapType>
+auto print_errors(const ErrorMapType &error_map,
+                  const std::string &labelA = "actual",
+                  const std::string &labelB = "expected") {
+  using TupleType = std::remove_reference_t<
+      decltype(std::declval<ErrorMapType>().begin()->second)>;
+  using ReferenceValueType = typename std::tuple_element<2, TupleType>::type;
+
+  std::stringstream ss;
+  ss << std::fixed << std::setprecision(sizeof(ReferenceValueType) * 2);
+  ss << "Mismatched elements (by indices):\n";
+
+  // Loop over error_map and print the error information
+  for (const auto &error : error_map) {
+    const auto &loc = std::get<0>(error.second);
+    const auto &a   = std::get<1>(error.second);
+    const auto &b   = std::get<2>(error.second);
+
+    auto diff = std::fabs(a - b);
+
+    ss << "  Index (";
+    for (std::size_t i = 0; i < loc.size(); ++i) {
+      ss << loc[i];
+      if (i < loc.size() - 1) {
+        ss << ", ";
+      }
+    }
+    ss << "): " << labelA + " " << a << " vs " << labelB + " " << b
+       << " (diff=" << diff << ")\n";
+  }
+
+  // Convert the stringstream data to a std::string
+  std::string data = ss.str();
+
+  // Check if the string is non-empty and its last character is a newline
+  if (!data.empty() && data.back() == '\n') {
+    data.pop_back();  // Remove the last character
+  }
+
+  return data;
+}
+
+}  // namespace Impl
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 #include <iomanip>
+#include <algorithm>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Concepts.hpp"
 
@@ -35,13 +36,14 @@ namespace Impl {
 /// set.
 /// \param loc_error [in] A Kokkos view containing index/location information
 /// for each error.
+/// \param verbose [in] How many elements to be returned (default: 3)
 /// \return A std::map where the key is the global index and the value is a
 /// tuple consisting of a vector of additional indices, the corresponding error
 /// value from the first view, and the error value from the second view.
 template <typename AErrorViewType, typename BErrorViewType,
           typename CountViewType>
 auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
-                 const CountViewType &loc_error) {
+                 const CountViewType &loc_error, const std::size_t verbose=3) {
   // Key: global idx
   // Value: tuple (vector of error idx, a, b)
   using a_value_type     = typename AErrorViewType::non_const_value_type;
@@ -60,9 +62,10 @@ auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
   using error_map_type = std::map<iType, error_value_type>;
   error_map_type error_map;
   const std::size_t nb_errors = h_a_error.extent(0);
+  const std::size_t nb_errors_verbose = std::min(nb_errors, verbose);
   const std::size_t rank      = h_loc_error.extent(1);
 
-  for (std::size_t err = 0; err < nb_errors; ++err) {
+  for (std::size_t err = 0; err < nb_errors_verbose; ++err) {
     iType global_idx = h_loc_error(err, 0);  // global idx -> key
 
     coord_type loc;

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -43,7 +43,8 @@ namespace Impl {
 template <typename AErrorViewType, typename BErrorViewType,
           typename CountViewType>
 auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
-                 const CountViewType &loc_error, const std::size_t verbose=3) {
+                 const CountViewType &loc_error,
+                 const std::size_t verbose = 3) {
   // Key: global idx
   // Value: tuple (vector of error idx, a, b)
   using a_value_type     = typename AErrorViewType::non_const_value_type;
@@ -61,9 +62,9 @@ auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
 
   using error_map_type = std::map<iType, error_value_type>;
   error_map_type error_map;
-  const std::size_t nb_errors = h_a_error.extent(0);
+  const std::size_t nb_errors         = h_a_error.extent(0);
   const std::size_t nb_errors_verbose = std::min(nb_errors, verbose);
-  const std::size_t rank      = h_loc_error.extent(1);
+  const std::size_t rank              = h_loc_error.extent(1);
 
   for (std::size_t err = 0; err < nb_errors_verbose; ++err) {
     iType global_idx = h_loc_error(err, 0);  // global idx -> key

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -60,7 +60,7 @@ auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
   using error_map_type = std::map<iType, error_value_type>;
   error_map_type error_map;
   const std::size_t nb_errors = h_a_error.extent(0);
-  const int rank              = h_loc_error.extent(1);
+  const std::size_t rank      = h_loc_error.extent(1);
 
   for (std::size_t err = 0; err < nb_errors; ++err) {
     iType global_idx = h_loc_error(err, 0);  // global idx -> key

--- a/testing/src/KokkosFFT_Testing.hpp
+++ b/testing/src/KokkosFFT_Testing.hpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_TESTING_HPP
+#define KOKKOSFFT_TESTING_HPP
+
+#include "KokkosFFT_Concepts.hpp"
+#include "KokkosFFT_Allclose.hpp"
+
+#endif

--- a/testing/unit_test/CMakeLists.txt
+++ b/testing/unit_test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp)
+
+target_compile_features(unit-tests-kokkos-fft-testing PUBLIC cxx_std_20)
+target_link_libraries(unit-tests-kokkos-fft-testing PUBLIC KokkosFFT::testing)
+
+# Enable GoogleTest
+include(GoogleTest)
+gtest_discover_tests(unit-tests-kokkos-fft-testing PROPERTIES DISCOVERY_TIMEOUT 600 DISCOVERY_MODE PRE_TEST)

--- a/testing/unit_test/CMakeLists.txt
+++ b/testing/unit_test/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp)
+add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreNotClose.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp)
 
 target_compile_features(unit-tests-kokkos-fft-testing PUBLIC cxx_std_20)
 target_link_libraries(unit-tests-kokkos-fft-testing PUBLIC KokkosFFT::testing)

--- a/testing/unit_test/Test_Allclose.cpp
+++ b/testing/unit_test/Test_Allclose.cpp
@@ -7,7 +7,6 @@
 #include "KokkosFFT_Allclose.hpp"
 
 namespace {
-
 using execution_space = Kokkos::DefaultExecutionSpace;
 using float_types     = ::testing::Types<float, double>;
 
@@ -18,8 +17,6 @@ struct TestAllClose : public ::testing::Test {
   const double m_rtol = 1.0e-5;
   const double m_atol = 1.0e-8;
 };
-
-TYPED_TEST_SUITE(TestAllClose, float_types);
 
 template <typename T>
 void test_allclose_1D_analytical(double rtol, double atol) {
@@ -105,6 +102,9 @@ void test_allclose_2D_analytical(double rtol, double atol) {
   EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
   EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
 }
+}  // namespace
+
+TYPED_TEST_SUITE(TestAllClose, float_types);
 
 TYPED_TEST(TestAllClose, View1D) {
   using float_type = typename TestFixture::float_type;
@@ -115,5 +115,3 @@ TYPED_TEST(TestAllClose, View2D) {
   using float_type = typename TestFixture::float_type;
   test_allclose_2D_analytical<float_type>(this->m_rtol, this->m_atol);
 }
-
-}  // namespace

--- a/testing/unit_test/Test_Allclose.cpp
+++ b/testing/unit_test/Test_Allclose.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Allclose.hpp"
+
+namespace {
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types     = ::testing::Types<float, double>;
+
+template <typename T>
+struct TestAllClose : public ::testing::Test {
+  using float_type = T;
+
+  const double m_rtol = 1.0e-5;
+  const double m_atol = 1.0e-8;
+};
+
+TYPED_TEST_SUITE(TestAllClose, float_types);
+
+template <typename T>
+void test_allclose_1D_analytical(double rtol, double atol) {
+  using View1DType = Kokkos::View<T*>;
+  const int n      = 3;
+  View1DType a("a", n), b("b", n), c("c", n), d("d", n), e("e", n);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1) = h_c(1) + 2.0 * atol;
+
+  // d includes both the relative and absolute errors -> error count 1
+  h_d(0) = h_b(0);
+  h_d(1) = h_c(1);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0) = h_e(0) + 0.1 * (h_e(0) * rtol);
+  h_e(1) = h_e(1) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(
+      b, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(), a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(execution_space(), a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(),
+                                                             a, rtol, atol)));
+  EXPECT_THAT(
+      e, KokkosFFT::Testing::allclose(execution_space(), a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_2D_analytical(double rtol, double atol) {
+  using View2DType = Kokkos::View<T**>;
+  const int n0 = 3, n1 = 2;
+  View2DType a("a", n0, n1), b("b", n0, n1), c("c", n0, n1), d("d", n0, n1),
+      e("e", n0, n1);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0) = h_b(0, 0) + 2.0 * (h_b(0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0) = h_c(1, 0) + 2.0 * atol;
+
+  // d includes both the relative and absolute errors -> error count 1
+  h_d(0, 0) = h_b(0, 0);
+  h_d(1, 0) = h_c(1, 0);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0) = h_e(0, 0) + 0.1 * (h_e(0, 0) * rtol);
+  h_e(1, 0) = h_e(1, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(
+      b, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(), a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(execution_space(), a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(),
+                                                             a, rtol, atol)));
+  EXPECT_THAT(
+      e, KokkosFFT::Testing::allclose(execution_space(), a, rtol, atol, 3));
+}
+
+TYPED_TEST(TestAllClose, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_1D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+}  // namespace

--- a/testing/unit_test/Test_Allclose.cpp
+++ b/testing/unit_test/Test_Allclose.cpp
@@ -57,13 +57,10 @@ void test_allclose_1D_analytical(double rtol, double atol) {
   Kokkos::deep_copy(d, h_d);
   Kokkos::deep_copy(e, h_e);
 
-  EXPECT_THAT(
-      b, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(), a)));
-  EXPECT_THAT(c, KokkosFFT::Testing::allclose(execution_space(), a, rtol));
-  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(),
-                                                             a, rtol, atol)));
-  EXPECT_THAT(
-      e, KokkosFFT::Testing::allclose(execution_space(), a, rtol, atol, 3));
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
 }
 
 template <typename T>
@@ -103,13 +100,10 @@ void test_allclose_2D_analytical(double rtol, double atol) {
   Kokkos::deep_copy(d, h_d);
   Kokkos::deep_copy(e, h_e);
 
-  EXPECT_THAT(
-      b, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(), a)));
-  EXPECT_THAT(c, KokkosFFT::Testing::allclose(execution_space(), a, rtol));
-  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(execution_space(),
-                                                             a, rtol, atol)));
-  EXPECT_THAT(
-      e, KokkosFFT::Testing::allclose(execution_space(), a, rtol, atol, 3));
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
 }
 
 TYPED_TEST(TestAllClose, View1D) {

--- a/testing/unit_test/Test_AreNotClose.cpp
+++ b/testing/unit_test/Test_AreNotClose.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Half.hpp>
+#include "KokkosFFT_CountErrors.hpp"
+
+namespace {
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types =
+    ::testing::Types<Kokkos::Experimental::half_t,
+                     Kokkos::Experimental::bhalf_t, float, double>;
+
+template <typename T>
+struct TestAreNotClose : public ::testing::Test {
+  using float_type    = T;
+  using BoolViewType  = Kokkos::View<bool, execution_space>;
+  const double m_rtol = 1.0e-5;
+  const double m_atol = 1.0e-8;
+};
+
+template <typename T, typename BoolViewType>
+void test_are_not_close_rtol(double rtol) {
+  T a(1.0);
+  T b               = a;
+  T c               = a + 1.0;
+  T d               = a + a * 0.01 * rtol;
+  const double atol = 0.0;
+  BoolViewType a_b_are_not_close("a_b_are_not_close"),
+      a_c_are_not_close("a_c_are_not_close"),
+      a_d_are_not_close("a_d_are_not_close");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        a_b_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, b, rtol, atol);
+        a_c_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, c, rtol, atol);
+        a_d_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, d, rtol, atol);
+      });
+
+  auto h_a_b_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_not_close);
+  auto h_a_c_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_not_close);
+  auto h_a_d_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_not_close);
+
+  ASSERT_FALSE(h_a_b_are_not_close());
+  ASSERT_TRUE(h_a_c_are_not_close());
+  ASSERT_FALSE(h_a_d_are_not_close());
+}
+
+template <typename T, typename BoolViewType>
+void test_are_not_close_atol(double atol) {
+  T a(1.0);
+  T b               = a;
+  T c               = a + 1.0;
+  T d               = a + 0.01 * atol;
+  const double rtol = 0.0;
+  BoolViewType a_b_are_not_close("a_b_are_not_close"),
+      a_c_are_not_close("a_c_are_not_close"),
+      a_d_are_not_close("a_d_are_not_close");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        a_b_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, b, rtol, atol);
+        a_c_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, c, rtol, atol);
+        a_d_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, d, rtol, atol);
+      });
+
+  auto h_a_b_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_not_close);
+  auto h_a_c_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_not_close);
+  auto h_a_d_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_not_close);
+
+  ASSERT_FALSE(h_a_b_are_not_close());
+  ASSERT_TRUE(h_a_c_are_not_close());
+  ASSERT_FALSE(h_a_d_are_not_close());
+}
+
+template <typename T, typename BoolViewType>
+void test_are_not_close_rtol_and_atol(double rtol, double atol) {
+  T a(1.0);
+  T b = a;
+  T c = a + 1.0;
+  T d = a + a * 0.01 * rtol + 0.01 * atol;
+  BoolViewType a_b_are_not_close("a_b_are_not_close"),
+      a_c_are_not_close("a_c_are_not_close"),
+      a_d_are_not_close("a_d_are_not_close");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        a_b_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, b, rtol, atol);
+        a_c_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, c, rtol, atol);
+        a_d_are_not_close() =
+            KokkosFFT::Testing::Impl::are_not_close(a, d, rtol, atol);
+      });
+
+  auto h_a_b_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_not_close);
+  auto h_a_c_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_not_close);
+  auto h_a_d_are_not_close = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_not_close);
+
+  ASSERT_FALSE(h_a_b_are_not_close());
+  ASSERT_TRUE(h_a_c_are_not_close());
+  ASSERT_FALSE(h_a_d_are_not_close());
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestAreNotClose, float_types);
+
+TYPED_TEST(TestAreNotClose, RelativeTolerance) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_are_not_close_rtol<float_type, BoolViewType>(this->m_rtol);
+}
+
+TYPED_TEST(TestAreNotClose, AbsoluteTolerance) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_are_not_close_atol<float_type, BoolViewType>(this->m_rtol);
+}
+
+TYPED_TEST(TestAreNotClose, RelativeAndAbsoluteTolerance) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_are_not_close_rtol_and_atol<float_type, BoolViewType>(this->m_rtol,
+                                                             this->m_atol);
+}

--- a/testing/unit_test/Test_CountErrors.cpp
+++ b/testing/unit_test/Test_CountErrors.cpp
@@ -19,8 +19,6 @@ struct TestCountErrors : public ::testing::Test {
   const double m_atol = 1.0e-8;
 };
 
-TYPED_TEST_SUITE(TestCountErrors, float_types);
-
 template <typename T>
 void test_view_errors_1D_analytical(double rtol, double atol) {
   using View1DType = Kokkos::View<T*>;
@@ -121,6 +119,9 @@ void test_view_errors_2D_analytical(double rtol, double atol) {
                                                    rtol, atol),
             0);
 }
+}  // namespace
+
+TYPED_TEST_SUITE(TestCountErrors, float_types);
 
 TYPED_TEST(TestCountErrors, View1D) {
   using float_type = typename TestFixture::float_type;
@@ -131,5 +132,3 @@ TYPED_TEST(TestCountErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_view_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
 }
-
-}  // namespace

--- a/testing/unit_test/Test_CountErrors.cpp
+++ b/testing/unit_test/Test_CountErrors.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_CountErrors.hpp"
+
+namespace {
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types     = ::testing::Types<float, double>;
+
+template <typename T>
+struct TestCountErrors : public ::testing::Test {
+  using float_type = T;
+
+  const double m_rtol = 1.0e-5;
+  const double m_atol = 1.0e-8;
+};
+
+TYPED_TEST_SUITE(TestCountErrors, float_types);
+
+template <typename T>
+void test_view_errors_1D_analytical(double rtol, double atol) {
+  using View1DType = Kokkos::View<T*>;
+  const int n      = 3;
+  View1DType a("a", n), b("b", n), c("c", n), d("d", n), e("e", n);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1) = h_c(1) + 2.0 * atol;
+
+  // d includes both the relative and absolute errors -> error count 1
+  h_d(0) = h_b(0);
+  h_d(1) = h_c(1);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0) = h_e(0) + 0.1 * (h_e(0) * rtol);
+  h_e(1) = h_e(1) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_2D_analytical(double rtol, double atol) {
+  using View2DType = Kokkos::View<T**>;
+  const int n0 = 3, n1 = 2;
+  View2DType a("a", n0, n1), b("b", n0, n1), c("c", n0, n1), d("d", n0, n1),
+      e("e", n0, n1);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0) = h_b(0, 0) + 2.0 * (h_b(0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0) = h_c(1, 0) + 2.0 * atol;
+
+  // d includes both the relative and absolute errors -> error count 1
+  h_d(0, 0) = h_b(0, 0);
+  h_d(1, 0) = h_c(1, 0);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0) = h_e(0, 0) + 0.1 * (h_e(0, 0) * rtol);
+  h_e(1, 0) = h_e(1, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+TYPED_TEST(TestCountErrors, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_1D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+}  // namespace

--- a/testing/unit_test/Test_FindErrors.cpp
+++ b/testing/unit_test/Test_FindErrors.cpp
@@ -19,8 +19,6 @@ struct TestFindErrors : public ::testing::Test {
   const double m_atol = 1.0e-8;
 };
 
-TYPED_TEST_SUITE(TestFindErrors, float_types);
-
 template <typename T>
 void test_find_errors_1D_analytical(double rtol, double atol) {
   using View1DType    = Kokkos::View<T*>;
@@ -115,6 +113,9 @@ void test_find_errors_2D_analytical(double rtol, double atol) {
     EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
   }
 }
+}  // namespace
+
+TYPED_TEST_SUITE(TestFindErrors, float_types);
 
 TYPED_TEST(TestFindErrors, View1D) {
   using float_type = typename TestFixture::float_type;
@@ -125,5 +126,3 @@ TYPED_TEST(TestFindErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_find_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
 }
-
-}  // namespace

--- a/testing/unit_test/Test_FindErrors.cpp
+++ b/testing/unit_test/Test_FindErrors.cpp
@@ -121,11 +121,9 @@ TYPED_TEST(TestFindErrors, View1D) {
   test_find_errors_1D_analytical<float_type>(this->m_rtol, this->m_atol);
 }
 
-/*
 TYPED_TEST(TestFindErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_find_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
 }
-*/
 
 }  // namespace

--- a/testing/unit_test/Test_FindErrors.cpp
+++ b/testing/unit_test/Test_FindErrors.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_CountErrors.hpp"
+
+namespace {
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types     = ::testing::Types<float, double>;
+
+template <typename T>
+struct TestFindErrors : public ::testing::Test {
+  using float_type = T;
+
+  const double m_rtol = 1.0e-5;
+  const double m_atol = 1.0e-8;
+};
+
+TYPED_TEST_SUITE(TestFindErrors, float_types);
+
+template <typename T>
+void test_find_errors_1D_analytical(double rtol, double atol) {
+  using View1DType    = Kokkos::View<T*>;
+  using CountViewType = Kokkos::View<std::size_t**>;
+  const std::size_t n = 3, nb_errors = 1;
+  View1DType a("a", n), b("b", n);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 2);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+
+  h_ref_a_error(0)      = T(3.0);
+  h_ref_b_error(0)      = h_b(0);
+  h_ref_loc_error(0, 0) = 0;  // global idx
+  h_ref_loc_error(0, 1) = 0;  // idx of dimension 0
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+  }
+}
+
+template <typename T>
+void test_find_errors_2D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View2DType     = Kokkos::View<T**>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, nb_errors = 1;
+  View2DType a("a", n0, n1), b("b", n0, n1);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 3);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1) = h_b(2, 1) + 2.0 * (h_b(2, 1) * rtol);
+
+  h_ref_a_error(0)      = T(3.0);
+  h_ref_b_error(0)      = h_b(2, 1);
+  h_ref_loc_error(0, 0) = 2 + 1 * b.extent(0);  // global idx
+  h_ref_loc_error(0, 1) = 2;                    // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;                    // idx of dimension 1
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+  }
+}
+
+TYPED_TEST(TestFindErrors, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_1D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+/*
+TYPED_TEST(TestFindErrors, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+*/
+
+}  // namespace

--- a/testing/unit_test/Test_Main.cpp
+++ b/testing/unit_test/Test_Main.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  Kokkos::initialize();
+  auto result = RUN_ALL_TESTS();
+  Kokkos::finalize();
+
+  return result;
+}

--- a/testing/unit_test/Test_PrintErrors.cpp
+++ b/testing/unit_test/Test_PrintErrors.cpp
@@ -22,9 +22,6 @@ struct TestPrintErrors : public ::testing::Test {
   using float_type = T;
 };
 
-TYPED_TEST_SUITE(TestSortErrors, float_types);
-TYPED_TEST_SUITE(TestPrintErrors, float_types);
-
 template <typename T>
 void test_sort_errors_1D_analytical() {
   using View1DType            = Kokkos::View<T*>;
@@ -210,6 +207,10 @@ void test_print_errors_2D_analytical() {
   // pattern.
   EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
 }
+}  // namespace
+
+TYPED_TEST_SUITE(TestSortErrors, float_types);
+TYPED_TEST_SUITE(TestPrintErrors, float_types);
 
 TYPED_TEST(TestSortErrors, View1D) {
   using float_type = typename TestFixture::float_type;
@@ -230,5 +231,3 @@ TYPED_TEST(TestPrintErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_print_errors_2D_analytical<float_type>();
 }
-
-}  // namespace

--- a/testing/unit_test/Test_PrintErrors.cpp
+++ b/testing/unit_test/Test_PrintErrors.cpp
@@ -144,7 +144,9 @@ void test_print_errors_1D_analytical() {
   // \s+ matches one or more whitespace characters.
   // Updated regex pattern: Replace \d with [0-9]
   std::string pattern =
-      R"(Mismatched elements \(by indices\):)" "\n" R"(\s+Index \(0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
 
   // Using GoogleMock's MatchesRegex matcher to compare the string with the
   // pattern.
@@ -198,7 +200,11 @@ void test_print_errors_2D_analytical() {
   // \s+ matches one or more whitespace characters.
   // Updated regex pattern: Replace \d with [0-9]
   std::string pattern =
-      R"(Mismatched elements \(by indices\):)" "\n" R"(\s+Index \(0, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))" "\n" R"(\s+Index \(1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
 
   // Using GoogleMock's MatchesRegex matcher to compare the string with the
   // pattern.

--- a/testing/unit_test/Test_PrintErrors.cpp
+++ b/testing/unit_test/Test_PrintErrors.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_PrintErrors.hpp"
+
+namespace {
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types     = ::testing::Types<float, double>;
+
+template <typename T>
+struct TestSortErrors : public ::testing::Test {
+  using float_type = T;
+};
+
+template <typename T>
+struct TestPrintErrors : public ::testing::Test {
+  using float_type = T;
+};
+
+TYPED_TEST_SUITE(TestSortErrors, float_types);
+TYPED_TEST_SUITE(TestPrintErrors, float_types);
+
+template <typename T>
+void test_sort_errors_1D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 1;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 2);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_loc_error(0, 0) = 0;  // global idx
+  h_loc_error(0, 1) = 0;  // idx of dimension 0
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon                = std::numeric_limits<T>::epsilon();
+  auto [loc, a_val, b_val] = error_map[0];
+  EXPECT_LT(Kokkos::abs(a_val - h_a_error(0)), epsilon);
+  EXPECT_LT(Kokkos::abs(b_val - h_b_error(0)), epsilon);
+  EXPECT_EQ(loc.at(0), h_loc_error(0, 1));
+}
+
+template <typename T>
+void test_sort_errors_2D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 3);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 3;  // global idx
+  h_loc_error(0, 1) = 0;  // idx of dimension 0
+  h_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_loc_error(1, 0) = 4;  // global idx
+  h_loc_error(1, 1) = 1;  // idx of dimension 0
+  h_loc_error(1, 2) = 1;  // idx of dimension 1
+
+  std::vector<std::size_t> global_indices;
+  global_indices.push_back(3);
+  global_indices.push_back(4);
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+  }
+}
+
+template <typename T>
+void test_print_errors_1D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 1;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 2);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_loc_error(0, 0) = 0;  // global idx
+  h_loc_error(0, 1) = 0;  // idx of dimension 0
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0): actual 3.0000000000000000 vs expected 3.0000599999999999
+  // (diff=0.0000599999999999)";
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):\n\s+Index \(0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_2D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 3);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 3;  // global idx
+  h_loc_error(0, 1) = 0;  // idx of dimension 0
+  h_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_loc_error(1, 0) = 4;  // global idx
+  h_loc_error(1, 1) = 1;  // idx of dimension 0
+  h_loc_error(1, 2) = 1;  // idx of dimension 1
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1): actual 3.0000000000000000 vs expected 3.0000599999999999
+  // (diff=0.0000599999999999)\n" "  Index (1, 1): actual 3.0000000000000000 vs
+  // expected 4.0000000000000000 (diff=1.0000000000000000)";
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):\n\s+Index \(0, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\)\n\s+Index \(1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+TYPED_TEST(TestSortErrors, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_1D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_2D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_1D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_2D_analytical<float_type>();
+}
+
+}  // namespace

--- a/testing/unit_test/Test_PrintErrors.cpp
+++ b/testing/unit_test/Test_PrintErrors.cpp
@@ -128,12 +128,15 @@ void test_print_errors_1D_analytical() {
   Kokkos::deep_copy(loc_error, h_loc_error);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
 
+  // clang-format off
+  // NOLINTBEGIN(*)
   // Example error message. The floating point numbers may vary.
   // "Mismatched elements (by indices):\n"
-  // "  Index (0): actual 3.0000000000000000 vs expected 3.0000599999999999
-  // (diff=0.0000599999999999)";
+  // "  Index (0): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)";
+  // NOLINTEND(*)
+  // clang-format on
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   // Regular expression pattern matching the expected format.
@@ -141,7 +144,7 @@ void test_print_errors_1D_analytical() {
   // \s+ matches one or more whitespace characters.
   // Updated regex pattern: Replace \d with [0-9]
   std::string pattern =
-      R"(Mismatched elements \(by indices\):\n\s+Index \(0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+      R"(Mismatched elements \(by indices\):)" "\n" R"(\s+Index \(0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
 
   // Using GoogleMock's MatchesRegex matcher to compare the string with the
   // pattern.
@@ -178,13 +181,16 @@ void test_print_errors_2D_analytical() {
   Kokkos::deep_copy(loc_error, h_loc_error);
 
   auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
 
+  // clang-format off
+  // NOLINTBEGIN(*)
   // Example error message. The floating point numbers may vary.
   // "Mismatched elements (by indices):\n"
-  // "  Index (0, 1): actual 3.0000000000000000 vs expected 3.0000599999999999
-  // (diff=0.0000599999999999)\n" "  Index (1, 1): actual 3.0000000000000000 vs
-  // expected 4.0000000000000000 (diff=1.0000000000000000)";
+  // "  Index (0, 1): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   // Regular expression pattern matching the expected format.
@@ -192,7 +198,7 @@ void test_print_errors_2D_analytical() {
   // \s+ matches one or more whitespace characters.
   // Updated regex pattern: Replace \d with [0-9]
   std::string pattern =
-      R"(Mismatched elements \(by indices\):\n\s+Index \(0, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\)\n\s+Index \(1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+      R"(Mismatched elements \(by indices\):)" "\n" R"(\s+Index \(0, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))" "\n" R"(\s+Index \(1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
 
   // Using GoogleMock's MatchesRegex matcher to compare the string with the
   // pattern.


### PR DESCRIPTION
This PR aims at developing unit-testing tools. They are available only for c++ 20 or later.

- [x] View-to-view comparison matcher up to 2D Views (CountErrors + FindErrors + SortErrors + PrintErrors which are integrated in allclose matcher)
- [x] Printing errors with indices
- [x] Unit-tests for tools 

TO DO tasks are as follows.

For features,
- [ ] Remove dependency to `Kokkos::Impl` function
- [x] Find a better workaround to overload allclose matcher with default arguments (`KokkosFFT_Allclose.hpp`). Defining an impl function for allclose task that is reused from different matchers. Thanks again Trévis!
- [x] Fix the regular expression matcher, which does not pass (`Test_PrintErrors.cpp`). Related to current CI failure of Threads backend. Fixed. Thanks Trévis!
- [ ] Extend View to View comparison up to 8D views
- [ ] Array to Array comparison with absolute and relative error tolerance on device
- [ ] Cartesian product generator for parameterized typed tests
- [ ] Move `KokkosFFT_Concetps.hpp` under common
- [ ] Replace current test utils in this repo

For documentations, 
- [ ]  How to write a test with a template including CMake
- [ ]  Naming convention: test file name, fixture name, test name, etc...
- [ ]  Death tests, skipping test and compile time tests
- [ ]  Tests on random number: use a fixed seed to be deterministic
