### PR TITLE
Fixes a link in the documentation

### DIFF
--- a/docs/intro/building.rst
+++ b/docs/intro/building.rst
@@ -15,7 +15,7 @@ Available CMake options for kokkos-fft are listed.
 Compiler versions
 -----------------
 
-kokkos-fft relies on quite basic functionalities of Kokkos, and thus it is supposed to work with compilers used for `Kokkos <https://kokkos.org/kokkos-core-wiki/requirements.html>`_.
+kokkos-fft relies on quite basic functionalities of Kokkos, and thus it is supposed to work with compilers used for `Kokkos <https://kokkos.org/kokkos-core-wiki/get-started/requirements.html>`_.
 However, we have not tested all the listed compilers there and thus recommend the following compilers which we use frequently for testing.
 
 * ``gcc 8.3.0+`` - CPUs


### PR DESCRIPTION
The link https://kokkos.org/kokkos-core-wiki/requirements.html seems now broken, did we mean https://kokkos.org/kokkos-core-wiki/get-started/requirements.html ?