### PR TITLE
Cartesian product of types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(KokkosFFT_ENABLE_EXAMPLES "Build KokkosFFT examples" OFF)
 option(KokkosFFT_ENABLE_TESTS "Build KokkosFFT tests" OFF)
 option(KokkosFFT_ENABLE_BENCHMARK "Build benchmarks for KokkosFFT" OFF)
 option(KokkosFFT_ENABLE_DOCS "Build KokkosFFT documentaion/website" OFF)
+option(KokkosFFT_ENABLE_TESTING_TOOLS "Enable unit-testing tools" OFF)
 
 # Version information
 set(KOKKOSFFT_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/testing/src/KokkosFFT_TypeCartesianProduct.hpp
+++ b/testing/src/KokkosFFT_TypeCartesianProduct.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_TYPE_CARTESIAN_PRODUCT_HPP
+#define KOKKOSFFT_TYPE_CARTESIAN_PRODUCT_HPP
+
+#include <tuple>
+#include <type_traits>
+
+namespace KokkosFFT {
+namespace Testing {
+namespace Impl {
+
+/// Transform a sequence S to a tuple:
+/// - a std::integer_sequence<T, Ints...> to a
+/// std::tuple<std::integral_constant<T, Ints>...>
+/// - a std::pair<T, U> to a std::tuple<T, U>
+/// - identity otherwise (std::tuple)
+template <class S>
+struct to_tuple {
+  using type = S;
+};
+
+template <class T, T... Ints>
+struct to_tuple<std::integer_sequence<T, Ints...>> {
+  using type = std::tuple<std::integral_constant<T, Ints>...>;
+};
+
+template <class T, class U>
+struct to_tuple<std::pair<T, U>> {
+  using type = std::tuple<T, U>;
+};
+
+template <class S>
+using to_tuple_t = typename to_tuple<S>::type;
+
+template <class TupleOfTuples, class Tuple>
+struct for_each_tuple_cat;
+
+template <class... Tuples, class Tuple>
+struct for_each_tuple_cat<std::tuple<Tuples...>, Tuple> {
+  using type = std::tuple<decltype(std::tuple_cat(
+      std::declval<Tuples>(), std::declval<std::tuple<Tuple>>()))...>;
+};
+
+template <class... Tuples, class Tuple>
+struct for_each_tuple_cat<std::tuple<Tuples...>, std::tuple<Tuple>> {
+  using type = std::tuple<decltype(std::tuple_cat(
+      std::declval<Tuples>(), std::declval<std::tuple<Tuple>>()))...>;
+};
+
+/// Construct a tuple of tuples that is the result of the concatenation of the
+/// tuples in TupleOfTuples with Tuple.
+template <class TupleOfTuples, class Tuple>
+using for_each_tuple_cat_t =
+    typename for_each_tuple_cat<TupleOfTuples, Tuple>::type;
+
+template <class InTupleOfTuples, class OutTupleOfTuples>
+struct cartesian_product_impl;
+
+template <class... HeadArgs, class... TailTuples, class OutTupleOfTuples>
+struct cartesian_product_impl<
+    std::tuple<std::tuple<HeadArgs...>, TailTuples...>, OutTupleOfTuples>
+    : cartesian_product_impl<
+          std::tuple<TailTuples...>,
+          decltype(std::tuple_cat(
+              std::declval<for_each_tuple_cat_t<OutTupleOfTuples,
+                                                std::tuple<HeadArgs>>>()...))> {
+};
+
+template <class OutTupleOfTuples>
+struct cartesian_product_impl<std::tuple<>, OutTupleOfTuples> {
+  using type = OutTupleOfTuples;
+};
+
+/// Generate a std::tuple cartesian product from multiple tuple-like structures
+/// (std::tuple, std::integer_sequence and std::pair) Do not rely on the
+/// ordering result.
+template <class... InTuplesLike>
+using cartesian_product_t =
+    typename cartesian_product_impl<std::tuple<to_tuple_t<InTuplesLike>...>,
+                                    std::tuple<std::tuple<>>>::type;
+
+/// Transform a std::tuple<Args...> to a testing::Types<Args...>, identity
+/// otherwise
+template <class T>
+struct tuple_to_types {
+  using type = T;
+};
+
+template <class... Args>
+struct tuple_to_types<std::tuple<Args...>> {
+  using type = testing::Types<Args...>;
+};
+
+template <class T>
+using tuple_to_types_t = typename tuple_to_types<T>::type;
+
+}  // namespace Impl
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_TypeCartesianProduct.hpp
+++ b/testing/src/KokkosFFT_TypeCartesianProduct.hpp
@@ -98,6 +98,12 @@ template <class T>
 using tuple_to_types_t = typename tuple_to_types<T>::type;
 
 }  // namespace Impl
+
+// API to generate caresian product of input types
+template <class... InTuplesLike>
+using make_cartesian_types =
+    Impl::tuple_to_types_t<Impl::cartesian_product_t<InTuplesLike...>>;
+
 }  // namespace Testing
 }  // namespace KokkosFFT
 

--- a/testing/src/KokkosFFT_TypeCartesianProduct.hpp
+++ b/testing/src/KokkosFFT_TypeCartesianProduct.hpp
@@ -35,30 +35,38 @@ struct to_tuple<std::pair<T, U>> {
 template <class S>
 using to_tuple_t = typename to_tuple<S>::type;
 
-template <class TupleOfTuples, class Tuple>
+template <class TupleOfTuples, class Type>
 struct for_each_tuple_cat;
 
-template <class... Tuples, class Tuple>
-struct for_each_tuple_cat<std::tuple<Tuples...>, Tuple> {
+template <class... Tuples, class Type>
+struct for_each_tuple_cat<std::tuple<Tuples...>, Type> {
   using type = std::tuple<decltype(std::tuple_cat(
-      std::declval<Tuples>(), std::declval<std::tuple<Tuple>>()))...>;
+      std::declval<Tuples>(), std::declval<std::tuple<Type>>()))...>;
 };
 
-template <class... Tuples, class Tuple>
-struct for_each_tuple_cat<std::tuple<Tuples...>, std::tuple<Tuple>> {
+template <class... Tuples, class Type>
+struct for_each_tuple_cat<std::tuple<Tuples...>, std::tuple<Type>> {
   using type = std::tuple<decltype(std::tuple_cat(
-      std::declval<Tuples>(), std::declval<std::tuple<Tuple>>()))...>;
+      std::declval<Tuples>(), std::declval<std::tuple<Type>>()))...>;
 };
 
 /// Construct a tuple of tuples that is the result of the concatenation of the
 /// tuples in TupleOfTuples with Tuple.
-template <class TupleOfTuples, class Tuple>
+template <class TupleOfTuples, class Type>
 using for_each_tuple_cat_t =
-    typename for_each_tuple_cat<TupleOfTuples, Tuple>::type;
+    typename for_each_tuple_cat<TupleOfTuples, Type>::type;
 
 template <class InTupleOfTuples, class OutTupleOfTuples>
 struct cartesian_product_impl;
 
+/// \brief Recursive case: The cartesian product is built in a recursive manner.
+/// Each time, each element of the tuple in std::tuple<HeardArgs...> is added to
+/// all the tuples in OutTupleOfTuples. Then the process is repeated with the
+/// next tuple that is present in TailTuples...
+///
+/// \tparam HeadArgs The types of the first tuple in the input tuple of tuples
+/// \tparam TailTuples The remaining tuples in the input tuple of tuples
+/// \tparam OutTupleOfTuples The output tuple of tuples
 template <class... HeadArgs, class... TailTuples, class OutTupleOfTuples>
 struct cartesian_product_impl<
     std::tuple<std::tuple<HeadArgs...>, TailTuples...>, OutTupleOfTuples>

--- a/testing/unit_test/CMakeLists.txt
+++ b/testing/unit_test/CMakeLists.txt
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreNotClose.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp)
+add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreNotClose.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp 
+Test_TypeCartesianProduct.cpp)
 
 target_compile_features(unit-tests-kokkos-fft-testing PUBLIC cxx_std_20)
 target_link_libraries(unit-tests-kokkos-fft-testing PUBLIC KokkosFFT::testing)

--- a/testing/unit_test/Test_TypeCartesianProduct.cpp
+++ b/testing/unit_test/Test_TypeCartesianProduct.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include "KokkosFFT_TypeCartesianProduct.hpp"
+
+// All the tests in this file are compile time tests, so we skip all the tests
+// by GTEST_SKIP(). gtest is used for type parameterization.
+
+namespace {
+using multiple_types = ::testing::Types<int, std::size_t, float, double>;
+
+// Define the types to combine
+using base_real_types = std::tuple<float, double, long double>;
+using base_int_types  = std::tuple<int, std::size_t, bool>;
+
+using multiple_tuple_types = ::testing::Types<base_real_types, base_int_types>;
+
+// Define fixtures
+template <typename T>
+struct CompileTestManipulateTuples : public ::testing::Test {
+  using value_type = T;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
+};
+
+template <typename T>
+struct CompileTestCartesianProduct : public ::testing::Test {
+  using tuple_type = T;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
+};
+
+// Tests for appending ValueType or std::tuple<ValueType> to
+// Input tuple type
+template <typename ValueType>
+void test_concat_tuple1D() {
+  using input_tuple_type = std::tuple<std::tuple<double, double>>;
+  using tuple_and_tuple_type =
+      KokkosFFT::Testing::Impl::for_each_tuple_cat_t<input_tuple_type,
+                                                     std::tuple<ValueType>>;
+  using tuple_and_value_type =
+      KokkosFFT::Testing::Impl::for_each_tuple_cat_t<input_tuple_type,
+                                                     ValueType>;
+  using reference_tuple_type =
+      std::tuple<std::tuple<double, double, ValueType>>;
+
+  testing::StaticAssertTypeEq<tuple_and_value_type, reference_tuple_type>();
+  testing::StaticAssertTypeEq<tuple_and_tuple_type, reference_tuple_type>();
+}
+
+// Tests for appending ValueType or std::tuple<ValueType> to
+// Input 2D tuple type
+template <typename ValueType>
+void test_concat_tuple2D() {
+  using input_tuple_type =
+      std::tuple<std::tuple<double, double>, std::tuple<int, double>>;
+  using tuple_and_tuple_type =
+      KokkosFFT::Testing::Impl::for_each_tuple_cat_t<input_tuple_type,
+                                                     std::tuple<ValueType>>;
+  using tuple_and_value_type =
+      KokkosFFT::Testing::Impl::for_each_tuple_cat_t<input_tuple_type,
+                                                     ValueType>;
+  using reference_tuple_type = std::tuple<std::tuple<double, double, ValueType>,
+                                          std::tuple<int, double, ValueType>>;
+
+  testing::StaticAssertTypeEq<tuple_and_value_type, reference_tuple_type>();
+  testing::StaticAssertTypeEq<tuple_and_tuple_type, reference_tuple_type>();
+}
+
+// Tests for transforming a std::tuple<Args...> to a testing::Types<Args...>,
+// identity otherwise
+template <typename ValueType>
+void test_to_testing_types() {
+  using from_value_type = KokkosFFT::Testing::Impl::tuple_to_types_t<ValueType>;
+  using from_tuple_type =
+      KokkosFFT::Testing::Impl::tuple_to_types_t<std::tuple<ValueType>>;
+  using from_multi_tuple_type =
+      KokkosFFT::Testing::Impl::tuple_to_types_t<std::tuple<int, ValueType>>;
+  using from_nested_tuple_type = KokkosFFT::Testing::Impl::tuple_to_types_t<
+      std::tuple<std::tuple<int>, std::tuple<ValueType>>>;
+  using reference_value_type       = ValueType;  // Do nothing on non-tuple type
+  using reference_tuple_type       = ::testing::Types<ValueType>;
+  using reference_multi_tuple_type = ::testing::Types<int, ValueType>;
+  using reference_nested_tuple_type =
+      ::testing::Types<std::tuple<int>, std::tuple<ValueType>>;
+
+  testing::StaticAssertTypeEq<from_value_type, reference_value_type>();
+  testing::StaticAssertTypeEq<from_tuple_type, reference_tuple_type>();
+  testing::StaticAssertTypeEq<from_multi_tuple_type,
+                              reference_multi_tuple_type>();
+  testing::StaticAssertTypeEq<from_nested_tuple_type,
+                              reference_nested_tuple_type>();
+}
+
+// Tests for getting a cartesian product of types
+// E.g.
+// std::tuple<float, double, long double> would be converted to
+// std::tuple< std::tuple<float>, std::tuple<double>, std::tuple<long double> >
+template <typename TupleType>
+void test_cartesian_product_of_tuple1D() {
+  using cartesian_product_type =
+      KokkosFFT::Testing::Impl::cartesian_product_t<TupleType>;
+  using T0 = std::tuple<typename std::tuple_element<0, TupleType>::type>;
+  using T1 = std::tuple<typename std::tuple_element<1, TupleType>::type>;
+  using T2 = std::tuple<typename std::tuple_element<2, TupleType>::type>;
+
+  using reference_tuple_type = std::tuple<T0, T1, T2>;
+
+  testing::StaticAssertTypeEq<cartesian_product_type, reference_tuple_type>();
+}
+
+// Tests for getting a cartesian product of types
+// E.g.
+// std::tuple<float, double, long double> && std::tuple<float, double, long
+// double> would be converted to std::tuple< std::tuple<float, float>,
+// std::tuple<double, float>, std::tuple<long double, float>,
+//             std::tuple<float, double>, std::tuple<double, double>,
+//             std::tuple<long double, double>, std::tuple<float, long double>,
+//             std::tuple<double, long double>, std::tuple<long double, long
+//             double>>
+template <typename TupleType1, typename TupleType2>
+void test_cartesian_product_of_tuple2D() {
+  using cartesian_product_type =
+      KokkosFFT::Testing::Impl::cartesian_product_t<TupleType1, TupleType2>;
+
+  // Analyze TupleType1
+  using T0_1 = typename std::tuple_element<0, TupleType1>::type;
+  using T1_1 = typename std::tuple_element<1, TupleType1>::type;
+  using T2_1 = typename std::tuple_element<2, TupleType1>::type;
+
+  // Analyze TupleType2
+  using T0_2 = typename std::tuple_element<0, TupleType2>::type;
+  using T1_2 = typename std::tuple_element<1, TupleType2>::type;
+  using T2_2 = typename std::tuple_element<2, TupleType2>::type;
+
+  using reference_tuple_type = std::tuple<
+      std::tuple<T0_1, T0_2>, std::tuple<T1_1, T0_2>, std::tuple<T2_1, T0_2>,
+      std::tuple<T0_1, T1_2>, std::tuple<T1_1, T1_2>, std::tuple<T2_1, T1_2>,
+      std::tuple<T0_1, T2_2>, std::tuple<T1_1, T2_2>, std::tuple<T2_1, T2_2>>;
+
+  testing::StaticAssertTypeEq<cartesian_product_type, reference_tuple_type>();
+}
+
+// Tests for getting a cartesian product of types
+// E.g.
+// std::tuple<float, double, long double> && std::tuple<float, double, long
+// double> would be converted to std::tuple< std::tuple<float, float, float>,
+// std::tuple<double, float, float>, std::tuple<long double, float, float>,
+//             ...
+template <typename TupleType1, typename TupleType2, typename TupleType3>
+void test_cartesian_product_of_tuple3D() {
+  using cartesian_product_type =
+      KokkosFFT::Testing::Impl::cartesian_product_t<TupleType1, TupleType2,
+                                                    TupleType3>;
+
+  // Analyze TupleType1
+  using T0_1 = typename std::tuple_element<0, TupleType1>::type;
+  using T1_1 = typename std::tuple_element<1, TupleType1>::type;
+  using T2_1 = typename std::tuple_element<2, TupleType1>::type;
+
+  // Analyze TupleType2
+  using T0_2 = typename std::tuple_element<0, TupleType2>::type;
+  using T1_2 = typename std::tuple_element<1, TupleType2>::type;
+  using T2_2 = typename std::tuple_element<2, TupleType2>::type;
+
+  // Analyze TupleType3
+  using T0_3 = typename std::tuple_element<0, TupleType3>::type;
+  using T1_3 = typename std::tuple_element<1, TupleType3>::type;
+  using T2_3 = typename std::tuple_element<2, TupleType3>::type;
+
+  using reference_tuple_type =
+      std::tuple<std::tuple<T0_1, T0_2, T0_3>, std::tuple<T1_1, T0_2, T0_3>,
+                 std::tuple<T2_1, T0_2, T0_3>, std::tuple<T0_1, T1_2, T0_3>,
+                 std::tuple<T1_1, T1_2, T0_3>, std::tuple<T2_1, T1_2, T0_3>,
+                 std::tuple<T0_1, T2_2, T0_3>, std::tuple<T1_1, T2_2, T0_3>,
+                 std::tuple<T2_1, T2_2, T0_3>, std::tuple<T0_1, T0_2, T1_3>,
+                 std::tuple<T1_1, T0_2, T1_3>, std::tuple<T2_1, T0_2, T1_3>,
+                 std::tuple<T0_1, T1_2, T1_3>, std::tuple<T1_1, T1_2, T1_3>,
+                 std::tuple<T2_1, T1_2, T1_3>, std::tuple<T0_1, T2_2, T1_3>,
+                 std::tuple<T1_1, T2_2, T1_3>, std::tuple<T2_1, T2_2, T1_3>,
+                 std::tuple<T0_1, T0_2, T2_3>, std::tuple<T1_1, T0_2, T2_3>,
+                 std::tuple<T2_1, T0_2, T2_3>, std::tuple<T0_1, T1_2, T2_3>,
+                 std::tuple<T1_1, T1_2, T2_3>, std::tuple<T2_1, T1_2, T2_3>,
+                 std::tuple<T0_1, T2_2, T2_3>, std::tuple<T1_1, T2_2, T2_3>,
+                 std::tuple<T2_1, T2_2, T2_3>>;
+
+  testing::StaticAssertTypeEq<cartesian_product_type, reference_tuple_type>();
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(CompileTestManipulateTuples, multiple_types);
+TYPED_TEST_SUITE(CompileTestCartesianProduct, multiple_tuple_types);
+
+TYPED_TEST(CompileTestManipulateTuples, ConcatTuple1D) {
+  using value_type = typename TestFixture::value_type;
+  test_concat_tuple1D<value_type>();
+}
+
+TYPED_TEST(CompileTestManipulateTuples, ConcatTuple2D) {
+  using value_type = typename TestFixture::value_type;
+  test_concat_tuple2D<value_type>();
+}
+
+TYPED_TEST(CompileTestManipulateTuples, ToTestingTypes) {
+  using value_type = typename TestFixture::value_type;
+  test_to_testing_types<value_type>();
+}
+
+TYPED_TEST(CompileTestCartesianProduct, Tuple1D) {
+  using tuple_type = typename TestFixture::tuple_type;
+  test_cartesian_product_of_tuple1D<tuple_type>();
+}
+
+TYPED_TEST(CompileTestCartesianProduct, Tuple2D) {
+  using tuple_type = typename TestFixture::tuple_type;
+  test_cartesian_product_of_tuple2D<tuple_type, tuple_type>();
+}
+
+TYPED_TEST(CompileTestCartesianProduct, Tuple3D) {
+  using tuple_type = typename TestFixture::tuple_type;
+  test_cartesian_product_of_tuple3D<tuple_type, tuple_type, tuple_type>();
+}


### PR DESCRIPTION
This PR aims at introducing an API to generate cartesian product of types which originally developed for [DDC](https://github.com/CExA-project/ddc). For example, the following types are identical. This helper is used for [TYPED_TEST](https://github.com/google/googletest/blob/main/docs/advanced.md#typed-tests).

```C++
using cartesian_product_type =
       KokkosFFT::Testing::make_cartesian_types<std::tuple<float, double>, std::tuple<float, double>>;

using reference_type = testing::Types<std::tuple<float, float>, std::tuple<double, float>,
                      std::tuple<float, double>, std::tuple<double, double>;
```

- [x] Introduce an API `make_cartesian_types` to generate cartesian product of types
- [x] Compile time unit-tests for type generators