### PR TITLE
Add spack spec and fix install-test in spack CI

### DIFF
--- a/.github/workflows/spack-test.yaml
+++ b/.github/workflows/spack-test.yaml
@@ -17,6 +17,7 @@ jobs:
           - name: nvcc
             image: gcc
             kokkos: +cuda +wrapper cuda_arch=90
+            kokkos_fft: device_backend=cufft
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -37,8 +38,8 @@ jobs:
         run: |
           docker run -v ${{ github.workspace }}:/work ghcr.io/kokkos/kokkos-fft/base_${{ matrix.backend.image }}:latest \
           bash -c "source spack/share/spack/setup-env.sh && \
-            spack spec kokkos-fft +tests ^kokkos ${{ matrix.backend.kokkos }} && \
-            spack install kokkos-fft +tests ^kokkos ${{ matrix.backend.kokkos }} && \
+            spack spec kokkos-fft ${{ matrix.backend.kokkos_fft }} +tests ^kokkos ${{ matrix.backend.kokkos }} && \
+            spack install kokkos-fft ${{ matrix.backend.kokkos_fft }} +tests ^kokkos ${{ matrix.backend.kokkos }} && \
             spack load kokkos kokkos-fft && \
             cd install_test/as_library && \
             cmake -B build && \


### PR DESCRIPTION
In this PR, we improve the spack CI.

- [x] Add `spack spec kokkos-fft +tests ^kokkos ${{ matrix.backend.kokkos }}` for more information
- [x] Make an installation_test relying on spack packages