### PR TITLE
Almost equal nulp

### DIFF
--- a/testing/src/KokkosFFT_Allclose.hpp
+++ b/testing/src/KokkosFFT_Allclose.hpp
@@ -24,14 +24,15 @@ namespace Impl {
 /// \tparam AViewType The type of the first Kokkos view.
 /// \tparam BViewType The type of the second Kokkos view.
 ///
-/// \param listener [out] The testing match result listener.
-/// \param actual [in] The actual Kokkos view.
-/// \param expected [in] The expected (reference) Kokkos view.
-/// \param rtol [in]  Relative tolerance for comparing the view elements
+/// \param[out] listener The testing match result listener.
+/// \param[in] actual The actual Kokkos view.
+/// \param[in] expected The expected (reference) Kokkos view.
+/// \param[in] rtol Relative tolerance for comparing the view elements
 /// (default 1.e-5).
-/// \param atol [in] Absolute tolerance for comparing the view elements
+/// \param[in] atol Absolute tolerance for comparing the view elements
 /// (default 1.e-8).
-/// \param verbose [in] How many elements to be reported (default: 3)
+/// \param[in] max_displayed_errors How many elements to be reported
+/// (default: 3)
 template <KokkosView AViewType, KokkosView BViewType>
   requires(std::is_same_v<typename AViewType::execution_space,
                           typename BViewType::execution_space> &&
@@ -40,7 +41,8 @@ template <KokkosView AViewType, KokkosView BViewType>
            (AViewType::rank() == BViewType::rank()))
 inline bool allclose_impl(testing::MatchResultListener* listener,
                           const AViewType& actual, const BViewType& expected,
-                          double rtol, double atol, std::size_t verbose) {
+                          double rtol, double atol,
+                          std::size_t max_displayed_errors) {
   const std::size_t rank = actual.rank();
   for (std::size_t i = 0; i < rank; i++) {
     if (actual.extent(i) != expected.extent(i)) {
@@ -62,8 +64,8 @@ inline bool allclose_impl(testing::MatchResultListener* listener,
       exec_space, actual, expected, errors, op);
 
   exec_space.fence();
-  auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error, verbose);
+  auto error_map = KokkosFFT::Testing::Impl::sort_errors(
+      a_val, e_val, loc_error, max_displayed_errors);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *listener << error_str;
@@ -71,9 +73,9 @@ inline bool allclose_impl(testing::MatchResultListener* listener,
 }
 }  // namespace Impl
 
-MATCHER_P4(allclose, expected, rtol, atol, verbose, "") {
+MATCHER_P4(allclose, expected, rtol, atol, max_displayed_errors, "") {
   return Impl::allclose_impl(result_listener, arg, expected, rtol, atol,
-                             verbose);
+                             max_displayed_errors);
 }
 
 MATCHER_P3(allclose, expected, rtol, atol, "") {

--- a/testing/src/KokkosFFT_AlmostEqualNulp.hpp
+++ b/testing/src/KokkosFFT_AlmostEqualNulp.hpp
@@ -29,7 +29,8 @@ namespace Impl {
 /// \param[in] expected The expected (reference) Kokkos view.
 /// \param[in] nulp The maximum allowed difference in ULPs for the
 /// numbers to be considered equal
-/// \param [in] verbose How many elements to be reported (default: 3)
+/// \param [in] max_displayed_errors How many elements to be reported
+/// (default: 3)
 template <KokkosView AViewType, KokkosView BViewType>
   requires(std::is_same_v<typename AViewType::execution_space,
                           typename BViewType::execution_space> &&
@@ -39,7 +40,7 @@ template <KokkosView AViewType, KokkosView BViewType>
 inline bool almost_equal_nulp_impl(testing::MatchResultListener* listener,
                                    const AViewType& actual,
                                    const BViewType& expected, std::size_t nulp,
-                                   std::size_t verbose) {
+                                   std::size_t max_displayed_errors) {
   const std::size_t rank = actual.rank();
   for (std::size_t i = 0; i < rank; i++) {
     if (actual.extent(i) != expected.extent(i)) {
@@ -61,8 +62,8 @@ inline bool almost_equal_nulp_impl(testing::MatchResultListener* listener,
       exec_space, actual, expected, errors, op);
 
   exec_space.fence();
-  auto error_map =
-      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error, verbose);
+  auto error_map = KokkosFFT::Testing::Impl::sort_errors(
+      a_val, e_val, loc_error, max_displayed_errors);
   std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
 
   *listener << error_str;
@@ -70,9 +71,9 @@ inline bool almost_equal_nulp_impl(testing::MatchResultListener* listener,
 }
 }  // namespace Impl
 
-MATCHER_P3(almost_equal_nulp, expected, nulp, verbose, "") {
+MATCHER_P3(almost_equal_nulp, expected, nulp, max_displayed_errors, "") {
   return Impl::almost_equal_nulp_impl(result_listener, arg, expected, nulp,
-                                      verbose);
+                                      max_displayed_errors);
 }
 
 MATCHER_P2(almost_equal_nulp, expected, nulp, "") {

--- a/testing/src/KokkosFFT_AlmostEqualNulp.hpp
+++ b/testing/src/KokkosFFT_AlmostEqualNulp.hpp
@@ -29,7 +29,7 @@ namespace Impl {
 /// \param[in] expected The expected (reference) Kokkos view.
 /// \param[in] nulp The maximum allowed difference in ULPs for the
 /// numbers to be considered equal
-/// \param [in] max_displayed_errors How many elements to be reported
+/// \param[in] max_displayed_errors How many elements to be reported
 /// (default: 3)
 template <KokkosView AViewType, KokkosView BViewType>
   requires(std::is_same_v<typename AViewType::execution_space,

--- a/testing/src/KokkosFFT_AlmostEqualNulp.hpp
+++ b/testing/src/KokkosFFT_AlmostEqualNulp.hpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_ALMOST_EQUAL_NULP_HPP
+#define KOKKOSFFT_ALMOST_EQUAL_NULP_HPP
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Concepts.hpp"
+#include "KokkosFFT_Ulps.hpp"
+#include "KokkosFFT_CountErrors.hpp"
+#include "KokkosFFT_PrintErrors.hpp"
+
+namespace KokkosFFT {
+namespace Testing {
+namespace Impl {
+/// \brief Compares two Kokkos views element-wise and checks if they are close
+///        within specified n units in the last place (ULPs).
+///        AViewType and BViewType must have the same rank,
+///        non_const_value_type, and execution_space;
+///
+/// \tparam AViewType The type of the first Kokkos view.
+/// \tparam BViewType The type of the second Kokkos view.
+///
+/// \param[out] listener The testing match result listener.
+/// \param[in] actual The actual Kokkos view.
+/// \param[in] expected The expected (reference) Kokkos view.
+/// \param[in] nulp The maximum allowed difference in ULPs for the
+/// numbers to be considered equal
+/// \param [in] verbose How many elements to be reported (default: 3)
+template <KokkosView AViewType, KokkosView BViewType>
+  requires(std::is_same_v<typename AViewType::execution_space,
+                          typename BViewType::execution_space> &&
+           std::is_same_v<typename AViewType::non_const_value_type,
+                          typename BViewType::non_const_value_type> &&
+           (AViewType::rank() == BViewType::rank()))
+inline bool almost_equal_nulp_impl(testing::MatchResultListener* listener,
+                                   const AViewType& actual,
+                                   const BViewType& expected, std::size_t nulp,
+                                   std::size_t verbose) {
+  const std::size_t rank = actual.rank();
+  for (std::size_t i = 0; i < rank; i++) {
+    if (actual.extent(i) != expected.extent(i)) {
+      *listener << actual.label() << ".extent(" << i
+                << ") != " << expected.label() << ".extent(" << i << ")";
+      return false;
+    }
+  }
+  using ExecutionSpace = typename AViewType::execution_space;
+  ExecutionSpace exec_space;
+
+  KokkosFFT::Testing::Impl::UlpsComparisonOp op(nulp);
+
+  std::size_t errors =
+      KokkosFFT::Testing::Impl::count_errors(exec_space, actual, expected, op);
+  if (errors == 0) return true;
+
+  auto [a_val, e_val, loc_error] = KokkosFFT::Testing::Impl::find_errors(
+      exec_space, actual, expected, errors, op);
+
+  exec_space.fence();
+  auto error_map =
+      KokkosFFT::Testing::Impl::sort_errors(a_val, e_val, loc_error, verbose);
+  std::string error_str = KokkosFFT::Testing::Impl::print_errors(error_map);
+
+  *listener << error_str;
+  return false;
+}
+}  // namespace Impl
+
+MATCHER_P3(almost_equal_nulp, expected, nulp, verbose, "") {
+  return Impl::almost_equal_nulp_impl(result_listener, arg, expected, nulp,
+                                      verbose);
+}
+
+MATCHER_P2(almost_equal_nulp, expected, nulp, "") {
+  return Impl::almost_equal_nulp_impl(result_listener, arg, expected, nulp, 3);
+}
+
+MATCHER_P(almost_equal_nulp, expected, "") {
+  return Impl::almost_equal_nulp_impl(result_listener, arg, expected, 1, 3);
+}
+
+}  // namespace Testing
+}  // namespace KokkosFFT
+
+#endif

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -30,13 +30,15 @@ namespace Impl {
 /// the second data set.
 /// \tparam CountViewType The type of the Kokkos view storing index information
 /// for each error.
-/// \param a_error [in] A Kokkos view containing error values from the first
+///
+/// \param[in] a_error A Kokkos view containing error values from the first
 /// set.
-/// \param b_error [in] A Kokkos view containing error values from the second
+/// \param[in] b_error A Kokkos view containing error values from the second
 /// set.
-/// \param loc_error [in] A Kokkos view containing index/location information
+/// \param[in] loc_error A Kokkos view containing index/location information
 /// for each error.
-/// \param verbose [in] How many elements to be returned (default: 3)
+/// \param[in] max_displayed_errors How many elements to be returned
+/// (default: 3)
 /// \return A std::map where the key is the global index and the value is a
 /// tuple consisting of a vector of additional indices, the corresponding error
 /// value from the first view, and the error value from the second view.
@@ -44,7 +46,7 @@ template <typename AErrorViewType, typename BErrorViewType,
           typename CountViewType>
 auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
                  const CountViewType &loc_error,
-                 const std::size_t verbose = 3) {
+                 const std::size_t max_displayed_errors = 3) {
   // Key: global idx
   // Value: tuple (vector of error idx, a, b)
   using a_value_type     = typename AErrorViewType::non_const_value_type;
@@ -62,11 +64,12 @@ auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
 
   using error_map_type = std::map<iType, error_value_type>;
   error_map_type error_map;
-  const std::size_t nb_errors         = h_a_error.extent(0);
-  const std::size_t nb_errors_verbose = std::min(nb_errors, verbose);
-  const std::size_t rank              = h_loc_error.extent(1);
+  const std::size_t nb_errors = h_a_error.extent(0);
+  const std::size_t nb_errors_displayed =
+      std::min(nb_errors, max_displayed_errors);
+  const std::size_t rank = h_loc_error.extent(1);
 
-  for (std::size_t err = 0; err < nb_errors_verbose; ++err) {
+  for (std::size_t err = 0; err < nb_errors_displayed; ++err) {
     iType global_idx = h_loc_error(err, 0);  // global idx -> key
 
     coord_type loc;
@@ -87,10 +90,10 @@ auto sort_errors(const AErrorViewType &a_error, const BErrorViewType &b_error,
 /// actual and expected error values and their difference.
 ///
 /// \tparam ErrorMapType The type of the error map containing error information.
-/// \param error_map [in] A constant reference to a map that stores error
+/// \param[in] error_map A constant reference to a map that stores error
 /// details.
-/// \param labelA [in] A label for the first error value (default is "actual").
-/// \param labelB [in] A label for the second error value (default is
+/// \param[in] labelA A label for the first error value (default is "actual").
+/// \param[in] labelB A label for the second error value (default is
 /// "expected").
 /// \return A std::string containing the formatted error report.
 template <typename ErrorMapType>

--- a/testing/src/KokkosFFT_PrintErrors.hpp
+++ b/testing/src/KokkosFFT_PrintErrors.hpp
@@ -111,7 +111,7 @@ auto print_errors(const ErrorMapType &error_map,
     const auto &a   = std::get<1>(error.second);
     const auto &b   = std::get<2>(error.second);
 
-    auto diff = std::fabs(a - b);
+    auto diff = Kokkos::fabs(a - b);
 
     ss << "  Index (";
     for (std::size_t i = 0; i < loc.size(); ++i) {

--- a/testing/unit_test/CMakeLists.txt
+++ b/testing/unit_test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 add_executable(unit-tests-kokkos-fft-testing Test_Main.cpp Test_AreClose.cpp Test_AlmostEqualUlps.cpp Test_CountErrors.cpp Test_FindErrors.cpp Test_PrintErrors.cpp Test_Allclose.cpp
-Test_TypeCartesianProduct.cpp)
+Test_TypeCartesianProduct.cpp Test_AlmostEqualNulp.cpp)
 
 target_compile_features(unit-tests-kokkos-fft-testing PUBLIC cxx_std_20)
 target_link_libraries(unit-tests-kokkos-fft-testing PUBLIC KokkosFFT::testing)

--- a/testing/unit_test/Test_AlmostEqualNulp.cpp
+++ b/testing/unit_test/Test_AlmostEqualNulp.cpp
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_AlmostEqualNulp.hpp"
+#include "Test_Utils.hpp"
+
+namespace {
+using execution_space = Kokkos::DefaultExecutionSpace;
+using float_types =
+    ::testing::Types<Kokkos::Experimental::half_t,
+                     Kokkos::Experimental::bhalf_t, float, double>;
+
+template <typename T>
+struct TestAlmostEqualNulp : public ::testing::Test {
+  using float_type = T;
+};
+
+template <typename T>
+void test_almost_equal_nulp_1D_analytical() {
+  using View1DType = Kokkos::View<T*>;
+  const int n      = 3;
+  View1DType a("a", n), b("b", n), c("c", n), d("d", n);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1) = nextafter_wrapper(h_b(1), T(2.0));
+  h_d(1) = nextafter_wrapper(h_c(1), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_2D_analytical() {
+  using View2DType = Kokkos::View<T**>;
+  const int n0 = 3, n1 = 2;
+  View2DType a("a", n0, n1), b("b", n0, n1), c("c", n0, n1), d("d", n0, n1);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0) = nextafter_wrapper(h_b(1, 0), T(2.0));
+  h_d(0, 0) = nextafter_wrapper(h_b(0, 0), T(2.0));
+  h_d(1, 0) = nextafter_wrapper(h_c(1, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_3D_analytical() {
+  using View3DType = Kokkos::View<T***>;
+  const int n0 = 3, n1 = 2, n2 = 4;
+  View3DType a("a", n0, n1, n2), b("b", n0, n1, n2), c("c", n0, n1, n2),
+      d("d", n0, n1, n2);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0, 0) = nextafter_wrapper(h_b(1, 0, 0), T(2.0));
+  h_d(0, 0, 0) = nextafter_wrapper(h_b(0, 0, 0), T(2.0));
+  h_d(1, 0, 0) = nextafter_wrapper(h_c(1, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_4D_analytical() {
+  using View4DType = Kokkos::View<T****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5;
+  View4DType a("a", n0, n1, n2, n3), b("b", n0, n1, n2, n3),
+      c("c", n0, n1, n2, n3), d("d", n0, n1, n2, n3);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+  ;
+
+  h_c(1, 0, 0, 0) = nextafter_wrapper(h_b(1, 0, 0, 0), T(2.0));
+  h_d(0, 0, 0, 0) = nextafter_wrapper(h_b(0, 0, 0, 0), T(2.0));
+  h_d(1, 0, 2, 0) = nextafter_wrapper(h_c(1, 0, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_5D_analytical() {
+  using View5DType = Kokkos::View<T*****>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6;
+  View5DType a("a", n0, n1, n2, n3, n4), b("b", n0, n1, n2, n3, n4),
+      c("c", n0, n1, n2, n3, n4), d("d", n0, n1, n2, n3, n4);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0, 0, 0, 0) = nextafter_wrapper(h_b(1, 0, 0, 0, 0), T(2.0));
+  h_d(0, 0, 0, 0, 0) = nextafter_wrapper(h_b(0, 0, 0, 0, 0), T(2.0));
+  h_d(1, 0, 2, 0, 0) = nextafter_wrapper(h_c(1, 0, 0, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_6D_analytical() {
+  using View6DType = Kokkos::View<T******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3;
+  View6DType a("a", n0, n1, n2, n3, n4, n5), b("b", n0, n1, n2, n3, n4, n5),
+      c("c", n0, n1, n2, n3, n4, n5), d("d", n0, n1, n2, n3, n4, n5);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0, 0, 0, 0, 0) = nextafter_wrapper(h_b(1, 0, 0, 0, 0, 0), T(2.0));
+  h_d(0, 0, 0, 0, 0, 0) = nextafter_wrapper(h_b(0, 0, 0, 0, 0, 0), T(2.0));
+  h_d(1, 0, 2, 0, 0, 1) = nextafter_wrapper(h_c(1, 0, 0, 0, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_7D_analytical() {
+  using View7DType = Kokkos::View<T*******>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3;
+  View7DType a("a", n0, n1, n2, n3, n4, n5, n6),
+      b("b", n0, n1, n2, n3, n4, n5, n6), c("c", n0, n1, n2, n3, n4, n5, n6),
+      d("d", n0, n1, n2, n3, n4, n5, n6);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0, 0, 0, 0, 0, 0) =
+      nextafter_wrapper(h_b(1, 0, 0, 0, 0, 0, 0), T(2.0));
+  h_d(0, 0, 0, 0, 0, 0, 0) =
+      nextafter_wrapper(h_b(0, 0, 0, 0, 0, 0, 0), T(2.0));
+  h_d(1, 0, 2, 0, 0, 1, 2) =
+      nextafter_wrapper(h_c(1, 0, 0, 0, 0, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+template <typename T>
+void test_almost_equal_nulp_8D_analytical() {
+  using View8DType = Kokkos::View<T********>;
+  const int n0 = 3, n1 = 2, n2 = 4, n3 = 5, n4 = 6, n5 = 3, n6 = 3, n7 = 7;
+  View8DType a("a", n0, n1, n2, n3, n4, n5, n6, n7),
+      b("b", n0, n1, n2, n3, n4, n5, n6, n7),
+      c("c", n0, n1, n2, n3, n4, n5, n6, n7),
+      d("d", n0, n1, n2, n3, n4, n5, n6, n7);
+
+  Kokkos::deep_copy(a, T(1.0));
+  Kokkos::deep_copy(b, a);
+  Kokkos::deep_copy(c, a);
+  Kokkos::deep_copy(d, a);
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), c);
+  auto h_d = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d);
+
+  h_c(1, 0, 0, 0, 0, 0, 0, 0) =
+      nextafter_wrapper(h_b(1, 0, 0, 0, 0, 0, 0, 0), T(2.0));
+  h_d(0, 0, 0, 0, 0, 0, 0, 0) =
+      nextafter_wrapper(h_b(0, 0, 0, 0, 0, 0, 0, 0), T(2.0));
+  h_d(1, 0, 2, 0, 0, 1, 2, 0) =
+      nextafter_wrapper(h_c(1, 0, 0, 0, 0, 0, 0, 0), T(2.0));
+
+  Kokkos::deep_copy(c, h_c);
+  Kokkos::deep_copy(d, h_d);
+
+  // 0 ULP diff -> error count 0
+  EXPECT_THAT(b, KokkosFFT::Testing::almost_equal_nulp(a, 0));
+
+  // 1 ULP diff -> error count 0
+  EXPECT_THAT(c, KokkosFFT::Testing::almost_equal_nulp(a));
+
+  // 1 ULP diff + 2 ULP diff -> error count 1
+  EXPECT_THAT(d, ::testing::Not(KokkosFFT::Testing::almost_equal_nulp(a, 1)));
+
+  // 1 ULP diff + 2 ULP diff -> error count 0
+  EXPECT_THAT(d, KokkosFFT::Testing::almost_equal_nulp(a, 2, 3));
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestAlmostEqualNulp, float_types);
+
+TYPED_TEST(TestAlmostEqualNulp, View1D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_1D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View2D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_2D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View3D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_3D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View4D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_4D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View5D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_5D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View6D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_6D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View7D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_7D_analytical<float_type>();
+}
+
+TYPED_TEST(TestAlmostEqualNulp, View8D) {
+  using float_type = typename TestFixture::float_type;
+  test_almost_equal_nulp_8D_analytical<float_type>();
+}

--- a/testing/unit_test/Test_AlmostEqualUlps.cpp
+++ b/testing/unit_test/Test_AlmostEqualUlps.cpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Half.hpp>
 #include "KokkosFFT_Ulps.hpp"
+#include "Test_Utils.hpp"
 
 namespace {
 using execution_space = Kokkos::DefaultExecutionSpace;
@@ -18,94 +19,6 @@ struct TestAlmostEqualUlps : public ::testing::Test {
   using float_type   = T;
   using BoolViewType = Kokkos::View<bool, execution_space>;
 };
-
-// Helper function for nextafter on fp16 types
-template <typename fp16_t>
-  requires((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
-            std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>) &&
-           sizeof(fp16_t) == 2)
-fp16_t nextafter_fp16(fp16_t from, fp16_t to) {
-  constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
-  constexpr std::uint16_t FP16_SMALLEST_POS_DN =
-      0x0001;  // Smallest positive denormal
-  constexpr std::uint16_t FP16_SMALLEST_NEG_DN =
-      0x8001;  // Smallest negative denormal (magnitude)
-
-  // Handle Nans
-  if (Kokkos::isnan(from) || Kokkos::isnan(to)) {
-    return Kokkos::Experimental::quiet_NaN<fp16_t>::value;
-  }
-
-  // Handle equality
-  if (from == to) return to;
-
-  // Get unsigned integer representation of from
-  std::uint16_t uint_from = Kokkos::bit_cast<std::uint16_t>(from);
-
-  // Handle zeros
-  if (from == fp16_t(0)) {
-    // from is +0.0 or -0.0
-    // Return smallest magnitude number with the sign of 'to'.
-    // nextafter(±0, negative) -> smallest_negative
-    // nextafter(±0, positive) -> smallest_positive
-    return Kokkos::bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
-                                                : FP16_SMALLEST_NEG_DN);
-  }
-
-  // Determine direction and sign of 'from'
-  // True if moving to positive infinity
-  bool to_positive_infinity = (to > from);
-  bool from_is_negative     = (uint_from & FP16_SIGN_MASK);
-
-  std::uint16_t uint_result =
-      uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;
-  // This is equivalent to the following operations.
-  // std::uint16_t uint_result;
-  //
-  // if (from_is_negative) {
-  //  // For negative numbers, increasing magnitude means moving towards -inf
-  //  // (larger uint value) Decreasing magnitude means moving towards zero
-  //  // (smaller uint value)
-  //  if (to_positive_infinity) {
-  //    // Moving toward zero or positive
-  //    uint_result = uint_from - 1;
-  //  } else {
-  //    // Moving toward negative infinity
-  //    uint_result = uint_from + 1;
-  //  }
-  //} else {
-  //  // For positive numbers, increasing magnitude means moving towards +inf
-  //  // (larger uint value) Decreasing magnitude means moving towards zero
-  //  // (smaller uint value)
-  //  if (to_positive_infinity) {
-  //    // Moving toward positive infinity
-  //    uint_result = uint_from + 1;
-  //  } else {
-  //    // Moving toward zero or negative infinity
-  //    uint_result = uint_from - 1;
-  //  }
-  //}
-  return Kokkos::bit_cast<fp16_t>(uint_result);
-}
-
-template <typename T>
-auto nextafter_wrapper(T from, T to) {
-  if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t>) {
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-    return nextafter_fp16<T>(from, to);
-#else
-    return Kokkos::nextafter(from, to);
-#endif
-  } else if constexpr (std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-    return nextafter_fp16<T>(from, to);
-#else
-    return Kokkos::nextafter(from, to);
-#endif
-  } else {
-    return Kokkos::nextafter(from, to);
-  }
-}
 
 template <typename T, typename BoolViewType>
 void test_almost_equal_ulps_positive() {

--- a/testing/unit_test/Test_Utils.hpp
+++ b/testing/unit_test/Test_Utils.hpp
@@ -1,0 +1,95 @@
+#ifndef TEST_UTILS_HPP
+#define TEST_UTILS_HPP
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Half.hpp>
+
+// Helper function for nextafter on fp16 types
+template <typename fp16_t>
+  requires((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
+            std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>) &&
+           sizeof(fp16_t) == 2)
+fp16_t nextafter_fp16(fp16_t from, fp16_t to) {
+  constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
+  constexpr std::uint16_t FP16_SMALLEST_POS_DN =
+      0x0001;  // Smallest positive denormal
+  constexpr std::uint16_t FP16_SMALLEST_NEG_DN =
+      0x8001;  // Smallest negative denormal (magnitude)
+
+  // Handle Nans
+  if (Kokkos::isnan(from) || Kokkos::isnan(to)) {
+    return Kokkos::Experimental::quiet_NaN<fp16_t>::value;
+  }
+
+  // Handle equality
+  if (from == to) return to;
+
+  // Get unsigned integer representation of from
+  std::uint16_t uint_from = Kokkos::bit_cast<std::uint16_t>(from);
+
+  // Handle zeros
+  if (from == fp16_t(0)) {
+    // from is +0.0 or -0.0
+    // Return smallest magnitude number with the sign of 'to'.
+    // nextafter(±0, negative) -> smallest_negative
+    // nextafter(±0, positive) -> smallest_positive
+    return Kokkos::bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+                                                : FP16_SMALLEST_NEG_DN);
+  }
+
+  // Determine direction and sign of 'from'
+  // True if moving to positive infinity
+  bool to_positive_infinity = (to > from);
+  bool from_is_negative     = (uint_from & FP16_SIGN_MASK);
+
+  std::uint16_t uint_result =
+      uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;
+  // This is equivalent to the following operations.
+  // std::uint16_t uint_result;
+  //
+  // if (from_is_negative) {
+  //  // For negative numbers, increasing magnitude means moving towards -inf
+  //  // (larger uint value) Decreasing magnitude means moving towards zero
+  //  // (smaller uint value)
+  //  if (to_positive_infinity) {
+  //    // Moving toward zero or positive
+  //    uint_result = uint_from - 1;
+  //  } else {
+  //    // Moving toward negative infinity
+  //    uint_result = uint_from + 1;
+  //  }
+  //} else {
+  //  // For positive numbers, increasing magnitude means moving towards +inf
+  //  // (larger uint value) Decreasing magnitude means moving towards zero
+  //  // (smaller uint value)
+  //  if (to_positive_infinity) {
+  //    // Moving toward positive infinity
+  //    uint_result = uint_from + 1;
+  //  } else {
+  //    // Moving toward zero or negative infinity
+  //    uint_result = uint_from - 1;
+  //  }
+  //}
+  return Kokkos::bit_cast<fp16_t>(uint_result);
+}
+
+template <typename T>
+auto nextafter_wrapper(T from, T to) {
+  if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t>) {
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+    return nextafter_fp16<T>(from, to);
+#else
+    return Kokkos::nextafter(from, to);
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+    return nextafter_fp16<T>(from, to);
+#else
+    return Kokkos::nextafter(from, to);
+#endif
+  } else {
+    return Kokkos::nextafter(from, to);
+  }
+}
+
+#endif

--- a/testing/unit_test/Test_Utils.hpp
+++ b/testing/unit_test/Test_Utils.hpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 #ifndef TEST_UTILS_HPP
 #define TEST_UTILS_HPP
 


### PR DESCRIPTION
This PR aims at introducing a View-to-View matcher based on ulps comparison. 
Following changes are made

- [x] Use `Kokkos::fabs` instead of std::fabs to manipulate `Kokkos::half_t`
- [x] Moving `nextafter_wrapper` into `Test_Utils.hpp`
- [x] Introduce a `almost_equal_nulp` View-to-View matcher

Modified 19/June, based on review

- [x] Rename `verbose` to `max_displayed_errors` 