### PR TITLE
Unuse kokkos fft enable host and device

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -141,7 +141,7 @@ jobs:
           - name: native
             cmake_flags: ""
           - name: host_device
-            cmake_flags: -DKokkosFFT_ENABLE_HOST_AND_DEVICE=ON
+            cmake_flags: -DKokkosFFT_ENABLE_FFTW=ON
         exclude:
           - backend:
               name: clang-tidy

--- a/docs/api/enums/direction.rst
+++ b/docs/api/enums/direction.rst
@@ -1,0 +1,9 @@
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+..
+.. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+KokkosFFT::Direction
+--------------------
+
+.. doxygenenum:: KokkosFFT::Direction
+   :project: KokkosFFT

--- a/docs/api/enums/normalization.rst
+++ b/docs/api/enums/normalization.rst
@@ -1,0 +1,9 @@
+.. SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+..
+.. SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+KokkosFFT::Normalization
+------------------------
+
+.. doxygenenum:: KokkosFFT::Normalization
+   :project: KokkosFFT

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -172,3 +172,46 @@ Helper routines
    * - The inverse of :doc:`fftshift<api/helper/fftshift>`
      - :doc:`api/helper/ifftshift`
      - `numpy.fft.ifftshift <https://numpy.org/doc/stable/reference/generated/numpy.fft.ifftshift.html>`_
+
+Enums
+-----
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   api/enums/normalization
+   api/enums/direction
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Description
+     - ``kokkos-fft``
+   * - Tag to specify when and how to normalize
+     - :doc:`api/enums/normalization`
+   * - Tag to specify FFT direction
+     - :doc:`api/enums/direction`
+
+Macros
+------
+
+Following macros can be used to check whether a backend library is enabled or not.
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Description
+     - Macros
+   * - Defined if the FFTW is enabled.
+     - ``KOKKOSFFT_ENABLE_TPL_FFTW``
+   * - Defined if the cufft is enabled.
+     - ``KOKKOSFFT_ENABLE_TPL_CUFFT``
+   * - Defined if the hipfft is enabled.
+     - ``KOKKOSFFT_ENABLE_TPL_HIPFFT``
+   * - Defined if the rocfft is enabled.
+     - ``KOKKOSFFT_ENABLE_TPL_ROCFFT``
+   * - Defined if the oneMKL is enabled.
+     - ``KOKKOSFFT_ENABLE_TPL_ONEMKL``

--- a/docs/finding_libraries.rst
+++ b/docs/finding_libraries.rst
@@ -38,7 +38,7 @@ If CMake fails to find ``fftw``, please try to set ``FFTWDIR`` in the following 
 ------------------------------------------
 
 `oneMKL <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html>`_
-------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------
 
 The most likely scenario to miss ``oneMKL`` is that forgetting to initialize ``oneAPI``.
 Please make sure to initialize ``oneAPI`` as

--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -76,9 +76,10 @@ CMake options
 
 We rely on CMake to build kokkos-fft, more specifically ``CMake 3.22+``. Here is the list of CMake options. 
 For FFTs on Kokkos device only, we do not need to add extra compile options but for Kokkos ones.
-In order to use kokkos-fft from both host and device, it is necessary to add ``KokkosFFT_ENABLE_HOST_AND_DEVICE=ON``.
+In order to use kokkos-fft from both host and device, it is necessary to add ``KokkosFFT_ENABLE_FFTW=ON``.
 This option may be useful, for example FFT is used for initialization at host. 
 However, to enable this option, we need a pre-installed ``fftw`` for FFT on host, so it is disabled in default
+if one of the device backend is enabled.
 (see :doc:`minimum working example<../samples/05_1DFFT_HOST_DEVICE>`).
 
 .. list-table:: CMake options
@@ -88,7 +89,7 @@ However, to enable this option, we need a pre-installed ``fftw`` for FFT on host
    * - 
      - Description
      - Default
-   * - ``KokkosFFT_ENABLE_HOST_AND_DEVICE``
+   * - ``KokkosFFT_ENABLE_HOST_AND_DEVICE`` :red:`[Deprecated since 0.3]`
      - Enable FFT on both host and device.
      - OFF
    * - ``KokkosFFT_ENABLE_INTERNAL_KOKKOS``
@@ -103,9 +104,27 @@ However, to enable this option, we need a pre-installed ``fftw`` for FFT on host
    * - ``KokkosFFT_ENABLE_BENCHMARK``
      - Build benchmarks for kokkos-fft
      - OFF
+   * - ``KokkosFFT_ENABLE_FFTW``
+     - Use `fftw <http://www.fftw.org>`_ for Host backend
+     - ON (if non of Kokkos devices is enabled, otherwise OFF)
+   * - ``KokkosFFT_ENABLE_CUFFT``
+     - Use `cufft <https://developer.nvidia.com/cufft>`_ for CUDA backend
+     - ON (if ``Kokkos_ENABLE_CUDA`` is ON, otherwise OFF)
    * - ``KokkosFFT_ENABLE_ROCFFT``
      - Use `rocfft <https://github.com/ROCm/rocFFT>`_ for HIP backend
      - OFF
+   * - ``KokkosFFT_ENABLE_HIPFFT``
+     - Use `hipfft <https://github.com/ROCm/hipFFT>`_ for HIP backend
+     - ON (if ``Kokkos_ENABLE_HIP`` is ON, otherwise OFF)
+   * - ``KokkosFFT_ENABLE_ONEMKL``
+     - Use `oneMKL <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html>`_ for SYCL backend
+     - ON (if ``Kokkos_ENABLE_SYCL`` is ON, otherwise OFF)
+
+.. note::
+
+   To enable kokkos-fft on both host and device, set ``KokkosFFT_ENABLE_FFTW=ON`` instead of setting ``KokkosFFT_ENABLE_HOST_AND_DEVICE=ON``.
+   Multiple device tpls cannot be enabled at the same time. In addition, at least one tpl must be enabled to configure.
+   For example, it is allowed to set ``KokkosFFT_ENABLE_CUFFT=OFF`` even if ``Kokkos_ENABLE_CUDA=ON`` as long as ``KokkosFFT_ENABLE_FFTW=ON``.
 
 Kokkos backends
 ---------------

--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -106,7 +106,7 @@ if one of the device backend is enabled.
      - OFF
    * - ``KokkosFFT_ENABLE_FFTW``
      - Use `fftw <http://www.fftw.org>`_ for Host backend
-     - ON (if non of Kokkos devices is enabled, otherwise OFF)
+     - ON (if none of Kokkos devices is enabled, otherwise OFF)
    * - ``KokkosFFT_ENABLE_CUFFT``
      - Use `cufft <https://developer.nvidia.com/cufft>`_ for CUDA backend
      - ON (if ``Kokkos_ENABLE_CUDA`` is ON, otherwise OFF)

--- a/fft/src/CMakeLists.txt
+++ b/fft/src/CMakeLists.txt
@@ -45,10 +45,6 @@ elseif("FFTW_SERIAL" IN_LIST KOKKOSFFT_TPL_LIST)
   target_compile_definitions(fft INTERFACE KOKKOSFFT_ENABLE_TPL_FFTW)
 endif()
 
-if(KokkosFFT_ENABLE_HOST_AND_DEVICE)
-  target_compile_definitions(fft INTERFACE ENABLE_HOST_AND_DEVICE)
-endif()
-
 target_include_directories(
   fft INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>
 )

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -11,7 +11,7 @@
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_asserts.hpp"
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif
 
@@ -76,7 +76,7 @@ struct ScopedCufftPlan {
   }
 };
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 template <typename ExecutionSpace>
 struct FFTDataType {
   using float32 =

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -11,7 +11,7 @@
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_asserts.hpp"
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif
 
@@ -76,7 +76,7 @@ struct ScopedHIPfftPlan {
   }
 };
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 template <typename ExecutionSpace>
 struct FFTDataType {
   using float32 =

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -14,7 +14,7 @@
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_asserts.hpp"
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif
 
@@ -32,7 +32,7 @@ using FFTDirectionType                     = int;
 constexpr FFTDirectionType ROCFFT_FORWARD  = 1;
 constexpr FFTDirectionType ROCFFT_BACKWARD = -1;
 
-#if !defined(ENABLE_HOST_AND_DEVICE)
+#if !defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
 #endif
 
@@ -315,7 +315,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
   static constexpr FFTWTransformType type() { return m_type; };
 };
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 
 template <typename ExecutionSpace>
 struct FFTDataType {

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -12,7 +12,7 @@
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_utils.hpp"
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif
 
@@ -31,7 +31,7 @@ using FFTDirectionType                      = int;
 constexpr FFTDirectionType MKL_FFT_FORWARD  = 1;
 constexpr FFTDirectionType MKL_FFT_BACKWARD = -1;
 
-#if !defined(ENABLE_HOST_AND_DEVICE)
+#if !defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 enum class FFTWTransformType { R2C, D2Z, C2R, Z2D, C2C, Z2Z };
 #endif
 
@@ -76,7 +76,7 @@ struct transform_type<ExecutionSpace, Kokkos::complex<T1>,
   static constexpr FFTWTransformType type() { return m_type; };
 };
 
-#if defined(ENABLE_HOST_AND_DEVICE)
+#if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 
 template <typename ExecutionSpace>
 struct FFTDataType {


### PR DESCRIPTION
Resolves #150 

This PR aims at deprecating the usage of KokkosFFT_ENABLE_HOST_AND_DEVICE.

- [x] Remove `ENABLE_HOST_AND_DEVICE` from the source code.
- [x] Unuse `KokkosFFT_ENABLE_HOST_AND_DEVICE` in CI
- [x] Documented that `KokkosFFT_ENABLE_HOST_AND_DEVICE` is deprecated

Modified on 15/Apr
- [x] Add docs for enums and macros