### PR TITLE
Set commit sha instead of version of github actions

### DIFF
--- a/.github/workflows/__clang-format-check.yaml
+++ b/.github/workflows/__clang-format-check.yaml
@@ -18,8 +18,8 @@ jobs:
   clang-formatting-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: DoozyX/clang-format-lint-action@v0.20
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73  # v0.20
       with:
         source: 'common/ fft/ examples/ install_test/'
         exclude: ''

--- a/.github/workflows/__cmake-format-check.yaml
+++ b/.github/workflows/__cmake-format-check.yaml
@@ -18,7 +18,7 @@ jobs:
   cmake-formatting-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: cmake-format lint action
       uses: puneetmatharu/cmake-format-lint-action@2ac346e79e7ceac958bc637c1391285fb335ed7c # v1.0.5
       with:

--- a/.github/workflows/build_nightly.yaml
+++ b/.github/workflows/build_nightly.yaml
@@ -93,18 +93,18 @@ jobs:
               kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: true
           large-packages: false
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: recursive
 
       - name: Checkout Kokkos devel branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: kokkos/kokkos
           path: kokkos

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -34,8 +34,8 @@ jobs:
     name: spell check with typos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: crate-ci/typos@v1.31.1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: crate-ci/typos@b1a1ef3893ff35ade0cfa71523852a49bfd05d19  # v1.31.1
       with:
         files: ./cmake/ ./CMakeLists.txt ./docs/ ./README.md ./common/ ./fft/ ./examples/ ./install_test/
         config: ./.typos.toml
@@ -162,13 +162,13 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: true
           large-packages: false
 
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: recursive
 
@@ -199,7 +199,7 @@ jobs:
         if: ${{ matrix.target.name == 'native' }}
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: tests_${{ matrix.backend.name }}
           path: tests_${{ matrix.backend.name }}.tar
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Get artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: tests_${{ matrix.backend.name }}
 
@@ -336,7 +336,7 @@ jobs:
         if: ${{ matrix.backend.use_singularity }}
 
       - name: Login in GitHub Containers Repository with Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/cleanup_base.yaml
+++ b/.github/workflows/cleanup_base.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Cleanup old images
-        uses: SmartsquareGmbH/delete-old-packages@v0.8.1
+        uses: SmartsquareGmbH/delete-old-packages@e207ebd412f87647d9c35325e270c2156318c51c  # v0.8.1
         with:
           organization: kokkos
           type: container

--- a/.github/workflows/create_base.yaml
+++ b/.github/workflows/create_base.yaml
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: true
           large-packages: false
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Get Singularity
         env:
@@ -70,7 +70,7 @@ jobs:
           sudo apt-get install ./singularity-ce_${{ env.SINGULARITY_VERSION }}-jammy_amd64.deb
 
       - name: Login in GitHub Containers Repository with Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
         with:
           python-version: ${{ matrix.python-version }}
         

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v5
+      uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542  # v5.0.0


### PR DESCRIPTION
This PR aims to harden security following [github recommendations](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
>Pin actions to a full length commit SHA

Note that as a consequence, this will increase the number of dependabot PRs.