### PR TITLE
Refactor roll operation used in fftshift/ifftshift

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -12,12 +12,40 @@
 
 namespace KokkosFFT {
 namespace Impl {
+
+template <typename ExecutionSpace, typename ViewType, std::size_t Rank,
+          typename iType>
+struct Roll;
+
+/// \brief Compute shift amounts for FFT shift operations.
+/// Computes the shift for each axis so that the zero-frequency component is
+/// moved to the center of the spectrum (or back to its original position for an
+/// inverse shift). The provided axes (which can be negative) are first
+/// converted to non-negative axes. The function then calculates the shift as
+/// half of the extent of each selected axis, adjusted by the given direction (1
+/// for forward FFT shift, -1 for inverse FFT shift).
+///
+/// \tparam ViewType The type of the Kokkos View.
+/// \tparam DIM The number of axes to shift.
+///
+/// \param x[in,out] The input/output Kokkos View whose extents are used to
+/// determine the shift.
+/// \param axes[in] A container of axes indices (negative values allowed; they
+/// are converted).
+/// \param direction[in] The direction of the shift: 1 for fftshift and -1 for
+/// ifftshift.
+///
+/// \return A Kokkos::Array with the computed shift amounts for each axis.
+///
+/// \throws If any duplicate axes are found ("Axes overlap") or if any axis
+/// index is out of the valid range.
+///
 template <typename ViewType, std::size_t DIM = 1>
-auto get_shift(const ViewType& inout, axis_type<DIM> axes, int direction = 1) {
+auto get_shifts(const ViewType& x, axis_type<DIM> axes, int direction = 1) {
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> non_negative_axes;
   for (std::size_t i = 0; i < DIM; i++) {
-    int axis = KokkosFFT::Impl::convert_negative_axis(inout, axes.at(i));
+    int axis = KokkosFFT::Impl::convert_negative_axis(x, axes.at(i));
     non_negative_axes.push_back(axis);
   }
 
@@ -30,120 +58,151 @@ auto get_shift(const ViewType& inout, axis_type<DIM> axes, int direction = 1) {
       "Axes include an out-of-range index."
       "Axes must be in the range of [-rank, rank-1].");
 
-  axis_type<rank> shift = {0};
+  using ArrayType  = Kokkos::Array<std::size_t, rank>;
+  ArrayType shifts = {};
   for (int i = 0; i < static_cast<int>(DIM); i++) {
-    int axis       = non_negative_axes.at(i);
-    shift.at(axis) = inout.extent(axis) / 2 * direction;
+    int axis   = non_negative_axes.at(i);
+    int extent = x.extent(axis);
+    int shift  = extent / 2 * direction;
+    shift      = shift % extent;
+    if (shift < 0) shift += extent;
+    shifts[axis] = static_cast<std::size_t>(shift);
   }
-  return shift;
+  return shifts;
 }
 
-template <typename ExecutionSpace, typename ViewType>
-void roll(const ExecutionSpace& exec_space, const ViewType& inout,
-          axis_type<1> shift, axis_type<1> /* axes */) {
-  // Last parameter is ignored but present for keeping the interface consistent
-  static_assert(ViewType::rank() == 1, "roll: Rank of View must be 1.");
-  int n0 = inout.extent_int(0);
+/// \brief 1D Roll functor for in-place FFT shift operations.
+/// This struct implements a functor that applies a 1-dimensional circular shift
+/// (roll) on a Kokkos view. It shifts the data so that the zero-frequency
+/// component is moved to the center of the spectrum. The shift amount is
+/// specified by m_shifts which is calculated using the get_shifts function. The
+/// functor creates a temporary view to store the shifted data and then the
+/// shifted values are copied back into the original view.
+///
+/// \tparam ExecutionSpace The type of Kokkos execution space.
+/// \tparam ViewType The type of the Kokkos View.
+/// \tparam iType The index type used for the view.
+template <typename ExecutionSpace, typename ViewType, typename iType>
+struct Roll<ExecutionSpace, ViewType, 1, iType> {
+  using ArrayType          = Kokkos::Array<std::size_t, 1>;
+  using LayoutType         = typename ViewType::array_layout;
+  using ManageableViewType = typename manageable_view_type<ViewType>::type;
+  using policy_type =
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<iType>>;
 
-  ViewType tmp("tmp", n0);
-  int len = (n0 - 1) / 2 + 1;
+  ViewType m_x;
+  ManageableViewType m_tmp;
+  ArrayType m_shifts;
 
-  auto [s0, s1, s2] =
-      KokkosFFT::Impl::convert_negative_shift(inout, shift.at(0), 0);
-  int shift0 = s0, shift1 = s1, shift2 = s2;
-
-  // shift2 == 0 means shift
-  if (shift2 == 0) {
-    Kokkos::parallel_for(
-        "KokkosFFT::roll",
-        Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<int>>(exec_space,
-                                                                    0, len),
-        KOKKOS_LAMBDA(int i) {
-          if (i + shift0 < n0) {
-            tmp(i + shift0) = inout(i);
-          }
-          if (i + shift1 < n0) {
-            tmp(i) = inout(i + shift1);
-          }
-        });
-
-    Kokkos::deep_copy(inout, tmp);
+  /// \brief Constructor for the Roll functor.
+  ///
+  /// \param x[in,out] The input/output Kokkos view to be shifted.
+  /// \param shifts[in] The shift amounts for each axis.
+  /// \param exec_space[in] The Kokkos execution space to be used (defaults to
+  /// ExecutionSpace()).
+  Roll(const ViewType& x, const ArrayType& shifts,
+       const ExecutionSpace exec_space = ExecutionSpace())
+      : m_x(x),
+        m_tmp("tmp", create_layout<LayoutType>(extract_extents(x))),
+        m_shifts(shifts) {
+    Kokkos::parallel_for("KokkosFFT::roll-1D",
+                         policy_type(exec_space, 0, m_x.extent(0)), *this);
+    Kokkos::deep_copy(exec_space, m_x, m_tmp);
   }
-}
 
-template <typename ExecutionSpace, typename ViewType, std::size_t DIM1 = 1>
-void roll(const ExecutionSpace& exec_space, const ViewType& inout,
-          axis_type<2> shift, axis_type<DIM1> axes) {
-  constexpr int DIM0 = 2;
-  static_assert(ViewType::rank() == DIM0, "roll: Rank of View must be 2.");
-  int n0 = inout.extent_int(0), n1 = inout.extent_int(1);
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0) const {
+    iType i0_dst  = (i0 + m_shifts[0]) % static_cast<iType>(m_x.extent(0));
+    m_tmp(i0_dst) = m_x(i0);
+  }
+};
 
-  ViewType tmp("tmp", n0, n1);
-  int len0 = (n0 - 1) / 2 + 1;
-  int len1 = (n1 - 1) / 2 + 1;
+/// \brief 2D Roll functor for in-place FFT shift operations.
+/// This struct implements a functor that applies a 2-dimensional circular shift
+/// (roll) on a Kokkos view. It shifts the data so that the zero-frequency
+/// component is moved to the center of the spectrum. The shift amount is
+/// specified by m_shifts which is calculated using the get_shifts function. The
+/// functor creates a temporary view to store the shifted data and then the
+/// shifted values are copied back into the original view.
+///
+/// \tparam ExecutionSpace The type of Kokkos execution space.
+/// \tparam ViewType The type of the Kokkos View.
+/// \tparam iType The index type used for the view.
+template <typename ExecutionSpace, typename ViewType, typename iType>
+struct Roll<ExecutionSpace, ViewType, 2, iType> {
+  using ArrayType          = Kokkos::Array<std::size_t, 2>;
+  using LayoutType         = typename ViewType::array_layout;
+  using ManageableViewType = typename manageable_view_type<ViewType>::type;
 
-  using range_type = Kokkos::MDRangePolicy<
+  using policy_type = Kokkos::MDRangePolicy<
       ExecutionSpace,
-      Kokkos::Rank<2, Kokkos::Iterate::Default, Kokkos::Iterate::Default>>;
-  using tile_type  = typename range_type::tile_type;
-  using point_type = typename range_type::point_type;
+      Kokkos::Rank<2, Kokkos::Iterate::Default, Kokkos::Iterate::Default>,
+      Kokkos::IndexType<iType>>;
 
-  // [TO DO] Choose optimal tile sizes for each device
-  range_type range(exec_space, point_type{0, 0}, point_type{len0, len1},
-                   tile_type{4, 4});
+  ViewType m_x;
+  ManageableViewType m_tmp;
+  ArrayType m_shifts;
 
-  axis_type<2> shift0 = {0}, shift1 = {0}, shift2 = {n0 / 2, n1 / 2};
-  for (int i = 0; static_cast<std::size_t>(i) < DIM1; i++) {
-    int axis = axes.at(i);
-
-    auto [s0, s1, s2] =
-        KokkosFFT::Impl::convert_negative_shift(inout, shift.at(axis), axis);
-    shift0.at(axis) = s0;
-    shift1.at(axis) = s1;
-    shift2.at(axis) = s2;
+  /// \brief Constructor for the Roll functor.
+  ///
+  /// \param x[in,out] The input/output Kokkos view to be shifted.
+  /// \param shifts[in] The shift amounts for each axis.
+  /// \param exec_space[in] The Kokkos execution space to be used (defaults to
+  /// ExecutionSpace()).
+  Roll(const ViewType& x, const ArrayType& shifts,
+       const ExecutionSpace exec_space = ExecutionSpace())
+      : m_x(x),
+        m_tmp("tmp", create_layout<LayoutType>(extract_extents(x))),
+        m_shifts(shifts) {
+    iType n0 = m_x.extent(0), n1 = m_x.extent(1);
+    policy_type policy(exec_space, {0, 0}, {n0, n1}, {4, 4});
+    Kokkos::parallel_for("KokkosFFT::roll-2D", policy, *this);
+    Kokkos::deep_copy(exec_space, m_x, m_tmp);
   }
 
-  int shift_00 = shift0.at(0), shift_10 = shift0.at(1);
-  int shift_01 = shift1.at(0), shift_11 = shift1.at(1);
-  int shift_02 = shift2.at(0), shift_12 = shift2.at(1);
+  KOKKOS_INLINE_FUNCTION
+  void operator()(iType i0, iType i1) const {
+    auto get_dst = [&](iType idx_src, std::size_t axis) {
+      return (idx_src + m_shifts[axis]) % static_cast<iType>(m_x.extent(axis));
+    };
+    iType i0_dst          = get_dst(i0, 0);
+    iType i1_dst          = get_dst(i1, 1);
+    m_tmp(i0_dst, i1_dst) = m_x(i0, i1);
+  }
+};
 
-  Kokkos::parallel_for(
-      "KokkosFFT::roll", range, KOKKOS_LAMBDA(int i0, int i1) {
-        if (i0 + shift_00 < n0 && i1 + shift_10 < n1) {
-          tmp(i0 + shift_00, i1 + shift_10) = inout(i0, i1);
-        }
-
-        if (i0 + shift_01 < n0 && i1 + shift_11 < n1) {
-          tmp(i0, i1) = inout(i0 + shift_01, i1 + shift_11);
-        }
-
-        if (i0 + shift_01 < n0 && i1 + shift_10 < n1) {
-          tmp(i0 + shift_02, i1 + shift_10 + shift_12) =
-              inout(i0 + shift_01 + shift_02, i1 + shift_12);
-        }
-
-        if (i0 + shift_00 < n0 && i1 + shift_11 < n1) {
-          tmp(i0 + shift_00 + shift_02, i1 + shift_12) =
-              inout(i0 + shift_02, i1 + shift_11 + shift_12);
-        }
-      });
-
-  Kokkos::deep_copy(inout, tmp);
-}
-
+/// \brief Implementation of FFT shift operations.
+/// Computes the necessary shift amounts for each axis using the get_shifts
+/// function and applies an in-place FFT shift on the input view `x`. Depending
+/// on the memory span of `x`, it selects an appropriate index type (int64_t if
+/// the span exceeds the maximum value representable by int, otherwise int).
+///
+/// \tparam ExecutionSpace The type of Kokkos execution space.
+/// \tparam ViewType The type of the Kokkos View.
+/// \tparam DIM The number of axes to shift.
+///
+/// \param exec_space [in] Kokkos execution space.
+/// \param x [in,out] The input/output Kokkos View.
+/// \param axes [in] A container of axes indices (negative values allowed; they
+/// are converted).
+/// \param direction [in] The direction of the shift: 1 for fftshift and -1 for
+/// ifftshift.
+///
+/// \throws if any duplicate axes are found ("Axes overlap") or if any axis
+/// index is out of the valid range.
 template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
-void fftshift_impl(const ExecutionSpace& exec_space, const ViewType& inout,
-                   axis_type<DIM> axes) {
-  auto shift = get_shift(inout, axes);
-  roll(exec_space, inout, shift, axes);
+void fftshift_impl(const ExecutionSpace& exec_space, const ViewType& x,
+                   axis_type<DIM> axes, int direction) {
+  auto shifts = get_shifts(x, axes, direction);
+  if (x.span() >= std::size_t(std::numeric_limits<int>::max())) {
+    Roll<ExecutionSpace, ViewType, ViewType::rank(), int64_t>(x, shifts,
+                                                              exec_space);
+  } else {
+    Roll<ExecutionSpace, ViewType, ViewType::rank(), int>(x, shifts,
+                                                          exec_space);
+  }
 }
 
-template <typename ExecutionSpace, typename ViewType, std::size_t DIM = 1>
-void ifftshift_impl(const ExecutionSpace& exec_space, const ViewType& inout,
-                    axis_type<DIM> axes) {
-  auto shift = get_shift(inout, axes, -1);
-  roll(exec_space, inout, shift, axes);
-}
 }  // namespace Impl
 }  // namespace KokkosFFT
 
@@ -240,12 +299,12 @@ void fftshift(const ExecutionSpace& exec_space, const ViewType& inout,
 
   if (axes) {
     axis_type<1> tmp_axes{axes.value()};
-    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes);
+    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes, 1);
   } else {
     constexpr std::size_t rank = ViewType::rank();
     constexpr int start        = -static_cast<int>(rank);
     auto tmp_axes = KokkosFFT::Impl::index_sequence<int, rank, start>();
-    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes);
+    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes, 1);
   }
 }
 
@@ -272,7 +331,7 @@ void fftshift(const ExecutionSpace& exec_space, const ViewType& inout,
   static_assert(ViewType::rank() >= DIM,
                 "fftshift: View rank must be larger than or equal to the Rank "
                 "of FFT axes");
-  KokkosFFT::Impl::fftshift_impl(exec_space, inout, axes);
+  KokkosFFT::Impl::fftshift_impl(exec_space, inout, axes, 1);
 }
 
 /// \brief The inverse of fftshift
@@ -296,12 +355,12 @@ void ifftshift(const ExecutionSpace& exec_space, const ViewType& inout,
                 "ifftshift: View rank must be larger than or equal to 1");
   if (axes) {
     axis_type<1> tmp_axes{axes.value()};
-    KokkosFFT::Impl::ifftshift_impl(exec_space, inout, tmp_axes);
+    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes, -1);
   } else {
     constexpr std::size_t rank = ViewType::rank();
     constexpr int start        = -static_cast<int>(rank);
     auto tmp_axes = KokkosFFT::Impl::index_sequence<int, rank, start>();
-    KokkosFFT::Impl::ifftshift_impl(exec_space, inout, tmp_axes);
+    KokkosFFT::Impl::fftshift_impl(exec_space, inout, tmp_axes, -1);
   }
 }
 
@@ -329,7 +388,7 @@ void ifftshift(const ExecutionSpace& exec_space, const ViewType& inout,
                 "ifftshift: View rank must be larger than or equal to the Rank "
                 "of FFT axes");
 
-  KokkosFFT::Impl::ifftshift_impl(exec_space, inout, axes);
+  KokkosFFT::Impl::fftshift_impl(exec_space, inout, axes, -1);
 }
 }  // namespace KokkosFFT
 


### PR DESCRIPTION
This PR aims at refactoring the implementation details of Roll function. 
Previously, it is complicated to extend to higher dimensions. 
Although we support up to 2D now, it is now straightforward to extend up to 8D.

- [x] Compute all the shifts (same as View dimensions) in `get_shifts` function
- [x] Add tests for this
- [x] Roll function is updated to perform shits along each axes without conditionals
- [x] Use Manageable View type for the temporary buffer `tmp` 
- [x] Docstrings are added to the implementation details as well 