### PR TITLE
Add spack installation CI for HIP backend

### DIFF
--- a/.github/workflows/spack-test.yaml
+++ b/.github/workflows/spack-test.yaml
@@ -17,6 +17,13 @@ jobs:
           - name: nvcc
             image: gcc
             kokkos: +cuda +wrapper cuda_arch=90
+            spack_path: ""
+          - name: rocm
+            image: rocm
+            kokkos: +rocm amdgpu_target=gfx90a
+            spack_path: spack-configs/rocm
+    env:
+      SPACK_USER_CONFIG_PATH: ${{ matrix.backend.spack_path }}
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -41,4 +48,3 @@ jobs:
             spack load kokkos kokkos-fft && \
             cmake -B install_test/as_library/build && \
             cmake --build install_test/as_library/build -j 4"
-

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -16,23 +16,23 @@ RUN apt-get update && apt-get install -y \
         hipfft \
         rocfft \
         libfftw3-dev \
+        python3 \
         $ADDITIONAL_PACKAGES \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV FFTWDIR "/usr"
-
-ENV PATH=/opt/rocm/bin:$PATH
-ENV LD_LIBRARY_PATH /opt/rocm/hipfft/lib:$LD_LIBRARY_PATH
-ENV CMAKE_PREFIX_PATH /opt/rocm/hip/:/opt/rocm/:$CMAKE_PREFIX_PATH
+ENV FFTWDIR=/usr \
+    CMAKE_DIR=/opt/cmake \
+    PATH=/opt/rocm/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rocm/hipfft/lib:$LD_LIBRARY_PATH \
+    CMAKE_PREFIX_PATH=/opt/rocm/hip/:/opt/rocm/:$CMAKE_PREFIX_PATH
 
 RUN git config --global --add safe.directory "*"
 
 # Install newer CMake manually
 ARG CMAKE_VERSION=3.23.2
 
-ENV CMAKE_DIR=/opt/cmake
 RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
     CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
     CMAKE_SHA256=cmake-${CMAKE_VERSION}-SHA-256.txt && \

--- a/spack-configs/rocm/packages.yaml
+++ b/spack-configs/rocm/packages.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) The kokkos-fft development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+packages:
+  llvm-amdgpu:
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@6.2.0
+      prefix: /opt/rocm
+      extra_attributes:
+        compilers:
+          c: /opt/rocm/bin/amdclang
+          cxx: /opt/rocm/bin/amdclang++
+  hip:
+    buildable: false
+    externals:
+    - spec: hip@6.2.0
+      prefix: /opt/rocm-6.2.0
+  hipfft:
+    buildable: false
+    externals:
+    - spec: hipfft@6.2.0
+      prefix: /opt/rocm-6.2.0
+  rocfft:
+    buildable: false
+    externals:
+    - spec: rocfft@6.2.0
+      prefix: /opt/rocm-6.2.0
+  cmake:
+    buildable: false
+    externals:
+    - spec: cmake@3.23.2
+      prefix: /opt/cmake


### PR DESCRIPTION
This PR aims at adding a spack installation CI for rocm environment.
Documentation will be done in https://github.com/kokkos/kokkos-fft/pull/300