### PR TITLE
Improve almost_equal comparison operator

### DIFF
--- a/testing/src/KokkosFFT_AlmostEqual.hpp
+++ b/testing/src/KokkosFFT_AlmostEqual.hpp
@@ -14,7 +14,11 @@ namespace Impl {
 template <typename ScalarA, typename ScalarB, typename ScalarTol>
 KOKKOS_INLINE_FUNCTION bool are_almost_equal(ScalarA a, ScalarB b,
                                              ScalarTol rtol, ScalarTol atol) {
-  return Kokkos::abs(a - b) <= (atol + rtol * Kokkos::abs(b));
+  auto abs_diff = Kokkos::abs(a - b);
+  if (abs_diff <= atol) return true;
+
+  // b is a reference
+  return abs_diff <= rtol * Kokkos::abs(b);
 }
 
 template <typename ScalarTol>


### PR DESCRIPTION
This PR improves the comparison operator with relative and absolute tolerance. 
As pointed out by @cedricchevalier19, adding the two tolerances is not a good idea.
In the new implementation, these tolerances are tested separately.
See also https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/