### PR TITLE
Extend View to View matcher up to 8D

### DIFF
--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -282,8 +282,7 @@ struct FindErrors {
     Kokkos::parallel_for(
         "FindErrors", get_policy(space, a),
         FindErrorsInternal<std::make_index_sequence<m_rank_truncated>>(
-            a, b, nb_errors, m_a_error_pub, m_b_error_pub, m_loc_error_pub,
-            rtol, atol));
+            a, b, m_a_error_pub, m_b_error_pub, m_loc_error_pub, rtol, atol));
   }
 
   template <typename IndexSequence>
@@ -320,7 +319,7 @@ struct FindErrors {
     ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
     ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
     FindErrorsInternal(const AViewType& a, const BViewType& b,
-                       const iType nb_errors, const AErrorViewType& a_error,
+                       const AErrorViewType& a_error,
                        const BErrorViewType& b_error,
                        const CountViewType& loc_error, double rtol = 1.e-5,
                        double atol = 1.e-8)

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -192,26 +192,28 @@ struct ViewErrors {
   auto error() const { return m_error; }
 };
 
+/// \brief Finds errors in Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
 template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
           KokkosView BViewType, KokkosLayout Layout, std::size_t Rank,
           typename iType>
-struct FindErrors;
-
-/// \brief Finds errors in 1D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 1D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
+struct FindErrors {
+ private:
+  // Since MDRangePolicy is not available for 7D and 8D views, we need to
+  // handle them separately. We can use a 6D MDRangePolicy and iterate over
+  // the last two dimensions in the operator() function.
+  static constexpr std::size_t m_rank_truncated =
+      std::min(AViewType::rank(), std::size_t(6));
   using a_value_type = typename AViewType::non_const_value_type;
   using b_value_type = typename BViewType::non_const_value_type;
 
@@ -220,930 +222,244 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
   using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
   using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
 
-  AViewType m_a;
-  BViewType m_b;
+  AErrorViewType m_a_error_pub;
+  BErrorViewType m_b_error_pub;
+  CountViewType m_loc_error_pub;
 
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  using policy_type =
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<iType>>;
-
-  /// \brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  /// \param a [in] The first Kokkos view containing data.
-  /// \param b [in] The second Kokkos view containing data to compare against.
-  /// \param nb_errors [in] The maximum number of errors expected.
-  /// \param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  /// \param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  /// \param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 2),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-1D", policy_type(space, 0, m_a.extent(0)),
-                         *this);
-  }
-
-  ///\brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  ///\param i0 [in] The index of the element in the views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0) const {
-    auto tmp_a     = m_a(i0);
-    auto tmp_b     = m_b(i0);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count     = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)      = tmp_a;
-      m_b_error(count)      = tmp_b;
-      m_loc_error(count, 0) = i0;
-      m_loc_error(count, 1) = i0;
-    }
-  }
-
-  ///\brief Retrieves the error information.
-  ///
-  ///\return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 2D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 2D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<2, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 3),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-2D",
-                         policy_type(space, {0, 0}, {a.extent(0), a.extent(1)}),
-                         *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1) const {
-    auto tmp_a     = m_a(i0, i1);
-    auto tmp_b     = m_b(i0, i1);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count     = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)      = tmp_a;
-      m_b_error(count)      = tmp_b;
-      m_loc_error(count, 0) = i0 + i1 * m_a.extent(0);
-      m_loc_error(count, 1) = i0;
-      m_loc_error(count, 2) = i1;
-    }
-  }
-
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 3D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 3D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 3, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<3, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 4),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for(
-        "FindErrors-3D",
-        policy_type(space, {0, 0, 0}, {a.extent(0), a.extent(1), a.extent(2)}),
-        *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2) const {
-    auto tmp_a     = m_a(i0, i1, i2);
-    auto tmp_b     = m_b(i0, i1, i2);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)  = tmp_a;
-      m_b_error(count)  = tmp_b;
-      m_loc_error(count, 0) =
-          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1);
-      m_loc_error(count, 1) = i0;
-      m_loc_error(count, 2) = i1;
-      m_loc_error(count, 3) = i2;
-    }
-  }
-
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 4D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 4D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 4, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<4, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 5),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for(
-        "FindErrors-4D",
-        policy_type(space, {0, 0, 0, 0},
-                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3)}),
-        *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  /// \param i3 [in] The index along the fourth dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2,
-                  const iType i3) const {
-    auto tmp_a     = m_a(i0, i1, i2, i3);
-    auto tmp_b     = m_b(i0, i1, i2, i3);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)  = tmp_a;
-      m_b_error(count)  = tmp_b;
-      m_loc_error(count, 0) =
-          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
-          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2);
-      m_loc_error(count, 1) = i0;
-      m_loc_error(count, 2) = i1;
-      m_loc_error(count, 3) = i2;
-      m_loc_error(count, 4) = i3;
-    }
-  }
-
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 5D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 5D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 5, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<5, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 6),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-5D",
-                         policy_type(space, {0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4)}),
-                         *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  /// \param i3 [in] The index along the fourth dimension of the element in the
-  /// views.
-  /// \param i4 [in] The index along the fifth dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2,
-                  const iType i3, const iType i4) const {
-    auto tmp_a     = m_a(i0, i1, i2, i3, i4);
-    auto tmp_b     = m_b(i0, i1, i2, i3, i4);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)  = tmp_a;
-      m_b_error(count)  = tmp_b;
-      m_loc_error(count, 0) =
-          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
-          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
-          i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3);
-      m_loc_error(count, 1) = i0;
-      m_loc_error(count, 2) = i1;
-      m_loc_error(count, 3) = i2;
-      m_loc_error(count, 4) = i3;
-      m_loc_error(count, 5) = i4;
-    }
-  }
-
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 6D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 6D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 6, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 7),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-6D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4), a.extent(5)}),
-                         *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  /// \param i3 [in] The index along the fourth dimension of the element in the
-  /// views.
-  /// \param i4 [in] The index along the fifth dimension of the element in the
-  /// views.
-  /// \param i5 [in] The index along the sixth dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2,
-                  const iType i3, const iType i4, const iType i5) const {
-    auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5);
-    auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5);
-    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-    if (not_close) {
-      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
-      m_a_error(count)  = tmp_a;
-      m_b_error(count)  = tmp_b;
-      m_loc_error(count, 0) =
-          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
-          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
-          i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) +
-          i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
-              m_a.extent(4);
-      m_loc_error(count, 1) = i0;
-      m_loc_error(count, 2) = i1;
-      m_loc_error(count, 3) = i2;
-      m_loc_error(count, 4) = i3;
-      m_loc_error(count, 5) = i4;
-      m_loc_error(count, 6) = i5;
-    }
-  }
-
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 7D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 7D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 7, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
-  ///\brief Constructs a FindErrors object and performs the error detection.
-  /// This constructor initializes the output error views and launches a
-  /// parallel kernel to scan through the input view elements. For each element,
-  /// if the difference between the two views exceeds the specified tolerance,
-  /// the corresponding error values and their index are recorded.
-  ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
-  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
-             double rtol = 1.e-5, double atol = 1.e-8,
-             const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 8),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-7D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4), a.extent(5)}),
-                         *this);
-  }
-
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  /// \param i3 [in] The index along the fourth dimension of the element in the
-  /// views.
-  /// \param i4 [in] The index along the fifth dimension of the element in the
-  /// views.
-  /// \param i5 [in] The index along the sixth dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2,
-                  const iType i3, const iType i4, const iType i5) const {
-    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
-      auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6);
-      auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6);
-      bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
-      if (not_close) {
-        std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
-        m_a_error(count)  = tmp_a;
-        m_b_error(count)  = tmp_b;
-        m_loc_error(count, 0) =
-            i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
-            i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
-            i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) +
-            i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
-                m_a.extent(4) +
-            i6 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
-                m_a.extent(4) * m_a.extent(5);
-        m_loc_error(count, 1) = i0;
-        m_loc_error(count, 2) = i1;
-        m_loc_error(count, 3) = i2;
-        m_loc_error(count, 4) = i3;
-        m_loc_error(count, 5) = i4;
-        m_loc_error(count, 6) = i5;
-        m_loc_error(count, 7) = i6;
+  /// \brief Retrieves the policy for the parallel execution.
+  /// If the view is 1D, a Kokkos::RangePolicy is used. For higher dimensions up
+  /// to 6D, a Kokkos::MDRangePolicy is used. For 7D and 8D views, we use 6D
+  /// MDRangePolicy
+  /// \param[in] space The Kokkos execution space used to launch the parallel
+  /// reduction.
+  /// \param[in] a The Kokkos view to be used for determining the policy.
+  auto get_policy(const ExecutionSpace space, const AViewType a) const {
+    if constexpr (AViewType::rank() == 1) {
+      using range_policy_type =
+          Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<iType>>;
+      return range_policy_type(space, 0, a.extent(0));
+    } else {
+      static const Kokkos::Iterate outer_iteration_pattern =
+          Kokkos::Impl::layout_iterate_type_selector<
+              Layout>::outer_iteration_pattern;
+      static const Kokkos::Iterate inner_iteration_pattern =
+          Kokkos::Impl::layout_iterate_type_selector<
+              Layout>::inner_iteration_pattern;
+      using iterate_type =
+          Kokkos::Rank<m_rank_truncated, outer_iteration_pattern,
+                       inner_iteration_pattern>;
+      using mdrange_policy_type =
+          Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                Kokkos::IndexType<iType>>;
+      Kokkos::Array<std::size_t, m_rank_truncated> begins = {};
+      Kokkos::Array<std::size_t, m_rank_truncated> ends   = {};
+      for (std::size_t i = 0; i < m_rank_truncated; ++i) {
+        ends[i] = a.extent(i);
       }
+      return mdrange_policy_type(space, begins, ends);
     }
   }
 
-  /// \brief Retrieves the error information.
-  ///
-  /// \return A tuple containing the error view of the first input, the error
-  /// view of the second input, and the error locations.
-  auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
-  }
-};
-
-/// \brief Finds errors in 8D Kokkos views by comparing two views element-wise.
-/// This structure compares corresponding elements from two 8D Kokkos views and
-/// records errors when the difference exceeds a combined tolerance (absolute
-/// and relative). The error values from the first and second views along with
-/// their index information are stored in separate Kokkos views.
-///
-/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
-/// executed.
-/// \tparam AViewType The type of the first Kokkos view.
-/// \tparam BViewType The type of the second Kokkos view.
-/// \tparam Layout The memory layout type of the Kokkos views.
-/// \tparam iType The integer type used for indexing the view elements.
-template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
-          KokkosView BViewType, KokkosLayout Layout, typename iType>
-struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 8, iType> {
-  using a_value_type = typename AViewType::non_const_value_type;
-  using b_value_type = typename BViewType::non_const_value_type;
-
-  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
-  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
-  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
-  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
-
-  AViewType m_a;
-  BViewType m_b;
-
-  AErrorViewType m_a_error;
-  BErrorViewType m_b_error;
-  CountViewType m_loc_error;
-  CountType m_count;
-
-  double m_rtol;
-  double m_atol;
-
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::outer_iteration_pattern;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Impl::layout_iterate_type_selector<
-          Layout>::inner_iteration_pattern;
-  using iterate_type =
-      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
-  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                            Kokkos::IndexType<iType>>;
-
+ public:
   ///\brief Constructs a FindErrors object and performs the error detection.
   /// This constructor initializes the output error views and launches a
   /// parallel kernel to scan through the input view elements. For each element,
   /// if the difference between the two views exceeds the specified tolerance,
   /// the corresponding error values and their index are recorded.
   ///
-  ///\param a [in] The first Kokkos view containing data.
-  ///\param b [in] The second Kokkos view containing data to compare against.
-  ///\param nb_errors [in] The maximum number of errors expected.
-  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
-  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
-  ///\param space [in] The execution space used to launch the parallel kernel.
+  ///\param[in] a The first Kokkos view containing data.
+  ///\param[in] b The second Kokkos view containing data to compare against.
+  ///\param[in] nb_errors The maximum number of errors expected.
+  ///\param[in] rtol Relative tolerance for the comparison (default 1.e-5).
+  ///\param[in] atol Absolute tolerance for the comparison (default 1.e-8).
+  ///\param[in] space The execution space used to launch the parallel kernel.
   FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
              double rtol = 1.e-5, double atol = 1.e-8,
              const ExecutionSpace space = ExecutionSpace())
-      : m_a(a),
-        m_b(b),
-        m_a_error("a_error", nb_errors),
-        m_b_error("b_error", nb_errors),
-        m_loc_error("loc_error", nb_errors, 9),
-        m_count("count"),
-        m_rtol(rtol),
-        m_atol(atol) {
-    Kokkos::parallel_for("FindErrors-8D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4), a.extent(5)}),
-                         *this);
+      : m_a_error_pub("a_error", nb_errors),
+        m_b_error_pub("b_error", nb_errors),
+        m_loc_error_pub("loc_error", nb_errors, AViewType::rank() + 1) {
+    Kokkos::parallel_for(
+        "FindErrors", get_policy(space, a),
+        FindErrorsInternal<std::make_index_sequence<m_rank_truncated>>(
+            a, b, nb_errors, m_a_error_pub, m_b_error_pub, m_loc_error_pub,
+            rtol, atol));
   }
 
-  /// \brief Executes the element-wise comparison for the given index.
-  /// This operator is invoked in parallel by Kokkos. For each index, it
-  /// compares the corresponding elements from the two views. If the absolute
-  /// difference exceeds the tolerance, it stores the error values and their
-  /// index.
-  ///
-  /// \param i0 [in] The index along the first dimension of the element in the
-  /// views.
-  /// \param i1 [in] The index along the second dimension of the element in the
-  /// views.
-  /// \param i2 [in] The index along the third dimension of the element in the
-  /// views.
-  /// \param i3 [in] The index along the fourth dimension of the element in the
-  /// views.
-  /// \param i4 [in] The index along the fifth dimension of the element in the
-  /// views.
-  /// \param i5 [in] The index along the sixth dimension of the element in the
-  /// views.
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const iType i0, const iType i1, const iType i2,
-                  const iType i3, const iType i4, const iType i5) const {
-    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
-      for (iType i7 = 0; i7 < iType(m_a.extent(7)); i7++) {
-        auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6, i7);
-        auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6, i7);
+  template <typename IndexSequence>
+  struct FindErrorsInternal;
+
+  template <std::size_t... Idx>
+  struct FindErrorsInternal<std::index_sequence<Idx...>> {
+    template <std::size_t I>
+    using IndicesType = iType;
+
+    AViewType m_a;
+    BViewType m_b;
+
+    AErrorViewType m_a_error;
+    BErrorViewType m_b_error;
+    CountViewType m_loc_error;
+
+    //! The error counter
+    CountType m_count;
+
+    double m_rtol;
+    double m_atol;
+
+    ///\brief Constructs a FindErrorsInternal object and performs the error
+    /// detection.
+    /// This constructor initializes the output error views and launches a
+    /// parallel kernel to scan through the input view elements. For each
+    /// element, if the difference between the two views exceeds the specified
+    /// tolerance, the corresponding error values and their index are recorded.
+    ///
+    ///\param a [in] The first Kokkos view containing data.
+    ///\param b [in] The second Kokkos view containing data to compare against.
+    ///\param nb_errors [in] The maximum number of errors expected.
+    ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+    ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+    FindErrorsInternal(const AViewType& a, const BViewType& b,
+                       const iType nb_errors, const AErrorViewType& a_error,
+                       const BErrorViewType& b_error,
+                       const CountViewType& loc_error, double rtol = 1.e-5,
+                       double atol = 1.e-8)
+        : m_a(a),
+          m_b(b),
+          m_a_error(a_error),
+          m_b_error(b_error),
+          m_loc_error(loc_error),
+          m_count("count"),
+          m_rtol(rtol),
+          m_atol(atol) {}
+
+    /// \brief Executes the element-wise comparison for the given index.
+    /// This operator is invoked in parallel by Kokkos. For each index, it
+    /// compares the corresponding elements from the two views. If the absolute
+    /// difference exceeds the tolerance, it stores the error values and their
+    /// index.
+    ///
+    /// \param[in] indices The indices of the element in the views up to 6D.
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const IndicesType<Idx>... indices) const {
+      if constexpr (AViewType::rank() <= 6) {
+        auto tmp_a     = m_a(indices...);
+        auto tmp_b     = m_b(indices...);
         bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
         if (not_close) {
           std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
           m_a_error(count)  = tmp_a;
           m_b_error(count)  = tmp_b;
-          m_loc_error(count, 0) =
-              i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
-              i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
-              i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
-                  m_a.extent(3) +
-              i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
-                  m_a.extent(3) * m_a.extent(4) +
-              i6 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
-                  m_a.extent(3) * m_a.extent(4) * m_a.extent(5) +
-              i7 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
-                  m_a.extent(3) * m_a.extent(4) * m_a.extent(5) * m_a.extent(6);
-          m_loc_error(count, 1) = i0;
-          m_loc_error(count, 2) = i1;
-          m_loc_error(count, 3) = i2;
-          m_loc_error(count, 4) = i3;
-          m_loc_error(count, 5) = i4;
-          m_loc_error(count, 6) = i5;
-          m_loc_error(count, 7) = i6;
-          m_loc_error(count, 8) = i7;
+          iType error_indices[AViewType::rank()] = {indices...};
+          m_loc_error(count, 0) = get_global_idx(error_indices);
+          for (std::size_t i = 0; i < AViewType::rank(); i++) {
+            m_loc_error(count, i + 1) = error_indices[i];
+          }
+        }
+      } else if constexpr (AViewType::rank() == 7) {
+        for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+          auto tmp_a     = m_a(indices..., i6);
+          auto tmp_b     = m_b(indices..., i6);
+          bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+          if (not_close) {
+            std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+            m_a_error(count)  = tmp_a;
+            m_b_error(count)  = tmp_b;
+            iType error_indices[AViewType::rank()] = {indices..., i6};
+            m_loc_error(count, 0) = get_global_idx(error_indices);
+            for (std::size_t i = 0; i < AViewType::rank(); i++) {
+              m_loc_error(count, i + 1) = error_indices[i];
+            }
+          }
+        }
+      } else if constexpr (AViewType::rank() == 8) {
+        for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+          for (iType i7 = 0; i7 < iType(m_a.extent(7)); i7++) {
+            auto tmp_a     = m_a(indices..., i6, i7);
+            auto tmp_b     = m_b(indices..., i6, i7);
+            bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+            if (not_close) {
+              std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+              m_a_error(count)  = tmp_a;
+              m_b_error(count)  = tmp_b;
+              iType error_indices[AViewType::rank()] = {indices..., i6, i7};
+              m_loc_error(count, 0) = get_global_idx(error_indices);
+              for (std::size_t i = 0; i < AViewType::rank(); i++) {
+                m_loc_error(count, i + 1) = error_indices[i];
+              }
+            }
+          }
         }
       }
     }
-  }
+
+    KOKKOS_INLINE_FUNCTION
+    std::size_t get_global_idx(const iType error_indices[]) const {
+      std::size_t global_idx = error_indices[0];
+      if constexpr (AViewType::rank() == 1) {
+        return global_idx;
+      } else if constexpr (AViewType::rank() == 2) {
+        return global_idx + error_indices[1] * m_a.extent(0);
+      } else if constexpr (AViewType::rank() == 3) {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1);
+      } else if constexpr (AViewType::rank() == 4) {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1) +
+               error_indices[3] * m_a.extent(0) * m_a.extent(1) * m_a.extent(2);
+      } else if constexpr (AViewType::rank() == 5) {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1) +
+               error_indices[3] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) +
+               error_indices[4] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3);
+      } else if constexpr (AViewType::rank() == 6) {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1) +
+               error_indices[3] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) +
+               error_indices[4] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) +
+               error_indices[5] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4);
+      } else if constexpr (AViewType::rank() == 7) {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1) +
+               error_indices[3] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) +
+               error_indices[4] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) +
+               error_indices[5] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4) +
+               error_indices[6] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4) *
+                   m_a.extent(5);
+      } else {
+        return global_idx + error_indices[1] * m_a.extent(0) +
+               error_indices[2] * m_a.extent(0) * m_a.extent(1) +
+               error_indices[3] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) +
+               error_indices[4] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) +
+               error_indices[5] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4) +
+               error_indices[6] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4) *
+                   m_a.extent(5) +
+               error_indices[7] * m_a.extent(0) * m_a.extent(1) *
+                   m_a.extent(2) * m_a.extent(3) * m_a.extent(4) *
+                   m_a.extent(5) * m_a.extent(6);
+      }
+    }
+  };
 
   /// \brief Retrieves the error information.
   ///
   /// \return A tuple containing the error view of the first input, the error
   /// view of the second input, and the error locations.
   auto error_info() const {
-    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+    return std::make_tuple(m_a_error_pub, m_b_error_pub, m_loc_error_pub);
   }
 };
 

--- a/testing/src/KokkosFFT_CountErrors.hpp
+++ b/testing/src/KokkosFFT_CountErrors.hpp
@@ -60,7 +60,8 @@ KOKKOS_INLINE_FUNCTION bool are_not_close(ScalarA a, ScalarB b, ScalarTol rtol,
 /// tolerance defined by an absolute tolerance and a relative tolerance.
 ///
 /// \tparam ExecutionSpace The Kokkos execution space to run the
-/// parallel_reduce. \tparam AViewType The type of the first Kokkos view.
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
 /// \tparam BViewType The type of the second Kokkos view.
 /// \tparam Layout The layout type of the Kokkos views.
 /// \tparam iType The integer type used for indexing the view elements.
@@ -122,7 +123,8 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 1, iType> {
 /// tolerance defined by an absolute tolerance and a relative tolerance.
 ///
 /// \tparam ExecutionSpace The Kokkos execution space to run the
-/// parallel_reduce. \tparam AViewType The type of the first Kokkos view.
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
 /// \tparam BViewType The type of the second Kokkos view.
 /// \tparam Layout The layout type of the Kokkos views.
 /// \tparam iType The integer type used for indexing the view elements.
@@ -181,6 +183,515 @@ struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
     auto tmp_b     = m_b(i0, i1);
     bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
     err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 3D Kokkos views.
+/// This structure performs an element-by-element comparison of two 3D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 3, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<3, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-3D",
+        policy_type(space, {0, 0, 0}, {a.extent(0), a.extent(1), a.extent(2)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  std::size_t& err) const {
+    auto tmp_a     = m_a(i0, i1, i2);
+    auto tmp_b     = m_b(i0, i1, i2);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 4D Kokkos views.
+/// This structure performs an element-by-element comparison of two 4D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 4, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<4, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-4D",
+        policy_type(space, {0, 0, 0, 0},
+                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  const iType& i3, std::size_t& err) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3);
+    auto tmp_b     = m_b(i0, i1, i2, i3);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 5D Kokkos views.
+/// This structure performs an element-by-element comparison of two 5D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 5, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<5, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce("ViewErrors-5D",
+                            policy_type(space, {0, 0, 0, 0, 0},
+                                        {a.extent(0), a.extent(1), a.extent(2),
+                                         a.extent(3), a.extent(4)}),
+                            *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  const iType& i3, const iType& i4, std::size_t& err) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3, i4);
+    auto tmp_b     = m_b(i0, i1, i2, i3, i4);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 6D Kokkos views.
+/// This structure performs an element-by-element comparison of two 6D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 6, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-6D",
+        policy_type(space, {0, 0, 0, 0, 0, 0},
+                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3),
+                     a.extent(4), a.extent(5)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  const iType& i3, const iType& i4, const iType& i5,
+                  std::size_t& err) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5);
+    auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    err += static_cast<std::size_t>(not_close);
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 7D Kokkos views.
+/// This structure performs an element-by-element comparison of two 7D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 7, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-7D",
+        policy_type(space, {0, 0, 0, 0, 0, 0},
+                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3),
+                     a.extent(4), a.extent(5)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  const iType& i3, const iType& i4, const iType& i5,
+                  std::size_t& err) const {
+    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+      auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6);
+      auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6);
+      bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+      err += static_cast<std::size_t>(not_close);
+    }
+  };
+
+  /// \brief Retrieves the computed error count.
+  ///
+  /// \return The total number of mismatches detected.
+  auto error() const { return m_error; }
+};
+
+/// \brief Computes the number of error mismatches between two 8D Kokkos views.
+/// This structure performs an element-by-element comparison of two 8D views. It
+/// counts the number of elements where the difference exceeds a specified
+/// tolerance defined by an absolute tolerance and a relative tolerance.
+///
+/// \tparam ExecutionSpace The Kokkos execution space to run the
+/// parallel_reduce.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct ViewErrors<ExecutionSpace, AViewType, BViewType, Layout, 8, iType> {
+  AViewType m_a;
+  BViewType m_b;
+
+  double m_rtol;
+  double m_atol;
+
+  std::size_t m_error = 0;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  /// \brief Constructs the error counter and performs the error computation.
+  ///
+  /// \param a [in] First Kokkos view containing data to compare.
+  /// \param b [in] Second Kokkos view containing data to compare against.
+  /// \param rtol [in] Relative tolerance for comparing the view elements
+  /// (default 1.e-5).
+  /// \param atol [in] Absolute tolerance for comparing the view elements
+  /// (default 1.e-8).
+  /// \param space [in] The Kokkos execution space used to launch the parallel
+  /// reduction.
+  ViewErrors(const AViewType& a, const BViewType& b, double rtol = 1.e-5,
+             double atol = 1.e-8, const ExecutionSpace space = ExecutionSpace())
+      : m_a(a), m_b(b), m_rtol(rtol), m_atol(atol) {
+    Kokkos::parallel_reduce(
+        "ViewErrors-8D",
+        policy_type(space, {0, 0, 0, 0, 0, 0},
+                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3),
+                     a.extent(4), a.extent(5)}),
+        *this, m_error);
+  }
+
+  /// \brief Operator called by Kokkos to perform the comparison of each
+  /// element.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  /// \param err [in,out] The error counter incremented if a mismatch is
+  /// detected.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType& i0, const iType& i1, const iType& i2,
+                  const iType& i3, const iType& i4, const iType& i5,
+                  std::size_t& err) const {
+    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+      for (iType i7 = 0; i7 < iType(m_a.extent(7)); i7++) {
+        auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6, i7);
+        auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6, i7);
+        bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+        err += static_cast<std::size_t>(not_close);
+      }
+    }
   };
 
   /// \brief Retrieves the computed error count.
@@ -390,6 +901,755 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
   }
 };
 
+/// \brief Finds errors in 3D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 3D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 3, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<3, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 4),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for(
+        "FindErrors-3D",
+        policy_type(space, {0, 0, 0}, {a.extent(0), a.extent(1), a.extent(2)}),
+        *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2) const {
+    auto tmp_a     = m_a(i0, i1, i2);
+    auto tmp_b     = m_b(i0, i1, i2);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    if (not_close) {
+      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+      m_a_error(count)  = tmp_a;
+      m_b_error(count)  = tmp_b;
+      m_loc_error(count, 0) =
+          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1);
+      m_loc_error(count, 1) = i0;
+      m_loc_error(count, 2) = i1;
+      m_loc_error(count, 3) = i2;
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 4D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 4D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 4, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<4, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 5),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for(
+        "FindErrors-4D",
+        policy_type(space, {0, 0, 0, 0},
+                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3)}),
+        *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2,
+                  const iType i3) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3);
+    auto tmp_b     = m_b(i0, i1, i2, i3);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    if (not_close) {
+      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+      m_a_error(count)  = tmp_a;
+      m_b_error(count)  = tmp_b;
+      m_loc_error(count, 0) =
+          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
+          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2);
+      m_loc_error(count, 1) = i0;
+      m_loc_error(count, 2) = i1;
+      m_loc_error(count, 3) = i2;
+      m_loc_error(count, 4) = i3;
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 5D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 5D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 5, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<5, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 6),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-5D",
+                         policy_type(space, {0, 0, 0, 0, 0},
+                                     {a.extent(0), a.extent(1), a.extent(2),
+                                      a.extent(3), a.extent(4)}),
+                         *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2,
+                  const iType i3, const iType i4) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3, i4);
+    auto tmp_b     = m_b(i0, i1, i2, i3, i4);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    if (not_close) {
+      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+      m_a_error(count)  = tmp_a;
+      m_b_error(count)  = tmp_b;
+      m_loc_error(count, 0) =
+          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
+          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
+          i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3);
+      m_loc_error(count, 1) = i0;
+      m_loc_error(count, 2) = i1;
+      m_loc_error(count, 3) = i2;
+      m_loc_error(count, 4) = i3;
+      m_loc_error(count, 5) = i4;
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 6D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 6D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 6, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 7),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-6D",
+                         policy_type(space, {0, 0, 0, 0, 0, 0},
+                                     {a.extent(0), a.extent(1), a.extent(2),
+                                      a.extent(3), a.extent(4), a.extent(5)}),
+                         *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2,
+                  const iType i3, const iType i4, const iType i5) const {
+    auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5);
+    auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5);
+    bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+    if (not_close) {
+      std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+      m_a_error(count)  = tmp_a;
+      m_b_error(count)  = tmp_b;
+      m_loc_error(count, 0) =
+          i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
+          i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
+          i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) +
+          i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
+              m_a.extent(4);
+      m_loc_error(count, 1) = i0;
+      m_loc_error(count, 2) = i1;
+      m_loc_error(count, 3) = i2;
+      m_loc_error(count, 4) = i3;
+      m_loc_error(count, 5) = i4;
+      m_loc_error(count, 6) = i5;
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 7D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 7D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 7, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 8),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-7D",
+                         policy_type(space, {0, 0, 0, 0, 0, 0},
+                                     {a.extent(0), a.extent(1), a.extent(2),
+                                      a.extent(3), a.extent(4), a.extent(5)}),
+                         *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2,
+                  const iType i3, const iType i4, const iType i5) const {
+    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+      auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6);
+      auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6);
+      bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+      if (not_close) {
+        std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+        m_a_error(count)  = tmp_a;
+        m_b_error(count)  = tmp_b;
+        m_loc_error(count, 0) =
+            i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
+            i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
+            i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) +
+            i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
+                m_a.extent(4) +
+            i6 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) * m_a.extent(3) *
+                m_a.extent(4) * m_a.extent(5);
+        m_loc_error(count, 1) = i0;
+        m_loc_error(count, 2) = i1;
+        m_loc_error(count, 3) = i2;
+        m_loc_error(count, 4) = i3;
+        m_loc_error(count, 5) = i4;
+        m_loc_error(count, 6) = i5;
+        m_loc_error(count, 7) = i6;
+      }
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
+/// \brief Finds errors in 8D Kokkos views by comparing two views element-wise.
+/// This structure compares corresponding elements from two 8D Kokkos views and
+/// records errors when the difference exceeds a combined tolerance (absolute
+/// and relative). The error values from the first and second views along with
+/// their index information are stored in separate Kokkos views.
+///
+/// \tparam ExecutionSpace The Kokkos execution space where the parallel_for is
+/// executed.
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+/// \tparam Layout The memory layout type of the Kokkos views.
+/// \tparam iType The integer type used for indexing the view elements.
+template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
+          KokkosView BViewType, KokkosLayout Layout, typename iType>
+struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 8, iType> {
+  using a_value_type = typename AViewType::non_const_value_type;
+  using b_value_type = typename BViewType::non_const_value_type;
+
+  using AErrorViewType = Kokkos::View<a_value_type*, ExecutionSpace>;
+  using BErrorViewType = Kokkos::View<b_value_type*, ExecutionSpace>;
+  using CountViewType  = Kokkos::View<std::size_t**, ExecutionSpace>;
+  using CountType      = Kokkos::View<std::size_t, ExecutionSpace>;
+
+  AViewType m_a;
+  BViewType m_b;
+
+  AErrorViewType m_a_error;
+  BErrorViewType m_b_error;
+  CountViewType m_loc_error;
+  CountType m_count;
+
+  double m_rtol;
+  double m_atol;
+
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
+  using iterate_type =
+      Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
+  using policy_type = Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                                            Kokkos::IndexType<iType>>;
+
+  ///\brief Constructs a FindErrors object and performs the error detection.
+  /// This constructor initializes the output error views and launches a
+  /// parallel kernel to scan through the input view elements. For each element,
+  /// if the difference between the two views exceeds the specified tolerance,
+  /// the corresponding error values and their index are recorded.
+  ///
+  ///\param a [in] The first Kokkos view containing data.
+  ///\param b [in] The second Kokkos view containing data to compare against.
+  ///\param nb_errors [in] The maximum number of errors expected.
+  ///\param rtol [in] Relative tolerance for the comparison (default 1.e-5).
+  ///\param atol [in] Absolute tolerance for the comparison (default 1.e-8).
+  ///\param space [in] The execution space used to launch the parallel kernel.
+  FindErrors(const AViewType& a, const BViewType& b, const iType nb_errors,
+             double rtol = 1.e-5, double atol = 1.e-8,
+             const ExecutionSpace space = ExecutionSpace())
+      : m_a(a),
+        m_b(b),
+        m_a_error("a_error", nb_errors),
+        m_b_error("b_error", nb_errors),
+        m_loc_error("loc_error", nb_errors, 9),
+        m_count("count"),
+        m_rtol(rtol),
+        m_atol(atol) {
+    Kokkos::parallel_for("FindErrors-8D",
+                         policy_type(space, {0, 0, 0, 0, 0, 0},
+                                     {a.extent(0), a.extent(1), a.extent(2),
+                                      a.extent(3), a.extent(4), a.extent(5)}),
+                         *this);
+  }
+
+  /// \brief Executes the element-wise comparison for the given index.
+  /// This operator is invoked in parallel by Kokkos. For each index, it
+  /// compares the corresponding elements from the two views. If the absolute
+  /// difference exceeds the tolerance, it stores the error values and their
+  /// index.
+  ///
+  /// \param i0 [in] The index along the first dimension of the element in the
+  /// views.
+  /// \param i1 [in] The index along the second dimension of the element in the
+  /// views.
+  /// \param i2 [in] The index along the third dimension of the element in the
+  /// views.
+  /// \param i3 [in] The index along the fourth dimension of the element in the
+  /// views.
+  /// \param i4 [in] The index along the fifth dimension of the element in the
+  /// views.
+  /// \param i5 [in] The index along the sixth dimension of the element in the
+  /// views.
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType i0, const iType i1, const iType i2,
+                  const iType i3, const iType i4, const iType i5) const {
+    for (iType i6 = 0; i6 < iType(m_a.extent(6)); i6++) {
+      for (iType i7 = 0; i7 < iType(m_a.extent(7)); i7++) {
+        auto tmp_a     = m_a(i0, i1, i2, i3, i4, i5, i6, i7);
+        auto tmp_b     = m_b(i0, i1, i2, i3, i4, i5, i6, i7);
+        bool not_close = are_not_close(tmp_a, tmp_b, m_rtol, m_atol);
+        if (not_close) {
+          std::size_t count = Kokkos::atomic_fetch_add(m_count.data(), 1);
+          m_a_error(count)  = tmp_a;
+          m_b_error(count)  = tmp_b;
+          m_loc_error(count, 0) =
+              i0 + i1 * m_a.extent(0) + i2 * m_a.extent(0) * m_a.extent(1) +
+              i3 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) +
+              i4 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
+                  m_a.extent(3) +
+              i5 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
+                  m_a.extent(3) * m_a.extent(4) +
+              i6 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
+                  m_a.extent(3) * m_a.extent(4) * m_a.extent(5) +
+              i7 * m_a.extent(0) * m_a.extent(1) * m_a.extent(2) *
+                  m_a.extent(3) * m_a.extent(4) * m_a.extent(5) * m_a.extent(6);
+          m_loc_error(count, 1) = i0;
+          m_loc_error(count, 2) = i1;
+          m_loc_error(count, 3) = i2;
+          m_loc_error(count, 4) = i3;
+          m_loc_error(count, 5) = i4;
+          m_loc_error(count, 6) = i5;
+          m_loc_error(count, 7) = i6;
+          m_loc_error(count, 8) = i7;
+        }
+      }
+    }
+  }
+
+  /// \brief Retrieves the error information.
+  ///
+  /// \return A tuple containing the error view of the first input, the error
+  /// view of the second input, and the error locations.
+  auto error_info() const {
+    return std::make_tuple(m_a_error, m_b_error, m_loc_error);
+  }
+};
+
 /// \brief Computes the number of mismatch errors between two Kokkos views.
 /// This function performs an element-wise comparison between two Kokkos views
 /// and counts the number of mismatches where the absolute difference exceeds
@@ -409,10 +1669,11 @@ struct FindErrors<ExecutionSpace, AViewType, BViewType, Layout, 2, iType> {
 template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
           KokkosView BViewType>
   requires KokkosViewAccessible<ExecutionSpace, AViewType> &&
-           KokkosViewAccessible<ExecutionSpace, BViewType>
-std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
-                         const BViewType& b, double rtol = 1.e-5,
-                         double atol = 1.e-8) {
+           KokkosViewAccessible<ExecutionSpace, BViewType> &&
+           (AViewType::rank() == BViewType::rank())
+std::size_t
+    count_errors(const ExecutionSpace& exec, const AViewType& a,
+                 const BViewType& b, double rtol = 1.e-5, double atol = 1.e-8) {
   // Figure out iteration order in case we need it
   Kokkos::Iterate iterate = get_iteration_order(a);
 
@@ -470,7 +1731,8 @@ std::size_t count_errors(const ExecutionSpace& exec, const AViewType& a,
 template <KokkosExecutionSpace ExecutionSpace, KokkosView AViewType,
           KokkosView BViewType>
   requires KokkosViewAccessible<ExecutionSpace, AViewType> &&
-           KokkosViewAccessible<ExecutionSpace, BViewType>
+           KokkosViewAccessible<ExecutionSpace, BViewType> &&
+           (AViewType::rank() == BViewType::rank())
 auto find_errors(const ExecutionSpace& exec, const AViewType& a,
                  const BViewType& b, const std::size_t nb_errors,
                  double rtol = 1.e-5, double atol = 1.e-8) {
@@ -482,25 +1744,25 @@ auto find_errors(const ExecutionSpace& exec, const AViewType& a,
     if (iterate == Kokkos::Iterate::Right) {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType,
                        Kokkos::LayoutRight, AViewType::rank(), int64_t>
-          view_errors(a, b, nb_errors, rtol, atol, exec);
-      return view_errors.error_info();
+          find_errors(a, b, nb_errors, rtol, atol, exec);
+      return find_errors.error_info();
     } else {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
                        AViewType::rank(), int64_t>
-          view_errors(a, b, nb_errors, rtol, atol, exec);
-      return view_errors.error_info();
+          find_errors(a, b, nb_errors, rtol, atol, exec);
+      return find_errors.error_info();
     }
   } else {
     if (iterate == Kokkos::Iterate::Right) {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType,
                        Kokkos::LayoutRight, AViewType::rank(), int>
-          view_errors(a, b, nb_errors, rtol, atol, exec);
-      return view_errors.error_info();
+          find_errors(a, b, nb_errors, rtol, atol, exec);
+      return find_errors.error_info();
     } else {
       Impl::FindErrors<ExecutionSpace, AViewType, BViewType, Kokkos::LayoutLeft,
                        AViewType::rank(), int>
-          view_errors(a, b, nb_errors, rtol, atol, exec);
-      return view_errors.error_info();
+          find_errors(a, b, nb_errors, rtol, atol, exec);
+      return find_errors.error_info();
     }
   }
 }

--- a/testing/unit_test/Test_Allclose.cpp
+++ b/testing/unit_test/Test_Allclose.cpp
@@ -36,18 +36,18 @@ void test_allclose_1D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+  h_b(0) += 2.0 * (h_b(0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1) = h_c(1) + 2.0 * atol;
+  h_c(1) += 2.0 * atol;
 
   // d includes both the relative and absolute errors -> error count 1
   h_d(0) = h_b(0);
   h_d(1) = h_c(1);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0) = h_e(0) + 0.1 * (h_e(0) * rtol);
-  h_e(1) = h_e(1) + 0.1 * atol;
+  h_e(0) += 0.1 * (h_e(0) * rtol);
+  h_e(1) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -79,18 +79,18 @@ void test_allclose_2D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0) = h_b(0, 0) + 2.0 * (h_b(0, 0) * rtol);
+  h_b(0, 0) += 2.0 * (h_b(0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0) = h_c(1, 0) + 2.0 * atol;
+  h_c(1, 0) += 2.0 * atol;
 
   // d includes both the relative and absolute errors -> error count 1
   h_d(0, 0) = h_b(0, 0);
   h_d(1, 0) = h_c(1, 0);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0) = h_e(0, 0) + 0.1 * (h_e(0, 0) * rtol);
-  h_e(1, 0) = h_e(1, 0) + 0.1 * atol;
+  h_e(0, 0) += 0.1 * (h_e(0, 0) * rtol);
+  h_e(1, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -122,19 +122,19 @@ void test_allclose_3D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0) = h_b(0, 0, 0) + 2.0 * (h_b(0, 0, 0) * rtol);
+  h_b(0, 0, 0) += 2.0 * (h_b(0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0) = h_c(1, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0) += 2.0 * atol;
 
   // d includes two values with bigger errors than acceptance -> error count 2
   h_d(0, 0, 0) = h_b(0, 0, 0);
   h_d(1, 0, 0) = h_c(1, 0, 0);
-  h_d(1, 0, 2) = h_b(1, 0, 2) + 3.0 * (h_b(1, 0, 2) * rtol);
+  h_d(1, 0, 2) += 3.0 * (h_b(1, 0, 2) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0) = h_e(0, 0, 0) + 0.1 * (h_e(0, 0, 0) * rtol);
-  h_e(1, 0, 0) = h_e(1, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0) += 0.1 * (h_e(0, 0, 0) * rtol);
+  h_e(1, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -166,20 +166,20 @@ void test_allclose_4D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0) = h_b(0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0) = h_c(1, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0) += 2.0 * atol;
 
   // d includes three values with bigger errors than acceptance -> error count 3
   h_d(0, 0, 0, 0) = h_b(0, 0, 0, 0);
   h_d(1, 0, 0, 0) = h_c(1, 0, 0, 0);
-  h_d(1, 0, 2, 0) = h_b(1, 0, 2, 0) + 3.0 * (h_b(1, 0, 2, 0) * rtol);
-  h_d(1, 0, 1, 3) = h_b(1, 0, 1, 3) + 2.5 * (h_b(1, 0, 1, 3) * rtol);
+  h_d(1, 0, 2, 0) += 3.0 * (h_b(1, 0, 2, 0) * rtol);
+  h_d(1, 0, 1, 3) += 2.5 * (h_b(1, 0, 1, 3) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0) = h_e(0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0) = h_e(1, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -212,21 +212,21 @@ void test_allclose_5D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes four values with bigger errors than acceptance -> error count 4
   h_d(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0) = h_b(1, 0, 2, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0) = h_b(1, 0, 1, 3, 0) + 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
-  h_d(1, 0, 2, 1, 4) = h_b(1, 0, 2, 1, 4) + 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
+  h_d(1, 0, 2, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0) += 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
+  h_d(1, 0, 2, 1, 4) += 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0) = h_e(0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -259,28 +259,22 @@ void test_allclose_6D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes five values with bigger errors than acceptance -> error count 5
   h_d(0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0) =
-      h_b(1, 0, 2, 1, 4, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1) =
-      h_b(0, 0, 2, 1, 3, 1) + 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
+  h_d(1, 0, 2, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1) += 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -313,30 +307,23 @@ void test_allclose_7D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes six values with bigger errors than acceptance -> error count 6
   h_d(0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0, 0) =
-      h_b(1, 0, 2, 1, 4, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1, 0) =
-      h_b(0, 0, 2, 1, 3, 1, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2) =
-      h_b(0, 0, 2, 1, 4, 1, 2) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
+  h_d(1, 0, 2, 0, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0) += 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2) += 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -371,32 +358,24 @@ void test_allclose_8D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes seven values with bigger errors than acceptance -> error count 7
   h_d(0, 0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0, 0, 0) =
-      h_b(1, 0, 2, 1, 4, 0, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1, 0, 0) =
-      h_b(0, 0, 2, 1, 3, 1, 0, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2, 0) =
-      h_b(0, 0, 2, 1, 4, 1, 2, 0) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2, 5) =
-      h_b(0, 0, 2, 1, 4, 1, 2, 5) + 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
+  h_d(1, 0, 2, 0, 0, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0, 0) += 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 0) += 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 5) += 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);

--- a/testing/unit_test/Test_Allclose.cpp
+++ b/testing/unit_test/Test_Allclose.cpp
@@ -102,6 +102,312 @@ void test_allclose_2D_analytical(double rtol, double atol) {
   EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
   EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
 }
+
+template <typename T>
+void test_allclose_3D_analytical(double rtol, double atol) {
+  using View3DType = Kokkos::View<T***>;
+  const int n0 = 3, n1 = 2, n2 = 4;
+  View3DType a("a", n0, n1, n2), b("b", n0, n1, n2), c("c", n0, n1, n2),
+      d("d", n0, n1, n2), e("e", n0, n1, n2);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0) = h_b(0, 0, 0) + 2.0 * (h_b(0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0) = h_c(1, 0, 0) + 2.0 * atol;
+
+  // d includes two values with bigger errors than acceptance -> error count 2
+  h_d(0, 0, 0) = h_b(0, 0, 0);
+  h_d(1, 0, 0) = h_c(1, 0, 0);
+  h_d(1, 0, 2) = h_b(1, 0, 2) + 3.0 * (h_b(1, 0, 2) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0) = h_e(0, 0, 0) + 0.1 * (h_e(0, 0, 0) * rtol);
+  h_e(1, 0, 0) = h_e(1, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_4D_analytical(double rtol, double atol) {
+  using View4DType = Kokkos::View<T****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5;
+  View4DType a("a", n0, n1, n2, n3), b("b", n0, n1, n2, n3),
+      c("c", n0, n1, n2, n3), d("d", n0, n1, n2, n3), e("e", n0, n1, n2, n3);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0) = h_b(0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0) = h_c(1, 0, 0, 0) + 2.0 * atol;
+
+  // d includes three values with bigger errors than acceptance -> error count 3
+  h_d(0, 0, 0, 0) = h_b(0, 0, 0, 0);
+  h_d(1, 0, 0, 0) = h_c(1, 0, 0, 0);
+  h_d(1, 0, 2, 0) = h_b(1, 0, 2, 0) + 3.0 * (h_b(1, 0, 2, 0) * rtol);
+  h_d(1, 0, 1, 3) = h_b(1, 0, 1, 3) + 2.5 * (h_b(1, 0, 1, 3) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0) = h_e(0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0) = h_e(1, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_5D_analytical(double rtol, double atol) {
+  using View5DType = Kokkos::View<T*****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6;
+  View5DType a("a", n0, n1, n2, n3, n4), b("b", n0, n1, n2, n3, n4),
+      c("c", n0, n1, n2, n3, n4), d("d", n0, n1, n2, n3, n4),
+      e("e", n0, n1, n2, n3, n4);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes four values with bigger errors than acceptance -> error count 4
+  h_d(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0) = h_b(1, 0, 2, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0) = h_b(1, 0, 1, 3, 0) + 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
+  h_d(1, 0, 2, 1, 4) = h_b(1, 0, 2, 1, 4) + 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0) = h_e(0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_6D_analytical(double rtol, double atol) {
+  using View6DType = Kokkos::View<T******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3;
+  View6DType a("a", n0, n1, n2, n3, n4, n5), b("b", n0, n1, n2, n3, n4, n5),
+      c("c", n0, n1, n2, n3, n4, n5), d("d", n0, n1, n2, n3, n4, n5),
+      e("e", n0, n1, n2, n3, n4, n5);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes five values with bigger errors than acceptance -> error count 5
+  h_d(0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0) =
+      h_b(1, 0, 2, 1, 4, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1) =
+      h_b(0, 0, 2, 1, 3, 1) + 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_7D_analytical(double rtol, double atol) {
+  using View7DType = Kokkos::View<T*******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3;
+  View7DType a("a", n0, n1, n2, n3, n4, n5, n6),
+      b("b", n0, n1, n2, n3, n4, n5, n6), c("c", n0, n1, n2, n3, n4, n5, n6),
+      d("d", n0, n1, n2, n3, n4, n5, n6), e("e", n0, n1, n2, n3, n4, n5, n6);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes six values with bigger errors than acceptance -> error count 6
+  h_d(0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0) =
+      h_b(1, 0, 2, 1, 4, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0) =
+      h_b(0, 0, 2, 1, 3, 1, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2) =
+      h_b(0, 0, 2, 1, 4, 1, 2) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
+
+template <typename T>
+void test_allclose_8D_analytical(double rtol, double atol) {
+  using View8DType = Kokkos::View<T********>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3, n7 = 7;
+  View8DType a("a", n0, n1, n2, n3, n4, n5, n6, n7),
+      b("b", n0, n1, n2, n3, n4, n5, n6, n7),
+      c("c", n0, n1, n2, n3, n4, n5, n6, n7),
+      d("d", n0, n1, n2, n3, n4, n5, n6, n7),
+      e("e", n0, n1, n2, n3, n4, n5, n6, n7);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes seven values with bigger errors than acceptance -> error count 7
+  h_d(0, 0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0, 0) =
+      h_b(1, 0, 2, 1, 4, 0, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0, 0) =
+      h_b(0, 0, 2, 1, 3, 1, 0, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 0) =
+      h_b(0, 0, 2, 1, 4, 1, 2, 0) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 5) =
+      h_b(0, 0, 2, 1, 4, 1, 2, 5) + 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_THAT(b, ::testing::Not(KokkosFFT::Testing::allclose(a)));
+  EXPECT_THAT(c, KokkosFFT::Testing::allclose(a, rtol));
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::allclose(a, rtol, atol)));
+  EXPECT_THAT(e, KokkosFFT::Testing::allclose(a, rtol, atol, 3));
+}
 }  // namespace
 
 TYPED_TEST_SUITE(TestAllClose, float_types);
@@ -114,4 +420,34 @@ TYPED_TEST(TestAllClose, View1D) {
 TYPED_TEST(TestAllClose, View2D) {
   using float_type = typename TestFixture::float_type;
   test_allclose_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_3D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_4D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_5D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_6D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_7D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestAllClose, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_allclose_8D_analytical<float_type>(this->m_rtol, this->m_atol);
 }

--- a/testing/unit_test/Test_CountErrors.cpp
+++ b/testing/unit_test/Test_CountErrors.cpp
@@ -119,6 +119,360 @@ void test_view_errors_2D_analytical(double rtol, double atol) {
                                                    rtol, atol),
             0);
 }
+
+template <typename T>
+void test_view_errors_3D_analytical(double rtol, double atol) {
+  using View3DType = Kokkos::View<T***>;
+  const int n0 = 3, n1 = 2, n2 = 4;
+  View3DType a("a", n0, n1, n2), b("b", n0, n1, n2), c("c", n0, n1, n2),
+      d("d", n0, n1, n2), e("e", n0, n1, n2);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0) = h_b(0, 0, 0) + 2.0 * (h_b(0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0) = h_c(1, 0, 0) + 2.0 * atol;
+
+  // d includes two values with bigger errors than acceptance -> error count 2
+  h_d(0, 0, 0) = h_b(0, 0, 0);
+  h_d(1, 0, 0) = h_c(1, 0, 0);
+  h_d(1, 0, 2) = h_b(1, 0, 2) + 3.0 * (h_b(1, 0, 2) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0) = h_e(0, 0, 0) + 0.1 * (h_e(0, 0, 0) * rtol);
+  h_e(1, 0, 0) = h_e(1, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            2);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_4D_analytical(double rtol, double atol) {
+  using View4DType = Kokkos::View<T****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5;
+  View4DType a("a", n0, n1, n2, n3), b("b", n0, n1, n2, n3),
+      c("c", n0, n1, n2, n3), d("d", n0, n1, n2, n3), e("e", n0, n1, n2, n3);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0) = h_b(0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0) = h_c(1, 0, 0, 0) + 2.0 * atol;
+
+  // d includes three values with bigger errors than acceptance -> error count 3
+  h_d(0, 0, 0, 0) = h_b(0, 0, 0, 0);
+  h_d(1, 0, 0, 0) = h_c(1, 0, 0, 0);
+  h_d(1, 0, 2, 0) = h_b(1, 0, 2, 0) + 3.0 * (h_b(1, 0, 2, 0) * rtol);
+  h_d(1, 0, 1, 3) = h_b(1, 0, 1, 3) + 2.5 * (h_b(1, 0, 1, 3) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0) = h_e(0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0) = h_e(1, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            3);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_5D_analytical(double rtol, double atol) {
+  using View5DType = Kokkos::View<T*****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6;
+  View5DType a("a", n0, n1, n2, n3, n4), b("b", n0, n1, n2, n3, n4),
+      c("c", n0, n1, n2, n3, n4), d("d", n0, n1, n2, n3, n4),
+      e("e", n0, n1, n2, n3, n4);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes four values with bigger errors than acceptance -> error count 4
+  h_d(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0) = h_b(1, 0, 2, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0) = h_b(1, 0, 1, 3, 0) + 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
+  h_d(1, 0, 2, 1, 4) = h_b(1, 0, 2, 1, 4) + 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0) = h_e(0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            4);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_6D_analytical(double rtol, double atol) {
+  using View6DType = Kokkos::View<T******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3;
+  View6DType a("a", n0, n1, n2, n3, n4, n5), b("b", n0, n1, n2, n3, n4, n5),
+      c("c", n0, n1, n2, n3, n4, n5), d("d", n0, n1, n2, n3, n4, n5),
+      e("e", n0, n1, n2, n3, n4, n5);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes five values with bigger errors than acceptance -> error count 5
+  h_d(0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0) =
+      h_b(1, 0, 2, 1, 4, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1) =
+      h_b(0, 0, 2, 1, 3, 1) + 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            5);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_7D_analytical(double rtol, double atol) {
+  using View7DType = Kokkos::View<T*******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3;
+  View7DType a("a", n0, n1, n2, n3, n4, n5, n6),
+      b("b", n0, n1, n2, n3, n4, n5, n6), c("c", n0, n1, n2, n3, n4, n5, n6),
+      d("d", n0, n1, n2, n3, n4, n5, n6), e("e", n0, n1, n2, n3, n4, n5, n6);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes six values with bigger errors than acceptance -> error count 6
+  h_d(0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0) =
+      h_b(1, 0, 2, 1, 4, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0) =
+      h_b(0, 0, 2, 1, 3, 1, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2) =
+      h_b(0, 0, 2, 1, 4, 1, 2) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            6);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
+
+template <typename T>
+void test_view_errors_8D_analytical(double rtol, double atol) {
+  using View8DType = Kokkos::View<T********>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3, n7 = 7;
+  View8DType a("a", n0, n1, n2, n3, n4, n5, n6, n7),
+      b("b", n0, n1, n2, n3, n4, n5, n6, n7),
+      c("c", n0, n1, n2, n3, n4, n5, n6, n7),
+      d("d", n0, n1, n2, n3, n4, n5, n6, n7),
+      e("e", n0, n1, n2, n3, n4, n5, n6, n7);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+  Kokkos::deep_copy(e, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
+
+  // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(0, 0, 0, 0, 0, 0, 0, 0) =
+      h_b(0, 0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+
+  // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
+  h_c(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+
+  // d includes seven values with bigger errors than acceptance -> error count 7
+  h_d(0, 0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0);
+  h_d(1, 0, 2, 0, 0, 0, 0, 0) =
+      h_b(1, 0, 2, 0, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0, 0) =
+      h_b(1, 0, 1, 3, 0, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0, 0) =
+      h_b(1, 0, 2, 1, 4, 0, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0, 0) =
+      h_b(0, 0, 2, 1, 3, 1, 0, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 0) =
+      h_b(0, 0, 2, 1, 4, 1, 2, 0) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 5) =
+      h_b(0, 0, 2, 1, 4, 1, 2, 5) + 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
+
+  // e includes small relative and absolute errors -> error count 0
+  h_e(0, 0, 0, 0, 0, 0, 0, 0) =
+      h_e(0, 0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+
+  Kokkos::deep_copy(b, h_b);
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), b, a,
+                                                   rtol, atol),
+            1);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), c, a,
+                                                   rtol, atol),
+            0);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), d, a,
+                                                   rtol, atol),
+            7);
+  EXPECT_EQ(KokkosFFT::Testing::Impl::count_errors(execution_space(), e, a,
+                                                   rtol, atol),
+            0);
+}
 }  // namespace
 
 TYPED_TEST_SUITE(TestCountErrors, float_types);
@@ -131,4 +485,34 @@ TYPED_TEST(TestCountErrors, View1D) {
 TYPED_TEST(TestCountErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_view_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_3D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_4D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_5D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_6D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_7D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestCountErrors, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_view_errors_8D_analytical<float_type>(this->m_rtol, this->m_atol);
 }

--- a/testing/unit_test/Test_CountErrors.cpp
+++ b/testing/unit_test/Test_CountErrors.cpp
@@ -37,18 +37,18 @@ void test_view_errors_1D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+  h_b(0) += 2.0 * (h_b(0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1) = h_c(1) + 2.0 * atol;
+  h_c(1) += 2.0 * atol;
 
   // d includes both the relative and absolute errors -> error count 1
   h_d(0) = h_b(0);
   h_d(1) = h_c(1);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0) = h_e(0) + 0.1 * (h_e(0) * rtol);
-  h_e(1) = h_e(1) + 0.1 * atol;
+  h_e(0) += 0.1 * (h_e(0) * rtol);
+  h_e(1) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -88,18 +88,18 @@ void test_view_errors_2D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0) = h_b(0, 0) + 2.0 * (h_b(0, 0) * rtol);
+  h_b(0, 0) += 2.0 * (h_b(0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0) = h_c(1, 0) + 2.0 * atol;
+  h_c(1, 0) += 2.0 * atol;
 
   // d includes both the relative and absolute errors -> error count 1
   h_d(0, 0) = h_b(0, 0);
   h_d(1, 0) = h_c(1, 0);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0) = h_e(0, 0) + 0.1 * (h_e(0, 0) * rtol);
-  h_e(1, 0) = h_e(1, 0) + 0.1 * atol;
+  h_e(0, 0) += 0.1 * (h_e(0, 0) * rtol);
+  h_e(1, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -139,19 +139,19 @@ void test_view_errors_3D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0) = h_b(0, 0, 0) + 2.0 * (h_b(0, 0, 0) * rtol);
+  h_b(0, 0, 0) += 2.0 * (h_b(0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0) = h_c(1, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0) += 2.0 * atol;
 
   // d includes two values with bigger errors than acceptance -> error count 2
   h_d(0, 0, 0) = h_b(0, 0, 0);
   h_d(1, 0, 0) = h_c(1, 0, 0);
-  h_d(1, 0, 2) = h_b(1, 0, 2) + 3.0 * (h_b(1, 0, 2) * rtol);
+  h_d(1, 0, 2) += 3.0 * (h_b(1, 0, 2) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0) = h_e(0, 0, 0) + 0.1 * (h_e(0, 0, 0) * rtol);
-  h_e(1, 0, 0) = h_e(1, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0) += 0.1 * (h_e(0, 0, 0) * rtol);
+  h_e(1, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -191,20 +191,20 @@ void test_view_errors_4D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0) = h_b(0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0) = h_c(1, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0) += 2.0 * atol;
 
   // d includes three values with bigger errors than acceptance -> error count 3
   h_d(0, 0, 0, 0) = h_b(0, 0, 0, 0);
   h_d(1, 0, 0, 0) = h_c(1, 0, 0, 0);
-  h_d(1, 0, 2, 0) = h_b(1, 0, 2, 0) + 3.0 * (h_b(1, 0, 2, 0) * rtol);
-  h_d(1, 0, 1, 3) = h_b(1, 0, 1, 3) + 2.5 * (h_b(1, 0, 1, 3) * rtol);
+  h_d(1, 0, 2, 0) += 3.0 * (h_b(1, 0, 2, 0) * rtol);
+  h_d(1, 0, 1, 3) += 2.5 * (h_b(1, 0, 1, 3) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0) = h_e(0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0) = h_e(1, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -245,21 +245,21 @@ void test_view_errors_5D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes four values with bigger errors than acceptance -> error count 4
   h_d(0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0) = h_b(1, 0, 2, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0) = h_b(1, 0, 1, 3, 0) + 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
-  h_d(1, 0, 2, 1, 4) = h_b(1, 0, 2, 1, 4) + 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
+  h_d(1, 0, 2, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0) += 2.5 * (h_b(1, 0, 1, 3, 0) * rtol);
+  h_d(1, 0, 2, 1, 4) += 1.5 * (h_b(1, 0, 2, 1, 4) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0) = h_e(0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -300,28 +300,22 @@ void test_view_errors_6D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes five values with bigger errors than acceptance -> error count 5
   h_d(0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0) =
-      h_b(1, 0, 2, 1, 4, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1) =
-      h_b(0, 0, 2, 1, 3, 1) + 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
+  h_d(1, 0, 2, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1) += 1.8 * (h_b(0, 0, 2, 1, 3, 1) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -362,30 +356,23 @@ void test_view_errors_7D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes six values with bigger errors than acceptance -> error count 6
   h_d(0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0, 0) =
-      h_b(1, 0, 2, 1, 4, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1, 0) =
-      h_b(0, 0, 2, 1, 3, 1, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2) =
-      h_b(0, 0, 2, 1, 4, 1, 2) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
+  h_d(1, 0, 2, 0, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0) += 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2) += 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);
@@ -428,32 +415,24 @@ void test_view_errors_8D_analytical(double rtol, double atol) {
   auto h_e = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e);
 
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0, 0, 0, 0, 0, 0, 0, 0) =
-      h_b(0, 0, 0, 0, 0, 0, 0, 0) + 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_b(0, 0, 0, 0, 0, 0, 0, 0) += 2.0 * (h_b(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
 
   // c(a) includes 3.00000001 which is acceptable by rtol -> error count 0
-  h_c(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0) + 2.0 * atol;
+  h_c(1, 0, 0, 0, 0, 0, 0, 0) += 2.0 * atol;
 
   // d includes seven values with bigger errors than acceptance -> error count 7
   h_d(0, 0, 0, 0, 0, 0, 0, 0) = h_b(0, 0, 0, 0, 0, 0, 0, 0);
   h_d(1, 0, 0, 0, 0, 0, 0, 0) = h_c(1, 0, 0, 0, 0, 0, 0, 0);
-  h_d(1, 0, 2, 0, 0, 0, 0, 0) =
-      h_b(1, 0, 2, 0, 0, 0, 0, 0) + 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 1, 3, 0, 0, 0, 0) =
-      h_b(1, 0, 1, 3, 0, 0, 0, 0) + 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
-  h_d(1, 0, 2, 1, 4, 0, 0, 0) =
-      h_b(1, 0, 2, 1, 4, 0, 0, 0) + 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 3, 1, 0, 0) =
-      h_b(0, 0, 2, 1, 3, 1, 0, 0) + 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2, 0) =
-      h_b(0, 0, 2, 1, 4, 1, 2, 0) + 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
-  h_d(0, 0, 2, 1, 4, 1, 2, 5) =
-      h_b(0, 0, 2, 1, 4, 1, 2, 5) + 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
+  h_d(1, 0, 2, 0, 0, 0, 0, 0) += 3.0 * (h_b(1, 0, 2, 0, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 1, 3, 0, 0, 0, 0) += 2.5 * (h_b(1, 0, 1, 3, 0, 0, 0, 0) * rtol);
+  h_d(1, 0, 2, 1, 4, 0, 0, 0) += 1.5 * (h_b(1, 0, 2, 1, 4, 0, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 3, 1, 0, 0) += 1.8 * (h_b(0, 0, 2, 1, 3, 1, 0, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 0) += 2.1 * (h_b(0, 0, 2, 1, 4, 1, 2, 0) * rtol);
+  h_d(0, 0, 2, 1, 4, 1, 2, 5) += 1.7 * (h_b(0, 0, 2, 1, 4, 1, 2, 5) * rtol);
 
   // e includes small relative and absolute errors -> error count 0
-  h_e(0, 0, 0, 0, 0, 0, 0, 0) =
-      h_e(0, 0, 0, 0, 0, 0, 0, 0) + 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
-  h_e(1, 0, 0, 0, 0, 0, 0, 0) = h_e(1, 0, 0, 0, 0, 0, 0, 0) + 0.1 * atol;
+  h_e(0, 0, 0, 0, 0, 0, 0, 0) += 0.1 * (h_e(0, 0, 0, 0, 0, 0, 0, 0) * rtol);
+  h_e(1, 0, 0, 0, 0, 0, 0, 0) += 0.1 * atol;
 
   Kokkos::deep_copy(b, h_b);
   Kokkos::deep_copy(c, h_c);

--- a/testing/unit_test/Test_FindErrors.cpp
+++ b/testing/unit_test/Test_FindErrors.cpp
@@ -39,7 +39,7 @@ void test_find_errors_1D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(0) = h_b(0) + 2.0 * (h_b(0) * rtol);
+  h_b(0) += 2.0 * (h_b(0) * rtol);
 
   h_ref_a_error(0)      = T(3.0);
   h_ref_b_error(0)      = h_b(0);
@@ -86,7 +86,7 @@ void test_find_errors_2D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1) = h_b(2, 1) + 2.0 * (h_b(2, 1) * rtol);
+  h_b(2, 1) += 2.0 * (h_b(2, 1) * rtol);
 
   h_ref_a_error(0)      = T(3.0);
   h_ref_b_error(0)      = h_b(2, 1);
@@ -135,7 +135,7 @@ void test_find_errors_3D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3) = h_b(2, 1, 3) + 2.0 * (h_b(2, 1, 3) * rtol);
+  h_b(2, 1, 3) += 2.0 * (h_b(2, 1, 3) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3);
@@ -187,7 +187,7 @@ void test_find_errors_4D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3, 1) = h_b(2, 1, 3, 1) + 2.0 * (h_b(2, 1, 3, 1) * rtol);
+  h_b(2, 1, 3, 1) += 2.0 * (h_b(2, 1, 3, 1) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3, 1);
@@ -242,7 +242,7 @@ void test_find_errors_5D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3, 1, 2) = h_b(2, 1, 3, 1, 2) + 2.0 * (h_b(2, 1, 3, 1, 2) * rtol);
+  h_b(2, 1, 3, 1, 2) += 2.0 * (h_b(2, 1, 3, 1, 2) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3, 1, 2);
@@ -301,8 +301,7 @@ void test_find_errors_6D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3, 1, 2, 0) =
-      h_b(2, 1, 3, 1, 2, 0) + 2.0 * (h_b(2, 1, 3, 1, 2, 0) * rtol);
+  h_b(2, 1, 3, 1, 2, 0) += 2.0 * (h_b(2, 1, 3, 1, 2, 0) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0);
@@ -366,8 +365,7 @@ void test_find_errors_7D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3, 1, 2, 0, 1) =
-      h_b(2, 1, 3, 1, 2, 0, 1) + 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1) * rtol);
+  h_b(2, 1, 3, 1, 2, 0, 1) += 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0, 1);
@@ -434,8 +432,7 @@ void test_find_errors_8D_analytical(double rtol, double atol) {
 
   // Initialization and prepare reference at host
   // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
-  h_b(2, 1, 3, 1, 2, 0, 1, 0) =
-      h_b(2, 1, 3, 1, 2, 0, 1, 0) + 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1, 0) * rtol);
+  h_b(2, 1, 3, 1, 2, 0, 1, 0) += 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1, 0) * rtol);
 
   h_ref_a_error(0) = T(3.0);
   h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0, 1, 0);

--- a/testing/unit_test/Test_FindErrors.cpp
+++ b/testing/unit_test/Test_FindErrors.cpp
@@ -113,6 +113,375 @@ void test_find_errors_2D_analytical(double rtol, double atol) {
     EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
   }
 }
+
+template <typename T>
+void test_find_errors_3D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View3DType     = Kokkos::View<T***>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, nb_errors = 1;
+  View3DType a("a", n0, n1, n2), b("b", n0, n1, n2);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 4);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3) = h_b(2, 1, 3) + 2.0 * (h_b(2, 1, 3) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1);  // global idx
+  h_ref_loc_error(0, 1) = 2;  // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;  // idx of dimension 2
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+  }
+}
+
+template <typename T>
+void test_find_errors_4D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View4DType     = Kokkos::View<T****>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, n3 = 5, nb_errors = 1;
+  View4DType a("a", n0, n1, n2, n3), b("b", n0, n1, n2, n3);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 5);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3, 1) = h_b(2, 1, 3, 1) + 2.0 * (h_b(2, 1, 3, 1) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3, 1);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2);  // global idx
+  h_ref_loc_error(0, 1) = 2;                        // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;                        // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;                        // idx of dimension 2
+  h_ref_loc_error(0, 4) = 1;                        // idx of dimension 3
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+    EXPECT_EQ(h_loc_error(i, 4), h_ref_loc_error(i, 4));
+  }
+}
+
+template <typename T>
+void test_find_errors_5D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View5DType     = Kokkos::View<T*****>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 3, nb_errors = 1;
+  View5DType a("a", n0, n1, n2, n3, n4), b("b", n0, n1, n2, n3, n4);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 6);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3, 1, 2) = h_b(2, 1, 3, 1, 2) + 2.0 * (h_b(2, 1, 3, 1, 2) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3, 1, 2);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) +
+      2 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3);  // global idx
+  h_ref_loc_error(0, 1) = 2;  // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;  // idx of dimension 2
+  h_ref_loc_error(0, 4) = 1;  // idx of dimension 3
+  h_ref_loc_error(0, 5) = 2;  // idx of dimension 3
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+    EXPECT_EQ(h_loc_error(i, 4), h_ref_loc_error(i, 4));
+    EXPECT_EQ(h_loc_error(i, 5), h_ref_loc_error(i, 5));
+  }
+}
+
+template <typename T>
+void test_find_errors_6D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View6DType     = Kokkos::View<T******>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 3, n5 = 4,
+                    nb_errors = 1;
+  View6DType a("a", n0, n1, n2, n3, n4, n5), b("b", n0, n1, n2, n3, n4, n5);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 7);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3, 1, 2, 0) =
+      h_b(2, 1, 3, 1, 2, 0) + 2.0 * (h_b(2, 1, 3, 1, 2, 0) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) +
+      2 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) +
+      0 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) *
+          b.extent(4);        // global idx
+  h_ref_loc_error(0, 1) = 2;  // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;  // idx of dimension 2
+  h_ref_loc_error(0, 4) = 1;  // idx of dimension 3
+  h_ref_loc_error(0, 5) = 2;  // idx of dimension 4
+  h_ref_loc_error(0, 6) = 0;  // idx of dimension 5
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+    EXPECT_EQ(h_loc_error(i, 4), h_ref_loc_error(i, 4));
+    EXPECT_EQ(h_loc_error(i, 5), h_ref_loc_error(i, 5));
+    EXPECT_EQ(h_loc_error(i, 6), h_ref_loc_error(i, 6));
+  }
+}
+
+template <typename T>
+void test_find_errors_7D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View7DType     = Kokkos::View<T*******>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 3, n5 = 4, n6 = 2,
+                    nb_errors = 1;
+  View7DType a("a", n0, n1, n2, n3, n4, n5, n6),
+      b("b", n0, n1, n2, n3, n4, n5, n6);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 8);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3, 1, 2, 0, 1) =
+      h_b(2, 1, 3, 1, 2, 0, 1) + 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0, 1);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) +
+      2 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) +
+      0 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) * b.extent(4) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) * b.extent(4) *
+          b.extent(5);        // global idx
+  h_ref_loc_error(0, 1) = 2;  // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;  // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;  // idx of dimension 2
+  h_ref_loc_error(0, 4) = 1;  // idx of dimension 3
+  h_ref_loc_error(0, 5) = 2;  // idx of dimension 4
+  h_ref_loc_error(0, 6) = 0;  // idx of dimension 5
+  h_ref_loc_error(0, 7) = 1;  // idx of dimension 6
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+    EXPECT_EQ(h_loc_error(i, 4), h_ref_loc_error(i, 4));
+    EXPECT_EQ(h_loc_error(i, 5), h_ref_loc_error(i, 5));
+    EXPECT_EQ(h_loc_error(i, 6), h_ref_loc_error(i, 6));
+    EXPECT_EQ(h_loc_error(i, 7), h_ref_loc_error(i, 7));
+  }
+}
+
+template <typename T>
+void test_find_errors_8D_analytical(double rtol, double atol) {
+  using View1DType     = Kokkos::View<T*>;
+  using View8DType     = Kokkos::View<T********>;
+  using CountViewType  = Kokkos::View<std::size_t**>;
+  const std::size_t n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 3, n5 = 4, n6 = 2,
+                    n7 = 1, nb_errors = 1;
+  View8DType a("a", n0, n1, n2, n3, n4, n5, n6, n7),
+      b("b", n0, n1, n2, n3, n4, n5, n6, n7);
+  View1DType ref_a_error("ref_a_error", nb_errors),
+      ref_b_error("ref_b_error", nb_errors);
+  CountViewType ref_loc_error("ref_loc_error", nb_errors, 9);
+
+  Kokkos::deep_copy(a, T(3.0));
+  Kokkos::deep_copy(b, a);
+
+  auto h_ref_a_error   = Kokkos::create_mirror_view(ref_a_error);
+  auto h_ref_b_error   = Kokkos::create_mirror_view(ref_b_error);
+  auto h_ref_loc_error = Kokkos::create_mirror_view(ref_loc_error);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+
+  // Initialization and prepare reference at host
+  // b(0, 0) includes 3.00006 with bigger error than acceptance -> error count 1
+  h_b(2, 1, 3, 1, 2, 0, 1, 0) =
+      h_b(2, 1, 3, 1, 2, 0, 1, 0) + 2.0 * (h_b(2, 1, 3, 1, 2, 0, 1, 0) * rtol);
+
+  h_ref_a_error(0) = T(3.0);
+  h_ref_b_error(0) = h_b(2, 1, 3, 1, 2, 0, 1, 0);
+  h_ref_loc_error(0, 0) =
+      2 + 1 * b.extent(0) + 3 * b.extent(0) * b.extent(1) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) +
+      2 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) +
+      0 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) * b.extent(4) +
+      1 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) * b.extent(4) *
+          b.extent(5) +
+      0 * b.extent(0) * b.extent(1) * b.extent(2) * b.extent(3) * b.extent(4) *
+          b.extent(5) * b.extent(6);  // global idx
+  h_ref_loc_error(0, 1) = 2;          // idx of dimension 0
+  h_ref_loc_error(0, 2) = 1;          // idx of dimension 1
+  h_ref_loc_error(0, 3) = 3;          // idx of dimension 2
+  h_ref_loc_error(0, 4) = 1;          // idx of dimension 3
+  h_ref_loc_error(0, 5) = 2;          // idx of dimension 4
+  h_ref_loc_error(0, 6) = 0;          // idx of dimension 5
+  h_ref_loc_error(0, 7) = 1;          // idx of dimension 6
+  h_ref_loc_error(0, 8) = 0;          // idx of dimension 7
+  Kokkos::deep_copy(b, h_b);
+
+  auto [b_error, a_error, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      execution_space(), b, a, nb_errors, rtol, atol);
+  auto h_b_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_error);
+  auto h_a_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_error);
+  auto h_loc_error =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i = 0; i < nb_errors; i++) {
+    EXPECT_LT(Kokkos::abs(h_a_error(i) - h_ref_a_error(i)), epsilon);
+    EXPECT_LT(Kokkos::abs(h_b_error(i) - h_ref_b_error(i)), epsilon);
+    EXPECT_EQ(h_loc_error(i, 0), h_ref_loc_error(i, 0));
+    EXPECT_EQ(h_loc_error(i, 1), h_ref_loc_error(i, 1));
+    EXPECT_EQ(h_loc_error(i, 2), h_ref_loc_error(i, 2));
+    EXPECT_EQ(h_loc_error(i, 3), h_ref_loc_error(i, 3));
+    EXPECT_EQ(h_loc_error(i, 4), h_ref_loc_error(i, 4));
+    EXPECT_EQ(h_loc_error(i, 5), h_ref_loc_error(i, 5));
+    EXPECT_EQ(h_loc_error(i, 6), h_ref_loc_error(i, 6));
+    EXPECT_EQ(h_loc_error(i, 7), h_ref_loc_error(i, 7));
+    EXPECT_EQ(h_loc_error(i, 8), h_ref_loc_error(i, 8));
+  }
+}
 }  // namespace
 
 TYPED_TEST_SUITE(TestFindErrors, float_types);
@@ -125,4 +494,34 @@ TYPED_TEST(TestFindErrors, View1D) {
 TYPED_TEST(TestFindErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_find_errors_2D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_3D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_4D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_5D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_6D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_7D_analytical<float_type>(this->m_rtol, this->m_atol);
+}
+
+TYPED_TEST(TestFindErrors, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_find_errors_8D_analytical<float_type>(this->m_rtol, this->m_atol);
 }

--- a/testing/unit_test/Test_PrintErrors.cpp
+++ b/testing/unit_test/Test_PrintErrors.cpp
@@ -80,9 +80,8 @@ void test_sort_errors_2D_analytical() {
   h_loc_error(1, 1) = 1;  // idx of dimension 0
   h_loc_error(1, 2) = 1;  // idx of dimension 1
 
-  std::vector<std::size_t> global_indices;
-  global_indices.push_back(3);
-  global_indices.push_back(4);
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
 
   Kokkos::deep_copy(a_error, h_a_error);
   Kokkos::deep_copy(b_error, h_b_error);
@@ -98,6 +97,339 @@ void test_sort_errors_2D_analytical() {
     EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
     EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
     EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+  }
+}
+
+template <typename T>
+void test_sort_errors_3D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 4);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 9;   // global idx
+  h_loc_error(0, 1) = 0;   // idx of dimension 0
+  h_loc_error(0, 2) = 1;   // idx of dimension 1
+  h_loc_error(0, 3) = 1;   // idx of dimension 2
+  h_loc_error(1, 0) = 16;  // global idx
+  h_loc_error(1, 1) = 1;   // idx of dimension 0
+  h_loc_error(1, 2) = 1;   // idx of dimension 1
+  h_loc_error(1, 3) = 2;   // idx of dimension 2
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+  }
+}
+
+template <typename T>
+void test_sort_errors_4D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 5);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 81;  // global idx
+  h_loc_error(0, 1) = 0;   // idx of dimension 0
+  h_loc_error(0, 2) = 1;   // idx of dimension 1
+  h_loc_error(0, 3) = 1;   // idx of dimension 2
+  h_loc_error(0, 4) = 3;   // idx of dimension 3
+  h_loc_error(1, 0) = 64;  // global idx
+  h_loc_error(1, 1) = 1;   // idx of dimension 0
+  h_loc_error(1, 2) = 1;   // idx of dimension 1
+  h_loc_error(1, 3) = 2;   // idx of dimension 2
+  h_loc_error(1, 4) = 2;   // idx of dimension 3
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+    EXPECT_EQ(loc.at(3), h_loc_error(i_error, 4));
+  }
+}
+
+template <typename T>
+void test_sort_errors_5D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 6);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 201;  // global idx
+  h_loc_error(0, 1) = 0;    // idx of dimension 0
+  h_loc_error(0, 2) = 1;    // idx of dimension 1
+  h_loc_error(0, 3) = 1;    // idx of dimension 2
+  h_loc_error(0, 4) = 3;    // idx of dimension 3
+  h_loc_error(0, 5) = 1;    // idx of dimension 4
+  h_loc_error(1, 0) = 298;  // global idx
+  h_loc_error(1, 1) = 1;    // idx of dimension 0
+  h_loc_error(1, 2) = 1;    // idx of dimension 1
+  h_loc_error(1, 3) = 2;    // idx of dimension 2
+  h_loc_error(1, 4) = 2;    // idx of dimension 3
+  h_loc_error(1, 5) = 1;    // idx of dimension 4
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+    EXPECT_EQ(loc.at(3), h_loc_error(i_error, 4));
+    EXPECT_EQ(loc.at(4), h_loc_error(i_error, 5));
+  }
+}
+
+template <typename T>
+void test_sort_errors_6D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 7);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 561;  // global idx
+  h_loc_error(0, 1) = 0;    // idx of dimension 0
+  h_loc_error(0, 2) = 1;    // idx of dimension 1
+  h_loc_error(0, 3) = 1;    // idx of dimension 2
+  h_loc_error(0, 4) = 3;    // idx of dimension 3
+  h_loc_error(0, 5) = 1;    // idx of dimension 4
+  h_loc_error(0, 6) = 1;    // idx of dimension 5
+  h_loc_error(1, 0) = 658;  // global idx
+  h_loc_error(1, 1) = 1;    // idx of dimension 0
+  h_loc_error(1, 2) = 1;    // idx of dimension 1
+  h_loc_error(1, 3) = 2;    // idx of dimension 2
+  h_loc_error(1, 4) = 2;    // idx of dimension 3
+  h_loc_error(1, 5) = 1;    // idx of dimension 4
+  h_loc_error(1, 6) = 1;    // idx of dimension 5
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+    EXPECT_EQ(loc.at(3), h_loc_error(i_error, 4));
+    EXPECT_EQ(loc.at(4), h_loc_error(i_error, 5));
+    EXPECT_EQ(loc.at(5), h_loc_error(i_error, 6));
+  }
+}
+
+template <typename T>
+void test_sort_errors_7D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 8);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 2001;  // global idx
+  h_loc_error(0, 1) = 0;     // idx of dimension 0
+  h_loc_error(0, 2) = 1;     // idx of dimension 1
+  h_loc_error(0, 3) = 1;     // idx of dimension 2
+  h_loc_error(0, 4) = 3;     // idx of dimension 3
+  h_loc_error(0, 5) = 1;     // idx of dimension 4
+  h_loc_error(0, 6) = 1;     // idx of dimension 5
+  h_loc_error(0, 7) = 1;     // idx of dimension 6
+  h_loc_error(1, 0) = 3538;  // global idx
+  h_loc_error(1, 1) = 1;     // idx of dimension 0
+  h_loc_error(1, 2) = 1;     // idx of dimension 1
+  h_loc_error(1, 3) = 2;     // idx of dimension 2
+  h_loc_error(1, 4) = 2;     // idx of dimension 3
+  h_loc_error(1, 5) = 1;     // idx of dimension 4
+  h_loc_error(1, 6) = 1;     // idx of dimension 5
+  h_loc_error(1, 7) = 2;     // idx of dimension 6
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+    EXPECT_EQ(loc.at(3), h_loc_error(i_error, 4));
+    EXPECT_EQ(loc.at(4), h_loc_error(i_error, 5));
+    EXPECT_EQ(loc.at(5), h_loc_error(i_error, 6));
+    EXPECT_EQ(loc.at(6), h_loc_error(i_error, 7));
+  }
+}
+
+template <typename T>
+void test_sort_errors_8D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 9);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 2001;  // global idx
+  h_loc_error(0, 1) = 0;     // idx of dimension 0
+  h_loc_error(0, 2) = 1;     // idx of dimension 1
+  h_loc_error(0, 3) = 1;     // idx of dimension 2
+  h_loc_error(0, 4) = 3;     // idx of dimension 3
+  h_loc_error(0, 5) = 1;     // idx of dimension 4
+  h_loc_error(0, 6) = 1;     // idx of dimension 5
+  h_loc_error(0, 7) = 1;     // idx of dimension 6
+  h_loc_error(0, 8) = 0;     // idx of dimension 7
+  h_loc_error(1, 0) = 3538;  // global idx
+  h_loc_error(1, 1) = 1;     // idx of dimension 0
+  h_loc_error(1, 2) = 1;     // idx of dimension 1
+  h_loc_error(1, 3) = 2;     // idx of dimension 2
+  h_loc_error(1, 4) = 2;     // idx of dimension 3
+  h_loc_error(1, 5) = 1;     // idx of dimension 4
+  h_loc_error(1, 6) = 1;     // idx of dimension 5
+  h_loc_error(1, 7) = 2;     // idx of dimension 6
+  h_loc_error(1, 8) = 0;     // idx of dimension 7
+
+  std::vector<std::size_t> global_indices = {h_loc_error(0, 0),
+                                             h_loc_error(1, 0)};
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_error, b_error, loc_error);
+
+  T epsilon = std::numeric_limits<T>::epsilon();
+  for (std::size_t i_error = 0; i_error < nb_errors; ++i_error) {
+    auto [loc, a_val, b_val] = error_map[global_indices.at(i_error)];
+    EXPECT_LT(Kokkos::abs(a_val - h_a_error(i_error)), epsilon);
+    EXPECT_LT(Kokkos::abs(b_val - h_b_error(i_error)), epsilon);
+    EXPECT_EQ(loc.at(0), h_loc_error(i_error, 1));
+    EXPECT_EQ(loc.at(1), h_loc_error(i_error, 2));
+    EXPECT_EQ(loc.at(2), h_loc_error(i_error, 3));
+    EXPECT_EQ(loc.at(3), h_loc_error(i_error, 4));
+    EXPECT_EQ(loc.at(4), h_loc_error(i_error, 5));
+    EXPECT_EQ(loc.at(5), h_loc_error(i_error, 6));
+    EXPECT_EQ(loc.at(6), h_loc_error(i_error, 7));
+    EXPECT_EQ(loc.at(7), h_loc_error(i_error, 8));
   }
 }
 
@@ -207,6 +539,397 @@ void test_print_errors_2D_analytical() {
   // pattern.
   EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
 }
+
+template <typename T>
+void test_print_errors_3D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 4);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 9;   // global idx
+  h_loc_error(0, 1) = 0;   // idx of dimension 0
+  h_loc_error(0, 2) = 1;   // idx of dimension 1
+  h_loc_error(0, 3) = 1;   // idx of dimension 2
+  h_loc_error(1, 0) = 16;  // global idx
+  h_loc_error(1, 1) = 1;   // idx of dimension 0
+  h_loc_error(1, 2) = 1;   // idx of dimension 1
+  h_loc_error(1, 3) = 2;   // idx of dimension 2
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1, 1): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1, 2): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1, 2\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_4D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 5);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 81;  // global idx
+  h_loc_error(0, 1) = 0;   // idx of dimension 0
+  h_loc_error(0, 2) = 1;   // idx of dimension 1
+  h_loc_error(0, 3) = 1;   // idx of dimension 2
+  h_loc_error(0, 4) = 3;   // idx of dimension 3
+  h_loc_error(1, 0) = 64;  // global idx
+  h_loc_error(1, 1) = 1;   // idx of dimension 0
+  h_loc_error(1, 2) = 1;   // idx of dimension 1
+  h_loc_error(1, 3) = 2;   // idx of dimension 2
+  h_loc_error(1, 4) = 2;   // idx of dimension 3
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // [NOTE] Order reversed because of sorting by global idx
+  // "Mismatched elements (by indices):\n"
+  // "  Index (1, 1, 2, 2): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)\n"
+  // "  Index (0, 1, 1, 3): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(1, 1, 2, 2\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(0, 1, 1, 3\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_5D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 6);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 201;  // global idx
+  h_loc_error(0, 1) = 0;    // idx of dimension 0
+  h_loc_error(0, 2) = 1;    // idx of dimension 1
+  h_loc_error(0, 3) = 1;    // idx of dimension 2
+  h_loc_error(0, 4) = 3;    // idx of dimension 3
+  h_loc_error(0, 5) = 1;    // idx of dimension 4
+  h_loc_error(1, 0) = 298;  // global idx
+  h_loc_error(1, 1) = 1;    // idx of dimension 0
+  h_loc_error(1, 2) = 1;    // idx of dimension 1
+  h_loc_error(1, 3) = 2;    // idx of dimension 2
+  h_loc_error(1, 4) = 2;    // idx of dimension 3
+  h_loc_error(1, 5) = 1;    // idx of dimension 4
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1, 1, 3, 1): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1, 2, 2, 1): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1, 1, 3, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1, 2, 2, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_6D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 7);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 561;  // global idx
+  h_loc_error(0, 1) = 0;    // idx of dimension 0
+  h_loc_error(0, 2) = 1;    // idx of dimension 1
+  h_loc_error(0, 3) = 1;    // idx of dimension 2
+  h_loc_error(0, 4) = 3;    // idx of dimension 3
+  h_loc_error(0, 5) = 1;    // idx of dimension 4
+  h_loc_error(0, 6) = 1;    // idx of dimension 5
+  h_loc_error(1, 0) = 658;  // global idx
+  h_loc_error(1, 1) = 1;    // idx of dimension 0
+  h_loc_error(1, 2) = 1;    // idx of dimension 1
+  h_loc_error(1, 3) = 2;    // idx of dimension 2
+  h_loc_error(1, 4) = 2;    // idx of dimension 3
+  h_loc_error(1, 5) = 1;    // idx of dimension 4
+  h_loc_error(1, 6) = 1;    // idx of dimension 5
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1, 1, 3, 1, 1): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1, 2, 2, 1, 1): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1, 1, 3, 1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1, 2, 2, 1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_7D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 8);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 2001;  // global idx
+  h_loc_error(0, 1) = 0;     // idx of dimension 0
+  h_loc_error(0, 2) = 1;     // idx of dimension 1
+  h_loc_error(0, 3) = 1;     // idx of dimension 2
+  h_loc_error(0, 4) = 3;     // idx of dimension 3
+  h_loc_error(0, 5) = 1;     // idx of dimension 4
+  h_loc_error(0, 6) = 1;     // idx of dimension 5
+  h_loc_error(0, 7) = 1;     // idx of dimension 6
+  h_loc_error(1, 0) = 3538;  // global idx
+  h_loc_error(1, 1) = 1;     // idx of dimension 0
+  h_loc_error(1, 2) = 1;     // idx of dimension 1
+  h_loc_error(1, 3) = 2;     // idx of dimension 2
+  h_loc_error(1, 4) = 2;     // idx of dimension 3
+  h_loc_error(1, 5) = 1;     // idx of dimension 4
+  h_loc_error(1, 6) = 1;     // idx of dimension 5
+  h_loc_error(1, 7) = 2;     // idx of dimension 6
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1, 1, 3, 1, 1, 1): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1, 2, 2, 1, 1, 2): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1, 1, 3, 1, 1, 1\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1, 2, 2, 1, 1, 2\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
+
+template <typename T>
+void test_print_errors_8D_analytical() {
+  using View1DType            = Kokkos::View<T*>;
+  using CountViewType         = Kokkos::View<std::size_t**>;
+  const std::size_t nb_errors = 2;
+  View1DType a_error("ref_a_error", nb_errors),
+      b_error("ref_b_error", nb_errors);
+  CountViewType loc_error("ref_loc_error", nb_errors, 9);
+
+  auto h_a_error   = Kokkos::create_mirror_view(a_error);
+  auto h_b_error   = Kokkos::create_mirror_view(b_error);
+  auto h_loc_error = Kokkos::create_mirror_view(loc_error);
+
+  // Initialization and prepare reference at host
+  h_a_error(0)      = 3.0;
+  h_a_error(1)      = 3.0;
+  h_b_error(0)      = 3.0 + 2.0 * (3.0 * 1.0e-5);
+  h_b_error(1)      = 4.0;
+  h_loc_error(0, 0) = 2001;  // global idx
+  h_loc_error(0, 1) = 0;     // idx of dimension 0
+  h_loc_error(0, 2) = 1;     // idx of dimension 1
+  h_loc_error(0, 3) = 1;     // idx of dimension 2
+  h_loc_error(0, 4) = 3;     // idx of dimension 3
+  h_loc_error(0, 5) = 1;     // idx of dimension 4
+  h_loc_error(0, 6) = 1;     // idx of dimension 5
+  h_loc_error(0, 7) = 1;     // idx of dimension 6
+  h_loc_error(0, 8) = 0;     // idx of dimension 7
+  h_loc_error(1, 0) = 3538;  // global idx
+  h_loc_error(1, 1) = 1;     // idx of dimension 0
+  h_loc_error(1, 2) = 1;     // idx of dimension 1
+  h_loc_error(1, 3) = 2;     // idx of dimension 2
+  h_loc_error(1, 4) = 2;     // idx of dimension 3
+  h_loc_error(1, 5) = 1;     // idx of dimension 4
+  h_loc_error(1, 6) = 1;     // idx of dimension 5
+  h_loc_error(1, 7) = 2;     // idx of dimension 6
+  h_loc_error(1, 8) = 0;     // idx of dimension 7
+
+  Kokkos::deep_copy(a_error, h_a_error);
+  Kokkos::deep_copy(b_error, h_b_error);
+  Kokkos::deep_copy(loc_error, h_loc_error);
+
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(b_error, a_error, loc_error);
+
+  // clang-format off
+  // NOLINTBEGIN(*)
+  // Example error message. The floating point numbers may vary.
+  // "Mismatched elements (by indices):\n"
+  // "  Index (0, 1, 1, 3, 1, 1, 1, 0): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)\n"
+  // "  Index (1, 1, 2, 2, 1, 1, 2, 0): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)";
+  // NOLINTEND(*)
+  // clang-format on
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  // Regular expression pattern matching the expected format.
+  // \d+\.\d+ matches one or more digits, a literal dot, and one or more digits.
+  // \s+ matches one or more whitespace characters.
+  // Updated regex pattern: Replace \d with [0-9]
+  std::string pattern =
+      R"(Mismatched elements \(by indices\):)"
+      "\n"
+      R"(\s+Index \(0, 1, 1, 3, 1, 1, 1, 0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))"
+      "\n"
+      R"(\s+Index \(1, 1, 2, 2, 1, 1, 2, 0\): actual [0-9]+\.[0-9]+ vs expected [0-9]+\.[0-9]+ \(diff=[0-9]+\.[0-9]+\))";
+
+  // Using GoogleMock's MatchesRegex matcher to compare the string with the
+  // pattern.
+  EXPECT_THAT(error_str, ::testing::MatchesRegex(pattern));
+}
 }  // namespace
 
 TYPED_TEST_SUITE(TestSortErrors, float_types);
@@ -222,6 +945,36 @@ TYPED_TEST(TestSortErrors, View2D) {
   test_sort_errors_2D_analytical<float_type>();
 }
 
+TYPED_TEST(TestSortErrors, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_3D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_4D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_5D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_6D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_7D_analytical<float_type>();
+}
+
+TYPED_TEST(TestSortErrors, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_sort_errors_8D_analytical<float_type>();
+}
+
 TYPED_TEST(TestPrintErrors, View1D) {
   using float_type = typename TestFixture::float_type;
   test_print_errors_1D_analytical<float_type>();
@@ -230,4 +983,34 @@ TYPED_TEST(TestPrintErrors, View1D) {
 TYPED_TEST(TestPrintErrors, View2D) {
   using float_type = typename TestFixture::float_type;
   test_print_errors_2D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_3D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_4D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_5D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_6D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_7D_analytical<float_type>();
+}
+
+TYPED_TEST(TestPrintErrors, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_print_errors_8D_analytical<float_type>();
 }


### PR DESCRIPTION
This PR aims at extending View to View matcher up to 8D

- [x] 3D to 8D versions of `ViewErrors` and `FindErrors` are implemented
- [x] Unit-tests are added on 3D-8D Views

It may be counter-intuitive to give the global index from `LayoutLeft` order. 
This means that value at `(1, 1, 2, 2)` is printed before value at `(0, 1, 1, 3)`

```C++
  // [NOTE] Order reversed because of sorting by global idx
  // "Mismatched elements (by indices):\n"
  // "  Index (1, 1, 2, 2): actual 4.0000000000000000 vs expected 3.0000000000000000 (diff=1.0000000000000000)\n"
  // "  Index (0, 1, 1, 3): actual 3.0000599999999999 vs expected 3.0000000000000000 (diff=0.0000599999999999)";
  // NOLINTEND(*)
```