### PR TITLE
Update sycl base image to use oneapi newer than 2024.2.1

### DIFF
--- a/docker/intel/Dockerfile
+++ b/docker/intel/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-ARG BASE=intel/oneapi-basekit:2024.0.1-devel-ubuntu20.04
+ARG BASE=intel/oneapi-basekit:2025.1.0-0-devel-ubuntu24.04
 FROM $BASE
 
 ARG ADDITIONAL_PACKAGES
@@ -46,3 +46,4 @@ ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 WORKDIR /work
 CMD ["bash"]
+


### PR DESCRIPTION
This PR aims at updating the base image of sycl container to fix the [nightly failure](https://github.com/kokkos/kokkos-fft/actions/runs/14185022060). 
In the latest Kokkos, they raised IntelLLVM minimum for SYCL to 2024.2.1 (see [#PR](https://github.com/kokkos/kokkos/pull/7918)). 
