### PR TITLE
Detail license in README

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -4,12 +4,12 @@ SPDX-FileCopyrightText: (C) The kokkos-fft development team, see below
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 -->
 
-The kokkos-fft project licencing information follows the REUSE specification.
+The kokkos-fft project licensing information follows the REUSE specification.
 
 It is distributed under either:
 * the MIT License whose full text is available in the LICENSES/MIT.txt file,
 or, at your option,
-* the Apache-2.0 licence with LLVM exception whose full text is available in
+* the Apache-2.0 license with LLVM exception whose full text is available in
   the LICENSES/Apache-2.0.txt and LICENSES/LLVM-exception.txt files.
 
 For the purpose of copyright, the kokkos-fft development team is defined as follow:

--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Please see [this page](https://kokkosfft.readthedocs.io/en/latest/developer_guid
 [![License](https://img.shields.io/badge/License-Apache--2.0_WITH_LLVM--exception-blue)](https://spdx.org/licenses/LLVM-exception.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-kokkos-fft is distributed under either the MIT license, or at your option, the Apache-2.0 license with LLVM exception.
+kokkos-fft is mainly distributed under either the MIT license, or at your option, the Apache-2.0 license with LLVM exception. More strictly, [FindFFTW.cmake](https://github.com/kokkos/kokkos-fft/blob/main/cmake/FindFFTW.cmake) file is provided under BSD-3-Clause license and [reuse.yml](https://github.com/kokkos/kokkos-fft/blob/main/.github/workflows/reuse.yml) file is provided under CC0-1.0 license. Licenses are automatically confirmed with [REUSE compliance check](<https://reuse.software>) in CI (see [this page](https://kokkosfft.readthedocs.io/en/latest/developer/CI.html) for detail). 


### PR DESCRIPTION
Details licenses in README.md based on the joss-review #297

- [x] Fix typos in COPYRIGHT.md
- [x] Explained that BSD-3-Clause is from FindFFTW.cmake and CC0-1.0 is from reuse.yaml