### PR TITLE
Refactor convert_negative_axis to unuse View

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -41,7 +41,8 @@ auto get_shifts(const ViewType& x, axis_type<DIM> axes, int direction = 1) {
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> non_negative_axes;
   for (std::size_t i = 0; i < DIM; i++) {
-    int axis = KokkosFFT::Impl::convert_negative_axis(x, axes.at(i));
+    int axis =
+        KokkosFFT::Impl::convert_negative_axis(ViewType::rank(), axes.at(i));
     non_negative_axes.push_back(axis);
   }
 

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -24,11 +24,11 @@ namespace Impl {
 /// \tparam ViewType The type of the Kokkos View.
 /// \tparam DIM The number of axes to shift.
 ///
-/// \param x[in,out] The input/output Kokkos View whose extents are used to
+/// \param[in,out] x The input/output Kokkos View whose extents are used to
 /// determine the shift.
-/// \param axes[in] A container of axes indices (negative values allowed; they
+/// \param[in] axes A container of axes indices (negative values allowed; they
 /// are converted).
-/// \param direction[in] The direction of the shift: 1 for fftshift and -1 for
+/// \param[in] direction The direction of the shift: 1 for fftshift and -1 for
 /// ifftshift.
 ///
 /// \return A Kokkos::Array with the computed shift amounts for each axis.
@@ -38,16 +38,16 @@ namespace Impl {
 ///
 template <typename ViewType, std::size_t DIM = 1>
 auto get_shifts(const ViewType& x, axis_type<DIM> axes, int direction = 1) {
+  constexpr int rank = ViewType::rank();
+
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> non_negative_axes;
   for (std::size_t i = 0; i < DIM; i++) {
-    int axis =
-        KokkosFFT::Impl::convert_negative_axis(ViewType::rank(), axes.at(i));
+    int axis = KokkosFFT::Impl::convert_negative_axis(rank, axes.at(i));
     non_negative_axes.push_back(axis);
   }
 
   // Assert if the elements are overlapped
-  constexpr int rank = ViewType::rank();
   KOKKOSFFT_THROW_IF(KokkosFFT::Impl::has_duplicate_values(non_negative_axes),
                      "Axes overlap");
   KOKKOSFFT_THROW_IF(

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -39,14 +39,13 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   }
 
   // Convert the input axes to be in the range of [0, rank-1]
+  constexpr int rank = static_cast<int>(InViewType::rank());
   std::vector<int> positive_axes;
   for (std::size_t i = 0; i < DIM; i++) {
-    int axis =
-        KokkosFFT::Impl::convert_negative_axis(InViewType::rank(), axes.at(i));
+    int axis = KokkosFFT::Impl::convert_negative_axis(rank, axes.at(i));
     positive_axes.push_back(axis);
   }
 
-  constexpr int rank    = static_cast<int>(InViewType::rank());
   using full_shape_type = shape_type<rank>;
   full_shape_type modified_shape;
   for (int i = 0; i < rank; i++) {

--- a/common/src/KokkosFFT_padding.hpp
+++ b/common/src/KokkosFFT_padding.hpp
@@ -41,7 +41,8 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   // Convert the input axes to be in the range of [0, rank-1]
   std::vector<int> positive_axes;
   for (std::size_t i = 0; i < DIM; i++) {
-    int axis = KokkosFFT::Impl::convert_negative_axis(in, axes.at(i));
+    int axis =
+        KokkosFFT::Impl::convert_negative_axis(InViewType::rank(), axes.at(i));
     positive_axes.push_back(axis);
   }
 

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -21,7 +21,7 @@ auto get_map_axes(const ViewType& view, axis_type<DIM> axes) {
   axis_type<DIM> non_negative_axes = {};
   for (std::size_t i = 0; i < DIM; i++) {
     non_negative_axes.at(i) =
-        KokkosFFT::Impl::convert_negative_axis(view, axes.at(i));
+        KokkosFFT::Impl::convert_negative_axis(ViewType::rank(), axes.at(i));
   }
 
   // how indices are map

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -18,15 +18,16 @@ auto get_map_axes(const ViewType& view, axis_type<DIM> axes) {
                      "get_map_axes: input axes are not valid for the view");
 
   // Convert the input axes to be in the range of [0, rank-1]
+  constexpr int rank               = static_cast<int>(ViewType::rank());
   axis_type<DIM> non_negative_axes = {};
   for (std::size_t i = 0; i < DIM; i++) {
     non_negative_axes.at(i) =
-        KokkosFFT::Impl::convert_negative_axis(ViewType::rank(), axes.at(i));
+        KokkosFFT::Impl::convert_negative_axis(rank, axes.at(i));
   }
 
   // how indices are map
   // For 5D View and axes are (2,3), map would be (0, 1, 4, 2, 3)
-  constexpr int rank = static_cast<int>(ViewType::rank());
+
   std::vector<int> map;
   map.reserve(rank);
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -22,13 +22,11 @@ bool are_aliasing(const ScalarType1* ptr1, const ScalarType2* ptr2) {
   return (static_cast<const void*>(ptr1) == static_cast<const void*>(ptr2));
 }
 
-inline int convert_negative_axis(std::size_t rank, int axis = -1) {
-  int irank = static_cast<int>(rank);
-
-  KOKKOSFFT_THROW_IF(axis < -irank || axis >= irank,
+inline int convert_negative_axis(int rank, int axis = -1) {
+  KOKKOSFFT_THROW_IF(axis < -rank || axis >= rank,
                      "Axis must be in [-rank, rank-1]");
 
-  int non_negative_axis = axis < 0 ? irank + axis : axis;
+  int non_negative_axis = axis < 0 ? rank + axis : axis;
   return non_negative_axis;
 }
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -22,16 +22,13 @@ bool are_aliasing(const ScalarType1* ptr1, const ScalarType2* ptr2) {
   return (static_cast<const void*>(ptr1) == static_cast<const void*>(ptr2));
 }
 
-template <typename ViewType>
-auto convert_negative_axis(ViewType, int axis = -1) {
-  static_assert(Kokkos::is_view_v<ViewType>,
-                "convert_negative_axis: ViewType must be a Kokkos::View.");
-  int rank = static_cast<int>(ViewType::rank());
+inline int convert_negative_axis(std::size_t rank, int axis = -1) {
+  int irank = static_cast<int>(rank);
 
-  KOKKOSFFT_THROW_IF(axis < -rank || axis >= rank,
+  KOKKOSFFT_THROW_IF(axis < -irank || axis >= irank,
                      "Axis must be in [-rank, rank-1]");
 
-  int non_negative_axis = axis < 0 ? rank + axis : axis;
+  int non_negative_axis = axis < 0 ? irank + axis : axis;
   return non_negative_axis;
 }
 
@@ -39,7 +36,7 @@ template <typename ViewType>
 auto convert_negative_shift(const ViewType& view, int shift, int axis) {
   static_assert(Kokkos::is_view_v<ViewType>,
                 "convert_negative_shift: ViewType must be a Kokkos::View.");
-  int non_negative_axis = convert_negative_axis(view, axis);
+  int non_negative_axis = convert_negative_axis(ViewType::rank(), axis);
   int extent            = view.extent(non_negative_axis);
   int shift0 = 0, shift1 = 0, shift2 = extent / 2;
 
@@ -95,7 +92,8 @@ template <
     typename IntType, std::size_t DIM = 1,
     std::enable_if_t<Kokkos::is_view_v<ViewType> && std::is_integral_v<IntType>,
                      std::nullptr_t> = nullptr>
-bool are_valid_axes(const ViewType& view, const ArrayType<IntType, DIM>& axes) {
+bool are_valid_axes(const ViewType& /*view*/,
+                    const ArrayType<IntType, DIM>& axes) {
   static_assert(Kokkos::is_view_v<ViewType>,
                 "are_valid_axes: ViewType must be a Kokkos::View");
   static_assert(std::is_integral_v<IntType>,
@@ -114,7 +112,8 @@ bool are_valid_axes(const ViewType& view, const ArrayType<IntType, DIM>& axes) {
   // ensured that the 'non_negative_axes' are in the range of [0, rank-1]
   try {
     for (std::size_t i = 0; i < DIM; i++) {
-      int axis = KokkosFFT::Impl::convert_negative_axis(view, axes[i]);
+      int axis =
+          KokkosFFT::Impl::convert_negative_axis(ViewType::rank(), axes[i]);
       non_negative_axes[i] = axis;
     }
   } catch (std::runtime_error& e) {

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -21,11 +21,6 @@ using paired_scalar_types = ::testing::Types<
 
 // Basically the same fixtures, used for labeling tests
 template <typename T>
-struct ConvertNegativeAxis : public ::testing::Test {
-  using layout_type = T;
-};
-
-template <typename T>
 struct ConvertNegativeShift : public ::testing::Test {
   using layout_type = T;
 };
@@ -45,7 +40,6 @@ struct PairedScalarTypes : public ::testing::Test {
 };
 
 // Tests for convert_negative_axes over ND views
-template <typename LayoutType>
 void test_convert_negative_axes_1d() {
   const std::size_t DIM = 1;
   int converted_axis_0 =
@@ -68,7 +62,6 @@ void test_convert_negative_axes_1d() {
                std::runtime_error);
 }
 
-template <typename LayoutType>
 void test_convert_negative_axes_2d() {
   const std::size_t DIM = 2;
   int converted_axis_0 =
@@ -95,7 +88,6 @@ void test_convert_negative_axes_2d() {
                std::runtime_error);
 }
 
-template <typename LayoutType>
 void test_convert_negative_axes_3d() {
   const std::size_t DIM = 3;
   int converted_axis_0 =
@@ -130,7 +122,6 @@ void test_convert_negative_axes_3d() {
                std::runtime_error);
 }
 
-template <typename LayoutType>
 void test_convert_negative_axes_4d() {
   const std::size_t DIM = 4;
   int converted_axis_0 =
@@ -390,38 +381,21 @@ void test_are_pointers_aliasing() {
 }
 }  // namespace
 
-TYPED_TEST_SUITE(ConvertNegativeAxis, test_types);
 TYPED_TEST_SUITE(ConvertNegativeShift, test_types);
 TYPED_TEST_SUITE(ContainerTypes, base_int_types);
 TYPED_TEST_SUITE(PairedScalarTypes, paired_scalar_types);
 
 // Tests for 1D View
-TYPED_TEST(ConvertNegativeAxis, 1DView) {
-  using layout_type = typename TestFixture::layout_type;
-
-  test_convert_negative_axes_1d<layout_type>();
-}
+TEST(ConvertNegativeAxis, 1DView) { test_convert_negative_axes_1d(); }
 
 // Tests for 2D View
-TYPED_TEST(ConvertNegativeAxis, 2DView) {
-  using layout_type = typename TestFixture::layout_type;
-
-  test_convert_negative_axes_2d<layout_type>();
-}
+TEST(ConvertNegativeAxis, 2DView) { test_convert_negative_axes_2d(); }
 
 // Tests for 3D View
-TYPED_TEST(ConvertNegativeAxis, 3DView) {
-  using layout_type = typename TestFixture::layout_type;
-
-  test_convert_negative_axes_3d<layout_type>();
-}
+TEST(ConvertNegativeAxis, 3DView) { test_convert_negative_axes_3d(); }
 
 // Tests for 4D View
-TYPED_TEST(ConvertNegativeAxis, 4DView) {
-  using layout_type = typename TestFixture::layout_type;
-
-  test_convert_negative_axes_4d<layout_type>();
-}
+TEST(ConvertNegativeAxis, 4DView) { test_convert_negative_axes_4d(); }
 
 // Tests for 1D View
 TYPED_TEST(ConvertNegativeShift, 1DView) {

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -47,13 +47,11 @@ struct PairedScalarTypes : public ::testing::Test {
 // Tests for convert_negative_axes over ND views
 template <typename LayoutType>
 void test_convert_negative_axes_1d() {
-  const int len        = 30;
-  using RealView1Dtype = Kokkos::View<double*, LayoutType, execution_space>;
-  RealView1Dtype x("x", len);
-
-  int converted_axis_0 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/0);
+  const std::size_t DIM = 1;
+  int converted_axis_0 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/0);
   int converted_axis_minus1 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-1);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-1);
 
   int ref_converted_axis_0      = 0;
   int ref_converted_axis_minus1 = 0;
@@ -63,23 +61,22 @@ void test_convert_negative_axes_1d() {
 
   // Check if errors are correctly raised against invalid axis
   // axis must be in [-1, 1)
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/1); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/1); },
                std::runtime_error);
 
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-2); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-2); },
                std::runtime_error);
 }
 
 template <typename LayoutType>
 void test_convert_negative_axes_2d() {
-  const int n0 = 3, n1 = 5;
-  using RealView2Dtype = Kokkos::View<double**, LayoutType, execution_space>;
-  RealView2Dtype x("x", n0, n1);
-
-  int converted_axis_0 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/0);
-  int converted_axis_1 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/1);
+  const std::size_t DIM = 2;
+  int converted_axis_0 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/0);
+  int converted_axis_1 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/1);
   int converted_axis_minus1 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-1);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-1);
 
   int ref_converted_axis_0      = 0;
   int ref_converted_axis_1      = 1;
@@ -91,26 +88,26 @@ void test_convert_negative_axes_2d() {
 
   // Check if errors are correctly raised against invalid axis
   // axis must be in [-2, 2)
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/2); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/2); },
                std::runtime_error);
 
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-3); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-3); },
                std::runtime_error);
 }
 
 template <typename LayoutType>
 void test_convert_negative_axes_3d() {
-  const int n0 = 3, n1 = 5, n2 = 8;
-  using RealView3Dtype = Kokkos::View<double***, LayoutType, execution_space>;
-  RealView3Dtype x("x", n0, n1, n2);
-
-  int converted_axis_0 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/0);
-  int converted_axis_1 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/1);
-  int converted_axis_2 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/2);
+  const std::size_t DIM = 3;
+  int converted_axis_0 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/0);
+  int converted_axis_1 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/1);
+  int converted_axis_2 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/2);
   int converted_axis_minus1 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-1);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-1);
   int converted_axis_minus2 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-2);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-2);
 
   int ref_converted_axis_0      = 0;
   int ref_converted_axis_1      = 1;
@@ -126,29 +123,30 @@ void test_convert_negative_axes_3d() {
 
   // Check if errors are correctly raised against invalid axis
   // axis must be in [-3, 3)
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/3); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/3); },
                std::runtime_error);
 
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-4); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-4); },
                std::runtime_error);
 }
 
 template <typename LayoutType>
 void test_convert_negative_axes_4d() {
-  const int n0 = 3, n1 = 5, n2 = 8, n3 = 13;
-  using RealView4Dtype = Kokkos::View<double****, LayoutType, execution_space>;
-  RealView4Dtype x("x", n0, n1, n2, n3);
-
-  int converted_axis_0 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/0);
-  int converted_axis_1 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/1);
-  int converted_axis_2 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/2);
-  int converted_axis_3 = KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/3);
+  const std::size_t DIM = 4;
+  int converted_axis_0 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/0);
+  int converted_axis_1 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/1);
+  int converted_axis_2 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/2);
+  int converted_axis_3 =
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/3);
   int converted_axis_minus1 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-1);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-1);
   int converted_axis_minus2 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-2);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-2);
   int converted_axis_minus3 =
-      KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-3);
+      KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-3);
 
   int ref_converted_axis_0      = 0;
   int ref_converted_axis_1      = 1;
@@ -168,10 +166,10 @@ void test_convert_negative_axes_4d() {
 
   // Check if errors are correctly raised against invalid axis
   // axis must be in [-4, 4)
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/4); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/4); },
                std::runtime_error);
 
-  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(x, /*axis=*/-5); },
+  EXPECT_THROW({ KokkosFFT::Impl::convert_negative_axis(DIM, /*axis=*/-5); },
                std::runtime_error);
 }
 


### PR DESCRIPTION
This PR aims at removing the unnecessary dependency to View type in `convert_negative_axis` function.
This function only needs the rank of the `View`.