### PR TITLE
Allow real input to fft and hfft

### DIFF
--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -6,3 +6,7 @@ KokkosFFT::hfft
 ---------------
 
 .. doxygenfunction:: KokkosFFT::hfft(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
+
+.. note::
+
+   For the real input, we internally convert it to complex and perform ``hfft`` on it.

--- a/docs/api/standard/fft.rst
+++ b/docs/api/standard/fft.rst
@@ -6,3 +6,7 @@ KokkosFFT::fft
 --------------
 
 .. doxygenfunction:: KokkosFFT::fft(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
+
+.. note::
+
+   For the real input, we internally convert it to complex and perform ``fft`` on it.

--- a/docs/api/standard/fft2.rst
+++ b/docs/api/standard/fft2.rst
@@ -6,3 +6,7 @@ KokkosFFT::fft2
 ---------------
 
 .. doxygenfunction:: KokkosFFT::fft2(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)
+
+.. note::
+
+   For the real input, we internally convert it to complex and perform ``fft2`` on it.

--- a/docs/api/standard/fftn.rst
+++ b/docs/api/standard/fftn.rst
@@ -6,3 +6,7 @@ KokkosFFT::fftn
 ---------------
 
 .. doxygenfunction:: KokkosFFT::fftn(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization norm, shape_type<DIM> s)
+
+.. note::
+
+   For the real input, we internally convert it to complex and perform ``fftn`` on it.

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -59,6 +59,7 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 1,
                 "fft: View rank must be larger than or equal to 1");
+
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
 

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -39,7 +39,7 @@ void execute(
 /// \tparam OutViewType: Output View type for the fft
 ///
 /// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
+/// \param in [in] Input data (real or complex)
 /// \param out [out] Output data (complex)
 /// \param norm [in] How the normalization is applied (default, backward)
 /// \param axis [in] Axis over which FFT is performed (default, -1)
@@ -224,7 +224,7 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
 /// \tparam OutViewType: Output View type for the fft
 ///
 /// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
+/// \param in [in] Input data (real or complex)
 /// \param out [out] Output data (real)
 /// \param norm [in] How the normalization is applied (default, backward)
 /// \param axis [in] Axis over which FFT is performed (default, -1)
@@ -332,7 +332,7 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
 /// \tparam OutViewType: Output View type for the fft
 ///
 /// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
+/// \param in [in] Input data (real or complex)
 /// \param out [out] Output data (complex)
 /// \param norm [in] How the normalization is applied (default, backward)
 /// \param axes [in] Axes over which FFT is performed (default, {-2, -1})
@@ -518,7 +518,7 @@ void irfft2(const ExecutionSpace& exec_space, const InViewType& in,
 /// \tparam DIM: The dimensionality of the fft
 ///
 /// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (complex)
+/// \param in [in] Input data (real or complex)
 /// \param out [out] Output data (complex)
 /// \param axes [in] Axes over which FFT is performed (default, all axes)
 /// \param norm [in] How the normalization is applied (default, backward)

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -59,13 +59,36 @@ void fft(const ExecutionSpace& exec_space, const InViewType& in,
       "and OutViewType.");
   static_assert(InViewType::rank() >= 1,
                 "fft: View rank must be larger than or equal to 1");
+  using in_value_type  = typename InViewType::non_const_value_type;
+  using out_value_type = typename OutViewType::non_const_value_type;
+
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
+                "fft: OutViewType must be complex");
 
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::fft");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
-  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axis,
-                       n);
-  plan.execute_impl(in, out, norm);
+  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
+    // Convert to complex type
+    using ComplexType = Kokkos::complex<in_value_type>;
+    using ComplexInViewType =
+        typename KokkosFFT::Impl::ConvertedViewType<InViewType,
+                                                    ComplexType>::type;
+    using ManageableComplexInViewType =
+        typename KokkosFFT::Impl::manageable_view_type<ComplexInViewType>::type;
+    using LayoutType = typename ManageableComplexInViewType::array_layout;
+    auto extents     = KokkosFFT::Impl::extract_extents(in);
+    ManageableComplexInViewType cin(
+        "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
+    Kokkos::deep_copy(cin, in);
+    KokkosFFT::Plan plan(exec_space, cin, out, KokkosFFT::Direction::forward,
+                         axis, n);
+    plan.execute_impl(cin, out, norm);
+  } else {
+    KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
+                         axis, n);
+    plan.execute_impl(in, out, norm);
+  }
 }
 
 /// \brief One dimensional FFT in backward direction
@@ -221,13 +244,9 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(InViewType::rank() >= 1,
                 "hfft: View rank must be larger than or equal to 1");
 
-  // [TO DO]
-  // allow real type as input, need to obtain complex view type from in view
-  // type
   using in_value_type  = typename InViewType::non_const_value_type;
   using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(KokkosFFT::Impl::is_complex_v<in_value_type>,
-                "hfft: InViewType must be complex");
+
   static_assert(KokkosFFT::Impl::is_real_v<out_value_type>,
                 "hfft: OutViewType must be real");
 
@@ -235,12 +254,26 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
-  // using ComplexViewType = typename
-  // KokkosFFT::Impl::complex_view_type<ExecutionSpace, InViewType>::type;
-  // ComplexViewType in_conj;
-  InViewType in_conj;
-  KokkosFFT::Impl::conjugate(exec_space, in, in_conj);
-  irfft(exec_space, in_conj, out, new_norm, axis, n);
+
+  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
+    // Convert to complex type
+    using ComplexType = Kokkos::complex<in_value_type>;
+    using ComplexInViewType =
+        typename KokkosFFT::Impl::ConvertedViewType<InViewType,
+                                                    ComplexType>::type;
+    using ManageableComplexInViewType =
+        typename KokkosFFT::Impl::manageable_view_type<ComplexInViewType>::type;
+    using LayoutType = typename ManageableComplexInViewType::array_layout;
+    auto extents     = KokkosFFT::Impl::extract_extents(in);
+    ManageableComplexInViewType cin(
+        "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
+    Kokkos::deep_copy(cin, in);
+    irfft(exec_space, cin, out, new_norm, axis, n);
+  } else {
+    InViewType in_conj;
+    KokkosFFT::Impl::conjugate(exec_space, in, in_conj);
+    irfft(exec_space, in_conj, out, new_norm, axis, n);
+  }
 }
 
 /// \brief Inverse of hfft
@@ -318,12 +351,36 @@ void fft2(const ExecutionSpace& exec_space, const InViewType& in,
   static_assert(InViewType::rank() >= 2,
                 "fft2: View rank must be larger than or equal to 2");
 
+  using in_value_type  = typename InViewType::non_const_value_type;
+  using out_value_type = typename OutViewType::non_const_value_type;
+
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
+                "fft2: OutViewType must be complex");
+
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::fft2");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
-                       s);
-  plan.execute_impl(in, out, norm);
+  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
+    // Convert to complex type
+    using ComplexType = Kokkos::complex<in_value_type>;
+    using ComplexInViewType =
+        typename KokkosFFT::Impl::ConvertedViewType<InViewType,
+                                                    ComplexType>::type;
+    using ManageableComplexInViewType =
+        typename KokkosFFT::Impl::manageable_view_type<ComplexInViewType>::type;
+    using LayoutType = typename ManageableComplexInViewType::array_layout;
+    auto extents     = KokkosFFT::Impl::extract_extents(in);
+    ManageableComplexInViewType cin(
+        "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
+    Kokkos::deep_copy(cin, in);
+    KokkosFFT::Plan plan(exec_space, cin, out, KokkosFFT::Direction::forward,
+                         axes, s);
+    plan.execute_impl(cin, out, norm);
+  } else {
+    KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
+                         axes, s);
+    plan.execute_impl(in, out, norm);
+  }
 }
 
 /// \brief Two dimensional FFT in backward direction
@@ -492,12 +549,36 @@ void fftn(
       InViewType::rank() >= DIM,
       "fftn: View rank must be larger than or equal to the Rank of FFT axes");
 
+  using in_value_type  = typename InViewType::non_const_value_type;
+  using out_value_type = typename OutViewType::non_const_value_type;
+
+  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
+                "fftn: OutViewType must be complex");
+
   Kokkos::Profiling::ScopedRegion region("KokkosFFT::fftn");
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axes),
                      "axes are invalid for in/out views");
-  KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward, axes,
-                       s);
-  plan.execute_impl(in, out, norm);
+  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
+    // Convert to complex type
+    using ComplexType = Kokkos::complex<in_value_type>;
+    using ComplexInViewType =
+        typename KokkosFFT::Impl::ConvertedViewType<InViewType,
+                                                    ComplexType>::type;
+    using ManageableComplexInViewType =
+        typename KokkosFFT::Impl::manageable_view_type<ComplexInViewType>::type;
+    using LayoutType = typename ManageableComplexInViewType::array_layout;
+    auto extents     = KokkosFFT::Impl::extract_extents(in);
+    ManageableComplexInViewType cin(
+        "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
+    Kokkos::deep_copy(cin, in);
+    KokkosFFT::Plan plan(exec_space, cin, out, KokkosFFT::Direction::forward,
+                         axes, s);
+    plan.execute_impl(cin, out, norm);
+  } else {
+    KokkosFFT::Plan plan(exec_space, in, out, KokkosFFT::Direction::forward,
+                         axes, s);
+    plan.execute_impl(in, out, norm);
+  }
 }
 
 /// \brief Inverse of fftn

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -307,7 +307,7 @@ void test_fft1_1dfft_1dview() {
   // Analytical tests with real signal
   const int len_sig = 6;
   RealView1DType signal("signal", len_sig);
-  ComplexView1DType signal_out("signal", len_sig),
+  ComplexView1DType signal_out("signal_out", len_sig),
       ref_signal("ref_signal", len_sig);
 
   execution_space exec;
@@ -342,8 +342,10 @@ void test_fft1_1dfft_1dview() {
   for (std::size_t i = 0; i < ref_signal_val.size(); i++) {
     h_ref_signal(i) = ref_signal_val.at(i);
   }
+
   Kokkos::deep_copy(signal, h_signal);
   Kokkos::deep_copy(ref_signal, h_ref_signal);
+
   KokkosFFT::fft(exec, signal, signal_out);
   EXPECT_TRUE(allclose(exec, signal_out, ref_signal, 1.e-5, 1.e-6));
   exec.fence();
@@ -399,7 +401,7 @@ void test_fft1_1dhfft_1dview() {
   // Analytical tests with real signal
   const int len_sig = 6;
   RealView1DType signal("signal", len_sig / 2 + 1),
-      signal_out("signal", len_sig), ref_signal("ref_signal", len_sig);
+      signal_out("signal_out", len_sig), ref_signal("ref_signal", len_sig);
 
   execution_space exec;
   const Kokkos::complex<T> z(1.0, 1.0);

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -295,13 +295,20 @@ void test_fft1_identity_reuse_plan(T atol = 1.0e-12) {
 
 template <typename T, typename LayoutType>
 void test_fft1_1dfft_1dview() {
-  const int len = 30;
+  const int len        = 30;
+  using RealView1DType = Kokkos::View<T*, LayoutType, execution_space>;
   using ComplexView1DType =
       Kokkos::View<Kokkos::complex<T>*, LayoutType, execution_space>;
 
   ComplexView1DType x("x", len), out("out", len), ref("ref", len);
   ComplexView1DType out_b("out_b", len), out_o("out_o", len),
       out_f("out_f", len);
+
+  // Analytical tests with real signal
+  const int len_sig = 6;
+  RealView1DType signal("signal", len_sig);
+  ComplexView1DType signal_out("signal", len_sig),
+      ref_signal("ref_signal", len_sig);
 
   execution_space exec;
   const Kokkos::complex<T> z(1.0, 1.0);
@@ -322,6 +329,23 @@ void test_fft1_1dfft_1dview() {
   EXPECT_TRUE(allclose(exec, out_b, ref, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(exec, out_o, ref, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(exec, out_f, ref, 1.e-5, 1.e-6));
+  exec.fence();
+
+  // For analytical tests
+  auto h_signal                 = Kokkos::create_mirror_view(signal);
+  auto h_ref_signal             = Kokkos::create_mirror_view(ref_signal);
+  std::vector<T> signal_val     = {1.0, 2.0, 3.0, 4.0, 3.0, 2.0};
+  std::vector<T> ref_signal_val = {15.0, -4.0, 0.0, -1.0, 0.0, -4.0};
+  for (std::size_t i = 0; i < signal_val.size(); i++) {
+    h_signal(i) = signal_val.at(i);
+  }
+  for (std::size_t i = 0; i < ref_signal_val.size(); i++) {
+    h_ref_signal(i) = ref_signal_val.at(i);
+  }
+  Kokkos::deep_copy(signal, h_signal);
+  Kokkos::deep_copy(ref_signal, h_ref_signal);
+  KokkosFFT::fft(exec, signal, signal_out);
+  EXPECT_TRUE(allclose(exec, signal_out, ref_signal, 1.e-5, 1.e-6));
   exec.fence();
 }
 
@@ -372,14 +396,21 @@ void test_fft1_1dhfft_1dview() {
   RealView1DType out("out", len);
   RealView1DType out_b("out_b", len), out_o("out_o", len), out_f("out_f", len);
 
+  // Analytical tests with real signal
+  const int len_sig = 6;
+  RealView1DType signal("signal", len_sig / 2 + 1),
+      signal_out("signal", len_sig), ref_signal("ref_signal", len_sig);
+
   execution_space exec;
   const Kokkos::complex<T> z(1.0, 1.0);
   Kokkos::Random_XorShift64_Pool<execution_space> random_pool(12345);
   Kokkos::fill_random(exec, x_herm, random_pool, z);
   exec.fence();
 
-  auto h_x      = Kokkos::create_mirror_view(x);
-  auto h_x_herm = Kokkos::create_mirror_view(x_herm);
+  auto h_x          = Kokkos::create_mirror_view(x);
+  auto h_x_herm     = Kokkos::create_mirror_view(x_herm);
+  auto h_signal     = Kokkos::create_mirror_view(signal);
+  auto h_ref_signal = Kokkos::create_mirror_view(ref_signal);
   Kokkos::deep_copy(h_x_herm, x_herm);
 
   auto last      = h_x_herm.extent(0) - 1;
@@ -395,9 +426,21 @@ void test_fft1_1dhfft_1dview() {
     h_x(len - i) = Kokkos::conj(h_x_herm(i));
   }
 
+  // For analytical tests
+  std::vector<T> signal_val     = {1.0, 2.0, 3.0, 4.0};
+  std::vector<T> ref_signal_val = {15.0, -4.0, 0.0, -1.0, 0.0, -4.0};
+  for (std::size_t i = 0; i < signal_val.size(); i++) {
+    h_signal(i) = signal_val.at(i);
+  }
+  for (std::size_t i = 0; i < ref_signal_val.size(); i++) {
+    h_ref_signal(i) = ref_signal_val.at(i);
+  }
+
   Kokkos::deep_copy(x_herm, h_x_herm);
   Kokkos::deep_copy(x_herm_ref, h_x_herm);
   Kokkos::deep_copy(x, h_x);
+  Kokkos::deep_copy(signal, h_signal);
+  Kokkos::deep_copy(ref_signal, h_ref_signal);
 
   KokkosFFT::fft(exec, x, ref);
 
@@ -421,6 +464,11 @@ void test_fft1_1dhfft_1dview() {
   EXPECT_TRUE(allclose(exec, out_b, out, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(exec, out_o, out, 1.e-5, 1.e-6));
   EXPECT_TRUE(allclose(exec, out_f, out, 1.e-5, 1.e-6));
+  exec.fence();
+
+  // Analytical tests
+  KokkosFFT::hfft(exec, signal, signal_out);
+  EXPECT_TRUE(allclose(exec, signal_out, ref_signal, 1.e-5, 1.e-6));
   exec.fence();
 }
 


### PR DESCRIPTION
This PR aims at making `fft` and `hfft` work on real input.

- [x] If the input data are real, allocate complex data internally and copy the input data to the complex buffer.
- [x] Add analytical tests for real input data 