### PR TITLE
Unuse sphinxcontrib bibtex

### DIFF
--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -9,11 +9,7 @@ Citing kokkos-fft
 
 Please cite the following article when using kokkos-fft in your work.
 
-.. bibliography::
-   :style: unsrt
-   :all:
-
-.. bibtex::
+::
 
    @article{Asahi2025, 
      doi = {10.21105/joss.08391}, 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ if read_the_docs_build:
 # ones.
 #...
 
-extensions = [ "breathe", "sphinx_copybutton", "sphinxcontrib.bibtex" ]
+extensions = [ "breathe", "sphinx_copybutton" ]
 
 #...
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,3 @@
 breathe
 sphinx-rtd-theme
 sphinx-copybutton
-sphinxcontrib-bibtex


### PR DESCRIPTION
Temporary fix to the errors on readthedocs.

```
[675](https://app.readthedocs.org/projects/kokkosfft/builds/29039181/#280477821--675)	  File "/home/docs/checkouts/readthedocs.org/user_builds/kokkosfft/envs/latest/lib/python3.10/site-packages/sphinxcontrib/bibtex/domain.py", line 303, in __init__
[676](https://app.readthedocs.org/projects/kokkosfft/builds/29039181/#280477821--676)	    raise ExtensionError("You must configure the bibtex_bibfiles setting")
[677](https://app.readthedocs.org/projects/kokkosfft/builds/29039181/#280477821--677)	sphinx.errors.ExtensionError: You must configure the bibtex_bibfiles setting
```