### PR TITLE
Suppress disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ x_hat = np.fft.rfft(x, axis=-1)
 
 In this example, the 1D batched `rfft` over 2D View along `axis -1` is executed. Some basic examples are found in [examples](examples).
 
-## Disclaimer
-**kokkos-fft is under development and subject to change without warning. The authors do not guarantee that this code runs correctly in all the environments.**
-
 ## Using kokkos-fft
 For the moment, there are two ways to use kokkos-fft: including as a subdirectory in CMake project or installing as a library. First of all, you need to clone this repo.
 ```bash


### PR DESCRIPTION
After v0.3.0, we secure the current APIs and thus no longer change APIs without deprecated warnings. 