### PR TITLE
Build CUDA backend with cxx20 in CI and enable testing-tools

### DIFF
--- a/.github/workflows/build_nightly.yaml
+++ b/.github/workflows/build_nightly.yaml
@@ -43,7 +43,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
           - name: serial
             image: gcc
             compiler:
@@ -59,9 +59,9 @@ jobs:
               c: gcc
               cxx: g++
             cmake_flags:
-              cxx_standard: 17
+              cxx_standard: 20
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
           - name: hip
             image: rocm
             compiler:
@@ -79,7 +79,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
           - name: sycl
             image: intel
             compiler:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -97,9 +97,9 @@ jobs:
               c: gcc
               cxx: g++
             cmake_flags:
-              cxx_standard: 17
+              cxx_standard: 20
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
               benchmark: ON
             cmake_build_type: Release
           - name: hip


### PR DESCRIPTION
Use `cxx20` to build with CUDA backend and enable testing-tools in CI.