### PR TITLE
Extract the core logic of get_map_axes helper

### DIFF
--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -52,7 +52,7 @@ auto get_map_axes(const std::array<IntType, FFT_DIM>& axes) {
     }
 
     // Then stack remaining axes
-    for (iType i = 0; i < rank; i++) {
+    for (IntType i = 0; i < rank; i++) {
       if (!is_found(non_negative_axes, i)) {
         map.push_back(i);
       }


### PR DESCRIPTION
This PR aims at extracting the core logic of `get_map_axes` which does not rely on `View`. 
For distributed FFT, we do not have an access to the global `View` which does not necessarily exist.
The extracted function can compute the mapping from the meta data of global `View` rather than `View` itself.