### PR TITLE
Update rocm Dockerfile to use hipcc 6.2.0

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-ARG BASE=rocm/dev-ubuntu-22.04:5.6-complete
+ARG BASE=rocm/dev-ubuntu-24.04:6.2-complete
 FROM $BASE
 
 ARG ADDITIONAL_PACKAGES


### PR DESCRIPTION
This PR aims at updating hipcc version in nightly to 6.2.0 which is a new minimum in Kokkos 5.0.