### PR TITLE
Print in/out view details and axes in case of extent errors

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -75,7 +75,7 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   static_assert(!(is_real_v<in_value_type> && is_real_v<out_value_type>),
                 "get_extents: real to real transform is not supported");
 
-  auto mismatched_extents = [&]() -> std::string {
+  auto mismatched_extents = [&in, &out, &axes, rank]() -> std::string {
     std::string message;
     message += in.label();
     message += "(";
@@ -93,9 +93,10 @@ auto get_extents(const InViewType& in, const OutViewType& out,
       message += std::to_string(out.extent(r));
     }
     message += "), with axes (";
-    for (std::size_t i = 0; i < axes.size(); i++) {
+    message += std::to_string(axes.at(0));
+    for (std::size_t i = 1; i < axes.size(); i++) {
+      message += ",";
       message += std::to_string(axes.at(i));
-      if (i < axes.size() - 1) message += ",";
     }
     message += ")";
     return message;

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -75,7 +75,7 @@ auto get_extents(const InViewType& in, const OutViewType& out,
   static_assert(!(is_real_v<in_value_type> && is_real_v<out_value_type>),
                 "get_extents: real to real transform is not supported");
 
-  auto mismatched_extents = [&in, &out, &axes, rank]() -> std::string {
+  auto mismatched_extents = [&in, &out, &axes]() -> std::string {
     std::string message;
     message += in.label();
     message += "(";


### PR DESCRIPTION
This PR aims at improving the error message from `get_extents` function.
If it fails, it prints the following error message.

```
C++ exception with description "tpls/kokkos-fft/common/src/KokkosFFT_Extents.hpp(81) 
`get_extents`: input and output extents must be the same except for the transform axis
" thrown in the test body.
```

After this PR, it will print

```
C++ exception with description "tpls/kokkos-fft/common/src/KokkosFFT_Extents.hpp(108) 
`get_extents`: input and output extents must be the same except for the transform axis: (4,7,5), fft(4,7,3), with axes (-1,-2)
" thrown in the test body.
```
