### PR TITLE
Add ulps comparison operator

### DIFF
--- a/testing/src/KokkosFFT_Ulps.hpp
+++ b/testing/src/KokkosFFT_Ulps.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_ULPS_HPP
+#define KOKKOSFFT_ULPS_HPP
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Half.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+#include <Kokkos_BitManipulation.hpp>
+#include "KokkosFFT_Concepts.hpp"
+
+namespace KokkosFFT {
+namespace Testing {
+namespace Impl {
+
+// Helper structure to select the correct integer type for bit reinterpretation
+template <typename T>
+struct FloatIntMap;
+
+template <>
+struct FloatIntMap<float> {
+  using IntType = std::int32_t;
+};
+template <>
+struct FloatIntMap<double> {
+  using IntType = std::int64_t;
+};
+
+template <>
+struct FloatIntMap<Kokkos::Experimental::half_t> {
+  using IntType = std::int16_t;
+};
+template <>
+struct FloatIntMap<Kokkos::Experimental::bhalf_t> {
+  using IntType = std::int16_t;
+};
+
+template <typename ScalarA, typename ScalarB>
+KOKKOS_INLINE_FUNCTION bool almost_equal_ulps(ScalarA a, ScalarB b,
+                                              std::size_t max_ulps_diff) {
+  // Handle non-finite cases and exact equality first
+  if (Kokkos::isnan(a) || Kokkos::isnan(b)) return false;
+
+  // Exact equality check: Handles +0 == -0, inf == inf, -inf == -inf
+  if (a == b) return true;
+
+  // Since a != b, we only need to check if a or b is infinite
+  if (Kokkos::isinf(a) || Kokkos::isinf(b)) return false;
+
+  // Get the integer representation of the floats
+  // Not sure how to compare if two types do not have the common type
+  using CommonFloatType = std::common_type_t<ScalarA, ScalarB>;
+  using IntType         = typename FloatIntMap<CommonFloatType>::IntType;
+
+  // Reinterpret the bits using Kokkos::bit_cast
+  IntType int_a = Kokkos::bit_cast<IntType>(a);
+  IntType int_b = Kokkos::bit_cast<IntType>(b);
+
+  // Calculate the ULP difference
+  IntType ulps_diff = int_a - int_b;
+
+  // Do not know how Kokkos::abs works on int16_t,
+  // so hardcode the absolute value
+  using UnsignedIntType         = typename std::make_unsigned<IntType>::type;
+  UnsignedIntType abs_ulps_diff = (ulps_diff < 0)
+                                      ? static_cast<UnsignedIntType>(-ulps_diff)
+                                      : static_cast<UnsignedIntType>(ulps_diff);
+
+  // Compare with the maximum allowed ULP difference
+  return abs_ulps_diff <= static_cast<UnsignedIntType>(max_ulps_diff);
+}
+
+}  // namespace Impl
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_Ulps.hpp
+++ b/testing/src/KokkosFFT_Ulps.hpp
@@ -63,7 +63,7 @@ KOKKOS_INLINE_FUNCTION UIntType float_to_biased_int(FloatType from) {
   // e.g., 0x80000000 for int32_t, 0x8000 for int16_t
   constexpr UIntType sign_mask = UIntType(1) << (sizeof(UIntType) * 8 - 1);
 
-  if ((to & sign_mask) != 0) {
+  if (to & sign_mask) {
     // Original float was negative (or -0.0f)
     // Bitwise NOT to reverse order and map to lower half conceptually
     return ~to + 1;

--- a/testing/src/KokkosFFT_Ulps.hpp
+++ b/testing/src/KokkosFFT_Ulps.hpp
@@ -28,14 +28,20 @@ struct FloatIntMap<double> {
   using IntType = std::int64_t;
 };
 
+// half_t and bhalf_t can be alias to float types
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 template <>
 struct FloatIntMap<Kokkos::Experimental::half_t> {
   using IntType = std::int16_t;
 };
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 template <>
 struct FloatIntMap<Kokkos::Experimental::bhalf_t> {
   using IntType = std::int16_t;
 };
+#endif
 
 template <typename ScalarA, typename ScalarB>
 KOKKOS_INLINE_FUNCTION bool almost_equal_ulps(ScalarA a, ScalarB b,

--- a/testing/src/KokkosFFT_Ulps.hpp
+++ b/testing/src/KokkosFFT_Ulps.hpp
@@ -46,6 +46,9 @@ struct FloatIntMap<Kokkos::Experimental::bhalf_t> {
 template <typename ScalarA, typename ScalarB>
 KOKKOS_INLINE_FUNCTION bool almost_equal_ulps(ScalarA a, ScalarB b,
                                               std::size_t max_ulps_diff) {
+  // We consider nans are identical
+  if (Kokkos::isnan(a) && Kokkos::isnan(b)) return true;
+
   // Handle non-finite cases and exact equality first
   if (Kokkos::isnan(a) || Kokkos::isnan(b)) return false;
 

--- a/testing/unit_test/CMakeLists.txt
+++ b/testing/unit_test/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreNotClose.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp 
+add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreNotClose.cpp Test_AlmostEqualUlps.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp 
 Test_TypeCartesianProduct.cpp)
 
 target_compile_features(unit-tests-kokkos-fft-testing PUBLIC cxx_std_20)

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -21,6 +21,8 @@ struct TestAlmostEqualUlps : public ::testing::Test {
 
 // Helper function for nextafter on fp16 types
 template <typename fp16_t>
+  requires(std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
+           std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
 fp16_t nextafter_fp16(fp16_t from, fp16_t to) {
   constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
   constexpr std::uint16_t FP16_POS_ZERO  = 0x0000;
@@ -94,7 +96,12 @@ template <typename T>
 auto nextafter_wrapper(T from, T to) {
   if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t> ||
                 std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+#if (defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT) || \
+    (defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT)
     return nextafter_fp16<T>(from, to);
+#else
+    return Kokkos::nextafter(from, to);
+#endif
   } else {
     return Kokkos::nextafter(from, to);
   }

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -96,8 +96,9 @@ template <typename T>
 auto nextafter_wrapper(T from, T to) {
   if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t> ||
                 std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
-#if (defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT) || \
-    (defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT)
+#if defined(KOKKOS_IMPL_HALF_TYPE_DEFINED) &&                        \
+    ((defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT) || \
+     (defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT))
     return nextafter_fp16<T>(from, to);
 #else
     return Kokkos::nextafter(from, to);

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -19,107 +19,175 @@ struct TestAlmostEqualUlps : public ::testing::Test {
   using BoolViewType = Kokkos::View<bool, execution_space>;
 };
 
+// Helper function for nextafter on fp16 types
+template <typename fp16_t>
+fp16_t nextafter_fp16(fp16_t from, fp16_t to) {
+  constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
+  constexpr std::uint16_t FP16_POS_ZERO  = 0x0000;
+  constexpr std::uint16_t FP16_NEG_ZERO  = 0x8000;
+  constexpr std::uint16_t FP16_SMALLEST_POS_DN =
+      0x0001;  // Smallest positive denormal
+  constexpr std::uint16_t FP16_SMALLEST_NEG_DN =
+      0x8001;  // Smallest negative denormal (magnitude)
+
+  // Handle Nans
+  if (Kokkos::isnan(from) || Kokkos::isnan(to)) {
+    return Kokkos::Experimental::quiet_NaN<fp16_t>::value;
+  }
+
+  // Handle equality
+  if (from == to) return to;
+
+  // Get unsigned integer representation of from
+  std::uint16_t uint_from = Kokkos::bit_cast<std::uint16_t>(from);
+
+  // Handle zeros
+  if (uint_from == FP16_POS_ZERO) {  // from is +0.0
+    // Direction is to a non-zero number.
+    // Return smallest magnitude number with the sign of 'to'.
+    // However, standard nextafter(+0, negative) -> smallest_negative
+    // And nextafter(+0, positive) -> smallest_positive
+    return Kokkos::bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+                                                : FP16_SMALLEST_NEG_DN);
+  }
+  if (uint_from == FP16_NEG_ZERO) {  // from is -0.0
+    // Return smallest magnitude number with the sign of 'to'.
+    // Standard nextafter(-0, negative) -> smallest_negative
+    // And nextafter(-0, positive) -> smallest_positive
+    return Kokkos::bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+                                                : FP16_SMALLEST_NEG_DN);
+  }
+
+  // Determine direction and sign of 'from'
+  // True if moving to positive infinity
+  bool increase_magnitude = (to > from);
+  bool from_is_negative   = ((uint_from & FP16_SIGN_MASK) != 0);
+
+  std::uint16_t uint_result;
+  if (from_is_negative) {
+    // For negative numbers, increasing magnitude means moving towards -inf
+    // (larger uint value) Decreasing magnitude means moving towards zero
+    // (smaller uint value)
+    if (increase_magnitude) {
+      // Moving toward zero or positive
+      uint_result = uint_from - 1;
+    } else {
+      // Moving toward negative infinity
+      uint_result = uint_from + 1;
+    }
+  } else {
+    // For positive numbers, increasing magnitude means moving towards +inf
+    // (larger uint value) Decreasing magnitude means moving towards zero
+    // (smaller uint value)
+    if (increase_magnitude) {
+      // Moving toward positive infinity
+      uint_result = uint_from + 1;
+    } else {
+      // Moving toward zero or negative infinity
+      uint_result = uint_from - 1;
+    }
+  }
+  return Kokkos::bit_cast<fp16_t>(uint_result);
+}
+
+template <typename T>
+auto nextafter_wrapper(T from, T to) {
+  if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t> ||
+                std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+    return nextafter_fp16<T>(from, to);
+  } else {
+    return Kokkos::nextafter(from, to);
+  }
+}
+
 template <typename T, typename BoolViewType>
 void test_almost_equal_ulps_positive() {
   T a(1.0);
   T b = a;
-  T c = Kokkos::nextafter(a, T(2.0));
-  T d = Kokkos::nextafter(c, T(2.0));
+  T c = nextafter_wrapper(a, T(2.0));
+  T d = nextafter_wrapper(c, T(2.0));
 
-  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
-      a_c_are_almsot_equal("a_c_are_almsot_equal"),
-      a_d_are_almsot_equal_ulp1("a_d_are_almsot_equal_ulp1"),
-      a_d_are_almsot_equal_ulp2("a_d_are_almsot_equal_ulp2");
+  BoolViewType a_b_are_almost_equal("a_b_are_almost_equal"),
+      a_c_are_almost_equal("a_c_are_almost_equal"),
+      a_d_are_almost_equal_ulp1("a_d_are_almost_equal_ulp1"),
+      a_d_are_almost_equal_ulp2("a_d_are_almost_equal_ulp2");
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
       KOKKOS_LAMBDA(int) {
         // ULP diff 0 -> true
-        a_b_are_almsot_equal() =
+        a_b_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
 
         // ULP diff 1 -> true
-        a_c_are_almsot_equal() =
+        a_c_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1);
 
         // ULP diff 2 -> false if ulp_diff is 1 and true if ulp_diff is 2
-        a_d_are_almsot_equal_ulp1() =
+        a_d_are_almost_equal_ulp1() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 1);
-        a_d_are_almsot_equal_ulp2() =
+        a_d_are_almost_equal_ulp2() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 2);
       });
 
-  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_b_are_almsot_equal);
-  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_c_are_almsot_equal);
-  auto h_a_d_are_almsot_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp1);
-  auto h_a_d_are_almsot_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp2);
+  auto h_a_b_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almost_equal);
+  auto h_a_c_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almost_equal);
+  auto h_a_d_are_almost_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almost_equal_ulp1);
+  auto h_a_d_are_almost_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almost_equal_ulp2);
 
-  ASSERT_TRUE(h_a_b_are_almsot_equal());
-  ASSERT_TRUE(h_a_c_are_almsot_equal());
-
-  if (std::is_same_v<T, Kokkos::Experimental::half_t> ||
-      std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
-    // FIXME do not understand why this is satisfied
-    ASSERT_TRUE(h_a_d_are_almsot_equal_ulp1());
-  } else {
-    ASSERT_FALSE(h_a_d_are_almsot_equal_ulp1());
-  }
-  ASSERT_TRUE(h_a_d_are_almsot_equal_ulp2());
+  ASSERT_TRUE(h_a_b_are_almost_equal());
+  ASSERT_TRUE(h_a_c_are_almost_equal());
+  ASSERT_FALSE(h_a_d_are_almost_equal_ulp1());
+  ASSERT_TRUE(h_a_d_are_almost_equal_ulp2());
 }
 
 template <typename T, typename BoolViewType>
 void test_almost_equal_ulps_negative() {
   T a(-1.0);
   T b = a;
-  T c = Kokkos::nextafter(a, T(-2.0));
-  T d = Kokkos::nextafter(c, T(-2.0));
+  T c = nextafter_wrapper(a, T(-2.0));
+  T d = nextafter_wrapper(c, T(-2.0));
 
-  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
-      a_c_are_almsot_equal("a_c_are_almsot_equal"),
-      a_d_are_almsot_equal_ulp1("a_d_are_almsot_equal_ulp1"),
-      a_d_are_almsot_equal_ulp2("a_d_are_almsot_equal_ulp2");
+  BoolViewType a_b_are_almost_equal("a_b_are_almost_equal"),
+      a_c_are_almost_equal("a_c_are_almost_equal"),
+      a_d_are_almost_equal_ulp1("a_d_are_almost_equal_ulp1"),
+      a_d_are_almost_equal_ulp2("a_d_are_almost_equal_ulp2");
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
       KOKKOS_LAMBDA(int) {
         // ULP diff 0 -> true
-        a_b_are_almsot_equal() =
+        a_b_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
 
         // ULP diff 1 -> true
-        a_c_are_almsot_equal() =
+        a_c_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1);
 
         // ULP diff 2 -> false if ulp_diff is 1 and true if ulp_diff is 2
-        a_d_are_almsot_equal_ulp1() =
+        a_d_are_almost_equal_ulp1() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 1);
-        a_d_are_almsot_equal_ulp2() =
+        a_d_are_almost_equal_ulp2() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 2);
       });
 
-  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_b_are_almsot_equal);
-  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_c_are_almsot_equal);
-  auto h_a_d_are_almsot_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp1);
-  auto h_a_d_are_almsot_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp2);
+  auto h_a_b_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almost_equal);
+  auto h_a_c_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almost_equal);
+  auto h_a_d_are_almost_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almost_equal_ulp1);
+  auto h_a_d_are_almost_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almost_equal_ulp2);
 
-  ASSERT_TRUE(h_a_b_are_almsot_equal());
-  ASSERT_TRUE(h_a_c_are_almsot_equal());
-  if (std::is_same_v<T, Kokkos::Experimental::half_t> ||
-      std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
-    // FIXME do not understand why this is satisfied
-    ASSERT_TRUE(h_a_d_are_almsot_equal_ulp1());
-  } else {
-    ASSERT_FALSE(h_a_d_are_almsot_equal_ulp1());
-  }
-  ASSERT_TRUE(h_a_d_are_almsot_equal_ulp2());
+  ASSERT_TRUE(h_a_b_are_almost_equal());
+  ASSERT_TRUE(h_a_c_are_almost_equal());
+  ASSERT_FALSE(h_a_d_are_almost_equal_ulp1());
+  ASSERT_TRUE(h_a_d_are_almost_equal_ulp2());
 }
 
 template <typename T, typename BoolViewType>
@@ -129,32 +197,32 @@ void test_almost_equal_ulps_near_zero() {
   T c(0.0);
   T d(-0.0);
 
-  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
-      c_d_are_almsot_equal("c_d_are_almsot_equal");
+  BoolViewType a_b_are_almost_equal("a_b_are_almost_equal"),
+      c_d_are_almost_equal("c_d_are_almost_equal");
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
       KOKKOS_LAMBDA(int) {
         // ULP diff should be big -> false
-        a_b_are_almsot_equal() =
+        a_b_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 1);
         // ULP diff should be 0 -> true (not sure this is a good behaviour)
-        c_d_are_almsot_equal() =
+        c_d_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(c, d, 0);
       });
 
-  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_b_are_almsot_equal);
-  auto h_c_d_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, c_d_are_almsot_equal);
+  auto h_a_b_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almost_equal);
+  auto h_c_d_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, c_d_are_almost_equal);
 
   if (std::is_same_v<T, Kokkos::Experimental::half_t>) {
     // FIXME do not understand why this is satisfied
-    ASSERT_TRUE(h_a_b_are_almsot_equal());
+    ASSERT_TRUE(h_a_b_are_almost_equal());
   } else {
-    ASSERT_FALSE(h_a_b_are_almsot_equal());
+    ASSERT_FALSE(h_a_b_are_almost_equal());
   }
-  ASSERT_TRUE(h_c_d_are_almsot_equal());
+  ASSERT_TRUE(h_c_d_are_almost_equal());
 }
 
 template <typename T, typename BoolViewType>
@@ -164,28 +232,28 @@ void test_almost_equal_ulps_inf() {
   // FIXME do not compile
   // T c = -Kokkos::Experimental::infinity<T>::value;
 
-  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal");
-  //  a_c_are_almsot_equal("a_c_are_almsot_equal");
+  BoolViewType a_b_are_almost_equal("a_b_are_almost_equal");
+  //  a_c_are_almost_equal("a_c_are_almost_equal");
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
       KOKKOS_LAMBDA(int) {
         // ULP diff should be 0 -> true
-        a_b_are_almsot_equal() =
+        a_b_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
         // They are always different -> false
         // FIXME do not compile
-        // a_c_are_almsot_equal() =
+        // a_c_are_almost_equal() =
         //    KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1000000);
       });
 
-  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_b_are_almsot_equal);
-  // auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-  //     Kokkos::HostSpace{}, a_c_are_almsot_equal);
+  auto h_a_b_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almost_equal);
+  // auto h_a_c_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+  //     Kokkos::HostSpace{}, a_c_are_almost_equal);
 
-  ASSERT_TRUE(h_a_b_are_almsot_equal());
-  // ASSERT_FALSE(h_a_c_are_almsot_equal());
+  ASSERT_TRUE(h_a_b_are_almost_equal());
+  // ASSERT_FALSE(h_a_c_are_almost_equal());
 }
 
 template <typename T, typename BoolViewType>
@@ -194,27 +262,27 @@ void test_almost_equal_ulps_nan() {
   T b = a;
   T c(1.0);
 
-  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
-      a_c_are_almsot_equal("a_c_are_almsot_equal");
+  BoolViewType a_b_are_almost_equal("a_b_are_almost_equal"),
+      a_c_are_almost_equal("a_c_are_almost_equal");
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
       KOKKOS_LAMBDA(int) {
         // Nans are always different -> false
-        a_b_are_almsot_equal() =
+        a_b_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
         // Value and Nan are always different -> false
-        a_c_are_almsot_equal() =
+        a_c_are_almost_equal() =
             KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1000000);
       });
 
-  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_b_are_almsot_equal);
-  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, a_c_are_almsot_equal);
+  auto h_a_b_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almost_equal);
+  auto h_a_c_are_almost_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almost_equal);
 
-  ASSERT_FALSE(h_a_b_are_almsot_equal());
-  ASSERT_FALSE(h_a_c_are_almsot_equal());
+  ASSERT_FALSE(h_a_b_are_almost_equal());
+  ASSERT_FALSE(h_a_c_are_almost_equal());
 }
 
 }  // namespace

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -55,7 +55,7 @@ fp16_t nextafter_fp16(fp16_t from, fp16_t to) {
   // Determine direction and sign of 'from'
   // True if moving to positive infinity
   bool to_positive_infinity = (to > from);
-  bool from_is_negative     = ((uint_from & FP16_SIGN_MASK) != 0);
+  bool from_is_negative     = (uint_from & FP16_SIGN_MASK);
 
   std::uint16_t uint_result =
       uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Half.hpp>
+#include "KokkosFFT_Ulps.hpp"
+
+namespace {
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types =
+    ::testing::Types<Kokkos::Experimental::half_t,
+                     Kokkos::Experimental::bhalf_t, float, double>;
+
+template <typename T>
+struct TestAlmostEqualUlps : public ::testing::Test {
+  using float_type   = T;
+  using BoolViewType = Kokkos::View<bool, execution_space>;
+};
+
+template <typename T, typename BoolViewType>
+void test_almost_equal_ulps_positive() {
+  T a(1.0);
+  T b = a;
+  T c = Kokkos::nextafter(a, T(2.0));
+  T d = Kokkos::nextafter(c, T(2.0));
+
+  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
+      a_c_are_almsot_equal("a_c_are_almsot_equal"),
+      a_d_are_almsot_equal_ulp1("a_d_are_almsot_equal_ulp1"),
+      a_d_are_almsot_equal_ulp2("a_d_are_almsot_equal_ulp2");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        // ULP diff 0 -> true
+        a_b_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
+
+        // ULP diff 1 -> true
+        a_c_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1);
+
+        // ULP diff 2 -> false if ulp_diff is 1 and true if ulp_diff is 2
+        a_d_are_almsot_equal_ulp1() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 1);
+        a_d_are_almsot_equal_ulp2() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 2);
+      });
+
+  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almsot_equal);
+  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almsot_equal);
+  auto h_a_d_are_almsot_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp1);
+  auto h_a_d_are_almsot_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp2);
+
+  ASSERT_TRUE(h_a_b_are_almsot_equal());
+  ASSERT_TRUE(h_a_c_are_almsot_equal());
+
+  if (std::is_same_v<T, Kokkos::Experimental::half_t> ||
+      std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+    // FIXME do not understand why this is satisfied
+    ASSERT_TRUE(h_a_d_are_almsot_equal_ulp1());
+  } else {
+    ASSERT_FALSE(h_a_d_are_almsot_equal_ulp1());
+  }
+  ASSERT_TRUE(h_a_d_are_almsot_equal_ulp2());
+}
+
+template <typename T, typename BoolViewType>
+void test_almost_equal_ulps_negative() {
+  T a(-1.0);
+  T b = a;
+  T c = Kokkos::nextafter(a, T(-2.0));
+  T d = Kokkos::nextafter(c, T(-2.0));
+
+  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
+      a_c_are_almsot_equal("a_c_are_almsot_equal"),
+      a_d_are_almsot_equal_ulp1("a_d_are_almsot_equal_ulp1"),
+      a_d_are_almsot_equal_ulp2("a_d_are_almsot_equal_ulp2");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        // ULP diff 0 -> true
+        a_b_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
+
+        // ULP diff 1 -> true
+        a_c_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1);
+
+        // ULP diff 2 -> false if ulp_diff is 1 and true if ulp_diff is 2
+        a_d_are_almsot_equal_ulp1() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 1);
+        a_d_are_almsot_equal_ulp2() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, d, 2);
+      });
+
+  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almsot_equal);
+  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almsot_equal);
+  auto h_a_d_are_almsot_equal_ulp1 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp1);
+  auto h_a_d_are_almsot_equal_ulp2 = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_d_are_almsot_equal_ulp2);
+
+  ASSERT_TRUE(h_a_b_are_almsot_equal());
+  ASSERT_TRUE(h_a_c_are_almsot_equal());
+  if (std::is_same_v<T, Kokkos::Experimental::half_t> ||
+      std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+    // FIXME do not understand why this is satisfied
+    ASSERT_TRUE(h_a_d_are_almsot_equal_ulp1());
+  } else {
+    ASSERT_FALSE(h_a_d_are_almsot_equal_ulp1());
+  }
+  ASSERT_TRUE(h_a_d_are_almsot_equal_ulp2());
+}
+
+template <typename T, typename BoolViewType>
+void test_almost_equal_ulps_near_zero() {
+  T a(1.0e-40);
+  T b(-1.0e-40);
+  T c(0.0);
+  T d(-0.0);
+
+  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
+      c_d_are_almsot_equal("c_d_are_almsot_equal");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        // ULP diff should be big -> false
+        a_b_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 1);
+        // ULP diff should be 0 -> true (not sure this is a good behaviour)
+        c_d_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(c, d, 0);
+      });
+
+  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almsot_equal);
+  auto h_c_d_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, c_d_are_almsot_equal);
+
+  if (std::is_same_v<T, Kokkos::Experimental::half_t>) {
+    // FIXME do not understand why this is satisfied
+    ASSERT_TRUE(h_a_b_are_almsot_equal());
+  } else {
+    ASSERT_FALSE(h_a_b_are_almsot_equal());
+  }
+  ASSERT_TRUE(h_c_d_are_almsot_equal());
+}
+
+template <typename T, typename BoolViewType>
+void test_almost_equal_ulps_inf() {
+  T a = Kokkos::Experimental::infinity<T>::value;
+  T b = a;
+  // FIXME do not compile
+  // T c = -Kokkos::Experimental::infinity<T>::value;
+
+  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal");
+  //  a_c_are_almsot_equal("a_c_are_almsot_equal");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        // ULP diff should be 0 -> true
+        a_b_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
+        // They are always different -> false
+        // FIXME do not compile
+        // a_c_are_almsot_equal() =
+        //    KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1000000);
+      });
+
+  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almsot_equal);
+  // auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+  //     Kokkos::HostSpace{}, a_c_are_almsot_equal);
+
+  ASSERT_TRUE(h_a_b_are_almsot_equal());
+  // ASSERT_FALSE(h_a_c_are_almsot_equal());
+}
+
+template <typename T, typename BoolViewType>
+void test_almost_equal_ulps_nan() {
+  T a = Kokkos::Experimental::quiet_NaN<T>::value;
+  T b = a;
+  T c(1.0);
+
+  BoolViewType a_b_are_almsot_equal("a_b_are_almsot_equal"),
+      a_c_are_almsot_equal("a_c_are_almsot_equal");
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Kokkos::IndexType<int>>{0, 1},
+      KOKKOS_LAMBDA(int) {
+        // Nans are always different -> false
+        a_b_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, b, 0);
+        // Value and Nan are always different -> false
+        a_c_are_almsot_equal() =
+            KokkosFFT::Testing::Impl::almost_equal_ulps(a, c, 1000000);
+      });
+
+  auto h_a_b_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_b_are_almsot_equal);
+  auto h_a_c_are_almsot_equal = Kokkos::create_mirror_view_and_copy(
+      Kokkos::HostSpace{}, a_c_are_almsot_equal);
+
+  ASSERT_FALSE(h_a_b_are_almsot_equal());
+  ASSERT_FALSE(h_a_c_are_almsot_equal());
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestAlmostEqualUlps, float_types);
+
+TYPED_TEST(TestAlmostEqualUlps, PositiveNumbers) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_almost_equal_ulps_positive<float_type, BoolViewType>();
+}
+
+TYPED_TEST(TestAlmostEqualUlps, NegativeNumbers) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_almost_equal_ulps_negative<float_type, BoolViewType>();
+}
+
+TYPED_TEST(TestAlmostEqualUlps, NearZero) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_almost_equal_ulps_near_zero<float_type, BoolViewType>();
+}
+
+TYPED_TEST(TestAlmostEqualUlps, Infinity) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_almost_equal_ulps_inf<float_type, BoolViewType>();
+}
+
+TYPED_TEST(TestAlmostEqualUlps, Nan) {
+  using float_type   = typename TestFixture::float_type;
+  using BoolViewType = typename TestFixture::BoolViewType;
+  test_almost_equal_ulps_nan<float_type, BoolViewType>();
+}


### PR DESCRIPTION
This PR introduces a comparison operator for unit-testing.
Some companions of `half_t` and `bhalf_t` are suspicious. 
In addition, `T c = -Kokkos::Experimental::infinity<T>::value;` does not compile for `half_t` and `bhalf_t`.
Should we say that positive zero is not equal to negative zero?

- [x] Implement a function that checks whether two floating point values are close in terms of ulps
- [x] Unit tests for positive, negative, near-zeros, infinities and nans.

Edited on 28/April
- [x] Adding `nextafter` helper for `fp16`
- [x]  Issues on AMD GPUs. Looks like `fp16` is `float` there.

```
[ 77%] Building CXX object testing/unit_test/CMakeFiles/unit-tests-kokkos-fft-testing.dir/Test_AlmostEqualUlps.cpp.o
/work/testing/unit_test/Test_AlmostEqualUlps.cpp:44:29: error: no matching function for call to 'bit_cast'
  std::uint16_t uint_from = Kokkos::bit_cast<std::uint16_t>(from);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/work/testing/unit_test/Test_AlmostEqualUlps.cpp:102:12: note: in instantiation of function template specialization '(anonymous namespace)::nextafter_fp16<float>' requested here
    return nextafter_fp16<T>(from, to);
           ^
/work/testing/unit_test/Test_AlmostEqualUlps.cpp:303:3: note: in instantiation of function template specialization '(anonymous namespace)::test_almost_equal_ulps_positive<float, Kokkos::View<bool, Kokkos::HIP>>' requested here
  test_almost_equal_ulps_positive<float_type, BoolViewType>();
```

Edited on 30/April
It seems that `half_t` is a half type but `bhalf_t` is not. The following code can work on HIP backend.

```C++
static_assert(sizeof(Kokkos::Experimental::half_t) == 2);
static_assert(sizeof(Kokkos::Experimental::bhalf_t) == 4);
// On CUDA backend, the following compiles
//static_assert(sizeof(Kokkos::Experimental::bhalf_t) == 2);
```