### PR TITLE
Introduce a helper to convert a view type with different base value type

### DIFF
--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -269,8 +269,8 @@ using add_pointer_n_t = typename add_pointer_n<T, Rank>::type;
 template <typename ViewType, typename T>
 struct ConvertedViewType {
   using data_type = add_pointer_n_t<T, ViewType::rank()>;
-  using type      = Kokkos::View<data_type, typename T::array_layout,
-                            typename T::memory_space>;
+  using type      = Kokkos::View<data_type, typename ViewType::array_layout,
+                            typename ViewType::execution_space>;
 };
 
 /// \brief Helper to define a complex 1D View type from a real/complex 1D View

--- a/common/src/KokkosFFT_traits.hpp
+++ b/common/src/KokkosFFT_traits.hpp
@@ -248,6 +248,31 @@ struct manageable_view_type {
                             typename T::memory_space>;
 };
 
+/// \brief Primary template: recurse by adding one pointer and decreasing Rank.
+template <typename T, std::size_t Rank>
+struct add_pointer_n {
+  using type = typename add_pointer_n<T*, Rank - 1>::type;
+};
+
+/// Base case: Rank == 0, just yield T.
+template <typename T>
+struct add_pointer_n<T, 0> {
+  using type = T;
+};
+
+/// Convenience alias:
+template <typename T, std::size_t Rank>
+using add_pointer_n_t = typename add_pointer_n<T, Rank>::type;
+
+/// \brief Helper to define a new View type with different value type
+/// while keeping rank, layout and memory space
+template <typename ViewType, typename T>
+struct ConvertedViewType {
+  using data_type = add_pointer_n_t<T, ViewType::rank()>;
+  using type      = Kokkos::View<data_type, typename T::array_layout,
+                            typename T::memory_space>;
+};
+
 /// \brief Helper to define a complex 1D View type from a real/complex 1D View
 /// type, while keeping other properties
 template <typename ExecutionSpace, typename ViewType,

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -186,6 +186,22 @@ void test_admissible_complex_type() {
   }
 }
 
+template <typename T>
+void test_add_pointers() {
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 0>, T>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 1>, T*>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 2>, T**>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 3>, T***>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 4>, T****>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 5>, T*****>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 6>,
+                              T******>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 7>,
+                              T*******>();
+  testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 8>,
+                              T********>();
+}
+
 // Tests for admissible view types
 template <typename T, typename LayoutType>
 void test_admissible_value_type() {
@@ -622,6 +638,14 @@ TYPED_TEST(CompileTestRealAndComplexTypes, admissible_complex_type) {
   using complex_type = typename TestFixture::complex_type;
 
   test_admissible_complex_type<complex_type>();
+}
+
+TYPED_TEST(CompileTestRealAndComplexTypes, add_pointers) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+
+  test_add_pointers<real_type>();
+  test_add_pointers<complex_type>();
 }
 
 TYPED_TEST(CompileTestRealAndComplexViewTypes, admissible_value_type) {

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -212,8 +212,10 @@ void test_add_pointers() {
 // \param LayoutType Layout type of the View
 template <typename T1, typename T2, typename LayoutType>
 void test_converted_view_types() {
-  using ViewType1 = Kokkos::View<T1*, LayoutType, Kokkos::DefaultExecutionSpace>;
-  using ViewType2 = Kokkos::View<T2*, LayoutType, Kokkos::DefaultExecutionSpace>;
+  using ViewType1 =
+      Kokkos::View<T1*, LayoutType, Kokkos::DefaultExecutionSpace>;
+  using ViewType2 =
+      Kokkos::View<T2*, LayoutType, Kokkos::DefaultExecutionSpace>;
   using DerivedViewType2 =
       typename KokkosFFT::Impl::ConvertedViewType<ViewType1, T2>::type;
   testing::StaticAssertTypeEq<DerivedViewType2, ViewType2>();

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -186,6 +186,7 @@ void test_admissible_complex_type() {
   }
 }
 
+// Tests for add_pointer helper
 template <typename T>
 void test_add_pointers() {
   testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 0>, T>();
@@ -200,6 +201,22 @@ void test_add_pointers() {
                               T*******>();
   testing::StaticAssertTypeEq<KokkosFFT::Impl::add_pointer_n_t<T, 8>,
                               T********>();
+}
+
+// Tests for converted view types
+// Real to Real, Real to Complex, Complex to Real, Complex to Complex
+// are tested
+//
+// \param T1 Value type of the first View
+// \param T2 Value type of the second View
+// \param LayoutType Layout type of the View
+template <typename T1, typename T2, typename LayoutType>
+void test_converted_view_types() {
+  using ViewType1 = Kokkos::View<T1*, LayoutType, Kokkos::DefaultExecutionSpace>;
+  using ViewType2 = Kokkos::View<T2*, LayoutType, Kokkos::DefaultExecutionSpace>;
+  using DerivedViewType2 =
+      typename KokkosFFT::Impl::ConvertedViewType<ViewType1, T2>::type;
+  testing::StaticAssertTypeEq<DerivedViewType2, ViewType2>();
 }
 
 // Tests for admissible view types
@@ -646,6 +663,17 @@ TYPED_TEST(CompileTestRealAndComplexTypes, add_pointers) {
 
   test_add_pointers<real_type>();
   test_add_pointers<complex_type>();
+}
+
+TYPED_TEST(CompileTestRealAndComplexViewTypes, converted_view_types) {
+  using real_type    = typename TestFixture::real_type;
+  using complex_type = typename TestFixture::complex_type;
+  using layout_type  = typename TestFixture::layout_type;
+
+  test_converted_view_types<real_type, real_type, layout_type>();
+  test_converted_view_types<real_type, complex_type, layout_type>();
+  test_converted_view_types<complex_type, real_type, layout_type>();
+  test_converted_view_types<complex_type, complex_type, layout_type>();
 }
 
 TYPED_TEST(CompileTestRealAndComplexViewTypes, admissible_value_type) {


### PR DESCRIPTION
This PR aims at introducing a helper to define a new view type with different value type while keeping other properties.
This helper is useful to allocate a buffer in complex data from the same shape of real data.

```C++
using DerivedViewType2 = typename KokkosFFT::Impl::ConvertedViewType<ViewType1, T2>::type;
```

- [x] Adding a `add_pointer_n` helper to manipulate pointer types
- [x] Adding a `ConvertedViewType` helper for base value type conversion