### PR TITLE
[Distributed] Refactor mpi wrapper

### DIFF
--- a/distributed/src/KokkosFFT_Distributed_All2All.hpp
+++ b/distributed/src/KokkosFFT_Distributed_All2All.hpp
@@ -5,101 +5,15 @@
 #ifndef KOKKOSFFT_DISTRIBUTED_ALL2ALL_HPP
 #define KOKKOSFFT_DISTRIBUTED_ALL2ALL_HPP
 
-#include <mpi.h>
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_asserts.hpp"
 #include "KokkosFFT_Distributed_MPI_Types.hpp"
+#include "KokkosFFT_Distributed_MPI_Comm.hpp"
+#include "KokkosFFT_Distributed_MPI_All2All.hpp"
 
 namespace KokkosFFT {
 namespace Distributed {
 namespace Impl {
-
-/// \brief MPI all-to-all communication for distributed data redistribution
-/// This class implements MPI_Alltoall communication pattern on Kokkos Views,
-/// used in distributed FFT operations for data redistribution between different
-/// domain decompositions. The class handles the computation of send counts
-/// based on the layout type and performs the actual MPI communication.
-///
-/// \tparam ExecutionSpace Kokkos execution space type
-/// \tparam ViewType Kokkos View type containing the data to be communicated,
-/// must have rank >= 2
-///
-/// The outermost dimension corresponds to the number of processes involved in
-/// the communication.
-/// For LayoutLeft, we expect the input and output views to have the shape
-/// (n0, n1, ..., nprocs).
-/// For LayoutRight, we expect the input and output views to have the shape
-/// (nprocs, n0, ..., n_N).
-/// The send_count and recv_count are the product of the other dimensions of the
-/// input and output views. It will raise an error if the nprocs obtained from
-/// the input and output views is not the same as the MPI size.
-template <typename ExecutionSpace, typename ViewType>
-struct All2All {
-  static_assert(ViewType::rank() >= 2,
-                "All2All: View rank must be larger than or equal to 2");
-  using value_type = typename ViewType::non_const_value_type;
-
-  ExecutionSpace m_exec_space;
-  MPI_Comm m_comm;
-  MPI_Datatype m_mpi_data_type;
-
-  /// \brief Constructor for All2All communication
-  /// \param[in] send Input view to be sent
-  /// \param[in] recv Output view to be received
-  /// \param[in] comm MPI communicator (default to MPI_COMM_WORLD)
-  /// \param[in] exec_space Execution space (default to ExecutionSpace()
-  /// instance)
-  /// \throws std::runtime_error if the extent of the dimension to be transposed
-  /// does not match MPI size
-  All2All(const ViewType& send, const ViewType& recv,
-          const MPI_Comm& comm            = MPI_COMM_WORLD,
-          const ExecutionSpace exec_space = ExecutionSpace())
-      : m_exec_space(exec_space),
-        m_comm(comm),
-        m_mpi_data_type(MPIDataType<value_type>::type()) {
-    using LayoutType = typename ViewType::array_layout;
-    int size_send    = std::is_same_v<LayoutType, Kokkos::LayoutLeft>
-                           ? send.extent_int(ViewType::rank() - 1)
-                           : send.extent_int(0);
-    int size_recv    = std::is_same_v<LayoutType, Kokkos::LayoutLeft>
-                           ? recv.extent_int(ViewType::rank() - 1)
-                           : recv.extent_int(0);
-
-    int size = 0;
-    ::MPI_Comm_size(m_comm, &size);
-    KOKKOSFFT_THROW_IF(
-        (size_send != size) || (size_recv != size),
-        "Extent of dimension to be transposed of send (" +
-            std::to_string(size_send) + ") or recv (" +
-            std::to_string(size_recv) +
-            ") buffer does not match MPI size: " + std::to_string(size));
-
-    // Compute the outermost dimension size
-    int send_count = static_cast<int>(send.size()) / size_send;
-    ::MPI_Alltoall(send.data(), send_count, m_mpi_data_type, recv.data(),
-                   send_count, m_mpi_data_type, m_comm);
-  }
-};
-
-/// \brief MPI all-to-all communication for distributed data redistribution
-/// \tparam ExecutionSpace Kokkos execution space type
-/// \tparam ViewType Kokkos View type containing the data to be communicated,
-/// must have rank >= 2
-///
-/// \param[in] exec_space Execution space
-/// \param[in] send Input view to be sent
-/// \param[in] recv Output view to be received
-/// \param[in] comm MPI communicator
-template <typename ExecutionSpace, typename ViewType>
-void all2all(const ExecutionSpace& exec_space, const ViewType& send,
-             const ViewType& recv, const MPI_Comm& comm) {
-  static_assert(ViewType::rank() >= 2,
-                "all2all: View rank must be larger than or equal to 2");
-  Kokkos::Profiling::ScopedRegion region("KokkosFFT::Distributed::all2all");
-  All2All(send, recv, comm, exec_space);
-}
-
+template <typename ExecutionSpace>
+using TplComm = ScopedMPIComm<ExecutionSpace>;
 }  // namespace Impl
 }  // namespace Distributed
 }  // namespace KokkosFFT

--- a/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
@@ -1,0 +1,73 @@
+#ifndef KOKKOSFFT_DISTRIBUTED_MPI_ALL2ALL_HPP
+#define KOKKOSFFT_DISTRIBUTED_MPI_ALL2ALL_HPP
+
+#include <type_traits>
+#include <mpi.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ScopedRegion.hpp>
+#include <KokkosFFT.hpp>
+#include "KokkosFFT_Distributed_MPI_Types.hpp"
+#include "KokkosFFT_Distributed_MPI_Comm.hpp"
+
+namespace KokkosFFT {
+namespace Distributed {
+namespace Impl {
+
+/// \brief MPI all-to-all communication for distributed data redistribution
+/// \tparam ViewType Kokkos View type containing the data to be communicated,
+/// must have rank >= 2
+///
+/// \param[in] send Input view to be sent
+/// \param[out] recv Output view to be received
+/// \param[in] comm MPI communicator
+template <typename ViewType>
+void all2all(const ViewType& send, const ViewType& recv, const MPI_Comm& comm) {
+  static_assert(ViewType::rank() >= 2,
+                "all2all: View rank must be larger than or equal to 2");
+  using value_type = typename ViewType::non_const_value_type;
+  using LayoutType = typename ViewType::array_layout;
+  std::string msg  = KokkosFFT::Impl::is_real_v<value_type>
+                         ? "KokkosFFT::Distributed::all2all[TPL_MPI,real]"
+                         : "KokkosFFT::Distributed::all2all[TPL_MPI,complex]";
+  Kokkos::Profiling::ScopedRegion region(msg);
+  int size_send = std::is_same_v<LayoutType, Kokkos::LayoutLeft>
+                      ? send.extent_int(ViewType::rank() - 1)
+                      : send.extent_int(0);
+  int size_recv = std::is_same_v<LayoutType, Kokkos::LayoutLeft>
+                      ? recv.extent_int(ViewType::rank() - 1)
+                      : recv.extent_int(0);
+  int size      = 0;
+  ::MPI_Comm_size(comm, &size);
+  KOKKOSFFT_THROW_IF(
+      (size_send != size) || (size_recv != size),
+      "Extent of dimension to be transposed of send (" +
+          std::to_string(size_send) + ") or recv (" +
+          std::to_string(size_recv) +
+          ") buffer does not match MPI size: " + std::to_string(size));
+
+  // Compute the outermost dimension size
+  auto mpi_data_type = mpi_datatype_v<value_type>;
+  int send_count     = static_cast<int>(send.size()) / size_send;
+  ::MPI_Alltoall(send.data(), send_count, mpi_data_type, recv.data(),
+                 send_count, mpi_data_type, comm);
+}
+
+/// \brief MPI all-to-all communication for distributed data redistribution
+/// \tparam ExecutionSpace Kokkos execution space type
+/// \tparam ViewType Kokkos View type containing the data to be communicated,
+/// must have rank >= 2
+///
+/// \param[in] send Input view to be sent
+/// \param[out] recv Output view to be received
+/// \param[in] comm MPI communicator wrapper
+template <typename ExecutionSpace, typename ViewType>
+void all2all(const ViewType& send, const ViewType& recv,
+             const ScopedMPIComm<ExecutionSpace>& comm) {
+  all2all(send, recv, comm.comm());
+}
+
+}  // namespace Impl
+}  // namespace Distributed
+}  // namespace KokkosFFT
+
+#endif

--- a/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 #ifndef KOKKOSFFT_DISTRIBUTED_MPI_ALL2ALL_HPP
 #define KOKKOSFFT_DISTRIBUTED_MPI_ALL2ALL_HPP
 

--- a/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_All2All.hpp
@@ -42,12 +42,18 @@ void all2all(const ViewType& send, const ViewType& recv, const MPI_Comm& comm) {
                       : recv.extent_int(0);
   int size      = 0;
   ::MPI_Comm_size(comm, &size);
-  KOKKOSFFT_THROW_IF(
-      (size_send != size) || (size_recv != size),
-      "Extent of dimension to be transposed of send (" +
-          std::to_string(size_send) + ") or recv (" +
-          std::to_string(size_recv) +
-          ") buffer does not match MPI size: " + std::to_string(size));
+
+  auto size_mismatch_msg = [size, size_send, size_recv]() -> std::string {
+    std::string message;
+    message = "Extent of dimension to be transposed of send (" +
+              std::to_string(size_send) + ") or recv (" +
+              std::to_string(size_recv) +
+              ") buffer does not match MPI size: " + std::to_string(size);
+    return message;
+  };
+
+  KOKKOSFFT_THROW_IF((size_send != size) || (size_recv != size),
+                     size_mismatch_msg());
 
   // Compute the outermost dimension size
   auto mpi_data_type = mpi_datatype_v<value_type>;

--- a/distributed/src/KokkosFFT_Distributed_MPI_Comm.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_Comm.hpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 #ifndef KOKKOSFFT_DISTRIBUTED_MPI_COMM_HPP
 #define KOKKOSFFT_DISTRIBUTED_MPI_COMM_HPP
 

--- a/distributed/src/KokkosFFT_Distributed_MPI_Comm.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_Comm.hpp
@@ -1,0 +1,93 @@
+#ifndef KOKKOSFFT_DISTRIBUTED_MPI_COMM_HPP
+#define KOKKOSFFT_DISTRIBUTED_MPI_COMM_HPP
+
+#include <mpi.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Distributed_MPI_Types.hpp"
+
+namespace KokkosFFT {
+namespace Distributed {
+namespace Impl {
+
+/// \brief Scoped wrapper for MPI_Comm
+/// This class provides a scoped wrapper around an MPI_Comm object
+/// just handles rank, size, comm and execution space.
+///
+/// \tparam ExecutionSpace Kokkos execution space type
+template <typename ExecutionSpace>
+struct ScopedMPIComm {
+ private:
+  using execution_space = ExecutionSpace;
+  MPI_Comm m_comm       = MPI_COMM_NULL;
+  execution_space m_exec_space;
+  int m_rank = 0;
+  int m_size = 1;
+
+ public:
+  /// \brief Construct a ScopedMPIComm
+  /// \param[in] comm MPI communicator
+  /// \param[in] exec_space Kokkos execution space
+  explicit ScopedMPIComm(MPI_Comm comm, const ExecutionSpace &exec_space)
+      : m_comm(comm), m_exec_space(exec_space) {
+    ::MPI_Comm_rank(comm, &m_rank);
+    ::MPI_Comm_size(comm, &m_size);
+  }
+
+  /// \brief Construct a ScopedMPIComm
+  /// \param[in] comm MPI communicator
+  explicit ScopedMPIComm(MPI_Comm comm)
+      : ScopedMPIComm(comm, ExecutionSpace{}) {}
+
+  ScopedMPIComm() = delete;
+
+  // Delete copy semantics
+  ScopedMPIComm(const ScopedMPIComm &)            = delete;
+  ScopedMPIComm &operator=(const ScopedMPIComm &) = delete;
+
+  /// \brief Move constructor
+  /// \param[in] other Another ScopedMPIComm to move from
+  ScopedMPIComm(ScopedMPIComm &&other) noexcept
+      : m_comm(other.m_comm),
+        m_exec_space(other.m_exec_space),
+        m_rank(other.m_rank),
+        m_size(other.m_size) {
+    other.m_comm = MPI_COMM_NULL;
+  }
+
+  /// \brief Move assignment operator
+  /// \param[in] other Another ScopedMPIComm to move from
+  ScopedMPIComm &operator=(ScopedMPIComm &&other) noexcept {
+    if (this != &other) {
+      m_comm       = other.m_comm;
+      m_exec_space = other.m_exec_space;
+      m_rank       = other.m_rank;
+      m_size       = other.m_size;
+      other.m_comm = MPI_COMM_NULL;
+    }
+    return *this;
+  }
+
+  ~ScopedMPIComm() = default;
+
+  /// \brief Get the MPI communicator
+  /// \return MPI_Comm object
+  MPI_Comm comm() const { return m_comm; }
+
+  /// \brief Get the execution space
+  /// \return Execution space object
+  execution_space exec_space() const { return m_exec_space; }
+
+  /// \brief Get the rank of the process
+  /// \return Rank of the process
+  int rank() const { return m_rank; }
+
+  /// \brief Get the size of the communicator
+  /// \return Size of the communicator
+  int size() const { return m_size; }
+};
+
+}  // namespace Impl
+}  // namespace Distributed
+}  // namespace KokkosFFT
+
+#endif

--- a/distributed/src/KokkosFFT_Distributed_MPI_Types.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_Types.hpp
@@ -13,37 +13,88 @@ namespace Distributed {
 namespace Impl {
 
 template <typename ValueType>
-struct MPIDataType {};
+auto mpi_datatype() -> MPI_Datatype {
+  using T = std::decay_t<ValueType>;
 
-template <>
-struct MPIDataType<int> {
-  static inline MPI_Datatype type() noexcept { return MPI_INT32_T; }
-};
+  if constexpr (std::is_same_v<T, char>) {
+    return MPI_CHAR;
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    return MPI_UNSIGNED_CHAR;
+  } else if constexpr (std::is_same_v<T, short>) {
+    return MPI_SHORT;
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    return MPI_UNSIGNED_SHORT;
+  } else if constexpr (std::is_same_v<T, int>) {
+    return MPI_INT32_T;
+  } else if constexpr (std::is_same_v<T, unsigned int>) {
+    return MPI_UINT32_T;
+  } else if constexpr (std::is_same_v<T, long>) {
+    return MPI_LONG;
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    return MPI_UNSIGNED_LONG;
+  } else if constexpr (std::is_same_v<T, long long>) {
+    return MPI_LONG_LONG;
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    return MPI_UNSIGNED_LONG_LONG;
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    return MPI_INT8_T;
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    return MPI_UINT8_T;
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    return MPI_INT16_T;
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    return MPI_UINT16_T;
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    return MPI_INT32_T;
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    return MPI_UINT32_T;
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    return MPI_INT64_T;
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    return MPI_UINT64_T;
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == sizeof(unsigned int))
+      return MPI_UNSIGNED;
+    else if constexpr (sizeof(std::size_t) == sizeof(unsigned long))
+      return MPI_UNSIGNED_LONG;
+    else if constexpr (sizeof(std::size_t) == sizeof(unsigned long long))
+      return MPI_UNSIGNED_LONG_LONG;
+    else {
+      static_assert(std::is_void_v<T>,
+                    "Unsupported std::size_t size for MPI mapping");
+      return MPI_UNSIGNED;  // unreachable
+    }
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == sizeof(int))
+      return MPI_INT;
+    else if constexpr (sizeof(std::ptrdiff_t) == sizeof(long))
+      return MPI_LONG;
+    else if constexpr (sizeof(std::ptrdiff_t) == sizeof(long long))
+      return MPI_LONG_LONG;
+    else {
+      static_assert(std::is_void_v<T>,
+                    "Unsupported std::ptrdiff_t size for MPI mapping");
+      return MPI_INT;  // unreachable
+    }
+  } else if constexpr (std::is_same_v<T, float>) {
+    return MPI_FLOAT;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return MPI_DOUBLE;
+  } else if constexpr (std::is_same_v<T, long double>) {
+    return MPI_LONG_DOUBLE;
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+    return MPI_COMPLEX;
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+    return MPI_DOUBLE_COMPLEX;
+  } else {
+    static_assert(std::is_void_v<T>,
+                  "Unsupported type for MPI datatype mapping");
+    return MPI_CHAR;  // unreachable
+  }
+}
 
-template <>
-struct MPIDataType<std::size_t> {
-  static inline MPI_Datatype type() noexcept { return MPI_UINT64_T; }
-};
-
-template <>
-struct MPIDataType<float> {
-  static inline MPI_Datatype type() noexcept { return MPI_FLOAT; }
-};
-
-template <>
-struct MPIDataType<double> {
-  static inline MPI_Datatype type() noexcept { return MPI_DOUBLE; }
-};
-
-template <>
-struct MPIDataType<Kokkos::complex<float>> {
-  static inline MPI_Datatype type() noexcept { return MPI_CXX_FLOAT_COMPLEX; }
-};
-
-template <>
-struct MPIDataType<Kokkos::complex<double>> {
-  static inline MPI_Datatype type() noexcept { return MPI_CXX_DOUBLE_COMPLEX; }
-};
+template <typename ValueType>
+inline MPI_Datatype mpi_datatype_v = mpi_datatype<ValueType>();
 
 }  // namespace Impl
 }  // namespace Distributed

--- a/distributed/unit_test/CMakeLists.txt
+++ b/distributed/unit_test/CMakeLists.txt
@@ -4,8 +4,9 @@
 
 set(SOURCES
         Test_Main.cpp
-        Test_All2All.cpp
+        Test_TplComm.cpp
         Test_MPI_Types.cpp
+        Test_All2All.cpp
     )
 
 add_executable(unit-tests-mpi ${SOURCES})

--- a/distributed/unit_test/Test_All2All.cpp
+++ b/distributed/unit_test/Test_All2All.cpp
@@ -21,15 +21,97 @@ struct TestAll2All : public ::testing::Test {
 
   int m_rank   = 0;
   int m_nprocs = 1;
+  int m_npx    = 1;
 
   virtual void SetUp() {
     ::MPI_Comm_rank(MPI_COMM_WORLD, &m_rank);
     ::MPI_Comm_size(MPI_COMM_WORLD, &m_nprocs);
+    m_npx = std::sqrt(m_nprocs);
   }
 };
 
+/// \brief Test all2all communication for 2D Views
+/// For 8x8 matrix.
+/// Before MPI
+/// Rank 0
+/// [[A00, A01, A02, A03, A04, A05, A06, A07],
+///  [A10, A11, A12, A13, A14, A15, A16, A17]]
+/// Rank 1
+/// [[A20, A21, A22, A23, A24, A25, A26, A27],
+///  [A30, A31, A32, A33, A34, A35, A36, A37]]
+/// Rank 2
+/// [[A40, A41, A42, A43, A44, A45, A46, A47],
+///  [A50, A51, A52, A53, A54, A55, A56, A57]]
+/// Rank 3
+/// [[A60, A61, A62, A63, A64, A65, A66, A67],
+///  [A70, A71, A72, A73, A74, A75, A76, A77]]
+///
+/// Send buffer (Each rank has 4x2x2 matrix)
+/// Rank 0
+/// [[[A00, A01], [A10, A11]],
+///  [[A02, A03], [A12, A13]],
+///  [[A04, A05], [A14, A15]],
+///  [[A06, A07], [A16, A17]]]
+/// Rank 1
+/// [[[A20, A21], [A30, A31]],
+///  [[A22, A23], [A32, A33]],
+///  [[A24, A25], [A34, A35]],
+///  [[A26, A27], [A36, A37]]]
+/// Rank 2
+/// [[[A40, A41], [A50, A51]],
+///  [[A42, A43], [A52, A53]],
+///  [[A44, A45], [A54, A55]],
+///  [[A46, A47], [A56, A57]]]
+/// Rank 3
+/// [[[A60, A61], [A70, A71]],
+///  [[A62, A63], [A72, A73]],
+///  [[A64, A65], [A74, A75]],
+///  [[A66, A67], [A76, A77]]]
+///
+/// Receive buffer (Each rank has 2x4x2 matrix)
+/// Rank 0
+/// [[[A00, A01], [A10, A11]],
+///  [[A20, A21], [A30, A31]],
+///  [[A40, A41], [A50, A51]],
+///  [[A60, A61], [A70, A71]]]
+/// Rank 1
+/// [[[A02, A03], [A12, A13]],
+///  [[A22, A23], [A32, A33]],
+///  [[A42, A43], [A52, A53]],
+///  [[A62, A63], [A72, A73]]]
+/// Rank 2
+/// [[[A04, A05], [A14, A15]],
+///  [[A24, A25], [A34, A35]],
+///  [[A44, A45], [A54, A55]],
+///  [[A64, A65], [A74, A75]]]
+/// Rank 3
+/// [[[A06, A07], [A16, A17]],
+///  [[A26, A27], [A36, A37]],
+///  [[A46, A47], [A56, A57]],
+///  [[A66, A67], [A76, A77]]]
+///
+/// After all2all communication with transpose
+/// Rank 0
+/// [[A00, A10, A20, A30, A40, A50, A60, A70],
+///  [A01, A11, A21, A31, A41, A51, A61, A71]]
+/// Rank 1
+/// [[A02, A12, A22, A32, A42, A52, A62, A72],
+///  [A03, A13, A23, A33, A43, A53, A63, A73]]
+/// Rank 2
+/// [[A04, A14, A24, A34, A44, A54, A64, A74],
+///  [A05, A15, A25, A35, A45, A55, A65, A75]]
+/// Rank 3
+/// [[A06, A16, A26, A36, A46, A56, A66, A76],
+///  [A07, A17, A27, A37, A47, A57, A67, A77]]
+/// \tparam T Data type
+/// \tparam LayoutType Layout of the data (LayoutLeft or LayoutRight)
+///
+/// \param[in] rank MPI rank
+/// \param[in] nprocs Number of MPI ranks
+/// \param[in] use_tpl_wrapper Whether to use template wrapper
 template <typename T, typename LayoutType>
-void test_all2all_view2D(int rank, int nprocs) {
+void test_all2all_view2D(int rank, int nprocs, bool use_tpl_wrapper) {
+  using float_type = KokkosFFT::Impl::base_floating_point_type<T>;
   using View3DType = Kokkos::View<T***, LayoutType, execution_space>;
 
   const std::size_t n0 = 16, n1 = 15;
@@ -58,23 +140,33 @@ void test_all2all_view2D(int rank, int nprocs) {
     for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
       for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
         if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
-          T value =
-              static_cast<T>(rank * send.size() + i0 + i1 * send.extent(0) +
-                             i2 * send.extent(0) * send.extent(1));
-          T value_T =
-              static_cast<T>(i2 * send.size() + i0 + i1 * send.extent(0) +
-                             rank * send.extent(0) * send.extent(1));
-          h_send(i0, i1, i2) = value;
-          h_ref(i0, i1, i2)  = value_T;
+          float_type value = static_cast<float_type>(
+              rank * send.size() + i0 + i1 * send.extent(0) +
+              i2 * send.extent(0) * send.extent(1));
+          float_type value_T = static_cast<float_type>(
+              i2 * send.size() + i0 + i1 * send.extent(0) +
+              rank * send.extent(0) * send.extent(1));
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
         } else {
-          T value =
-              static_cast<T>(rank * send.size() + i2 + i1 * send.extent(2) +
-                             i0 * send.extent(2) * send.extent(1));
-          T value_T =
-              static_cast<T>(i0 * send.size() + i2 + i1 * send.extent(2) +
-                             rank * send.extent(2) * send.extent(1));
-          h_send(i0, i1, i2) = value;
-          h_ref(i0, i1, i2)  = value_T;
+          float_type value = static_cast<float_type>(
+              rank * send.size() + i2 + i1 * send.extent(2) +
+              i0 * send.extent(2) * send.extent(1));
+          float_type value_T = static_cast<float_type>(
+              i0 * send.size() + i2 + i1 * send.extent(2) +
+              rank * send.extent(2) * send.extent(1));
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
         }
       }
     }
@@ -84,10 +176,16 @@ void test_all2all_view2D(int rank, int nprocs) {
   Kokkos::deep_copy(ref, h_ref);
 
   execution_space exec;
-  KokkosFFT::Distributed::Impl::all2all(exec, send, recv, MPI_COMM_WORLD);
+  if (use_tpl_wrapper) {
+    KokkosFFT::Distributed::Impl::TplComm<execution_space> comm(MPI_COMM_WORLD,
+                                                                exec);
+    KokkosFFT::Distributed::Impl::all2all(send, recv, comm);
+  } else {
+    KokkosFFT::Distributed::Impl::all2all(send, recv, MPI_COMM_WORLD);
+  }
   auto h_recv = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), recv);
 
-  T epsilon = std::numeric_limits<T>::epsilon() * 100;
+  auto epsilon = std::numeric_limits<float_type>::epsilon() * 100;
   for (std::size_t i2 = 0; i2 < send.extent(2); i2++) {
     for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
       for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
@@ -99,7 +197,7 @@ void test_all2all_view2D(int rank, int nprocs) {
 }
 
 template <typename T, typename LayoutType>
-void test_all2all_view2D_incorrect_proc_size(int nprocs) {
+void test_all2all_view2D_incorrect_proc_size(int nprocs, bool use_tpl_wrapper) {
   using View3DType = Kokkos::View<T***, LayoutType, execution_space>;
 
   const std::size_t n0 = 16, n1 = 15;
@@ -122,24 +220,537 @@ void test_all2all_view2D_incorrect_proc_size(int nprocs) {
       recv("recv", n0_buffer, n1_buffer, n2_buffer);
 
   execution_space exec;
-  EXPECT_THROW(
-      KokkosFFT::Distributed::Impl::all2all(exec, send, recv, MPI_COMM_WORLD),
-      std::runtime_error);
+  if (use_tpl_wrapper) {
+    KokkosFFT::Distributed::Impl::TplComm<execution_space> comm(MPI_COMM_WORLD,
+                                                                exec);
+    EXPECT_THROW(KokkosFFT::Distributed::Impl::all2all(send, recv, comm),
+                 std::runtime_error);
+  } else {
+    EXPECT_THROW(
+        KokkosFFT::Distributed::Impl::all2all(send, recv, MPI_COMM_WORLD),
+        std::runtime_error);
+  }
+}
+
+/// \brief Test all2all communication for 2D Views
+/// For 8x8 matrix.
+/// Before MPI
+/// Rank 0
+/// [[A00, A01, A02, A03],
+///  [A10, A11, A12, A13],
+///  [A20, A21, A22, A23],
+///  [A30, A31, A32, A33]]
+/// Rank 1
+/// [[A04, A05, A06, A07],
+///  [A14, A15, A16, A17],
+///  [A24, A25, A26, A27],
+///  [A34, A35, A36, A37]]
+/// Rank 2
+/// [[A40, A41, A42, A43],
+///  [A50, A51, A52, A53],
+///  [A60, A61, A62, A63],
+///  [A70, A71, A72, A73]]
+/// Rank 3
+/// [[A44, A45, A46, A47],
+///  [A54, A55, A56, A57],
+///  [A64, A65, A66, A67],
+///  [A74, A75, A76, A77]]
+///
+/// Send buffer (Each rank has 2x4x2 matrix)
+/// Rank 0 <-> Rank 2
+/// [[[A00, A01], [A10, A11], [A20, A21], [A30, A31]],
+///  [[A02, A03], [A12, A13], [A22, A23], [A32, A33]]]
+/// Rank 1 <-> Rank 3
+/// [[[A04, A05], [A14, A15], [A24, A25], [A34, A35]],
+///  [[A06, A07], [A16, A17], [A26, A27], [A36, A37]]]
+/// Rank 2 <-> Rank 0
+/// [[[A40, A41], [A50, A51], [A60, A61], [A70, A71]],
+///  [[A42, A43], [A52, A53], [A62, A63], [A72, A73]]]
+/// Rank 3 <-> Rank 1
+/// [[[A44, A45], [A54, A55], [A64, A65], [A74, A75]],
+///  [[A46, A47], [A56, A57], [A66, A67], [A76, A77]]]
+///
+/// Receive buffer (Each rank has 2x4x2 matrix)
+/// Rank 0 <-> Rank 2
+/// [[[A00, A01], [A10, A11], [A20, A21], [A30, A31]],
+///  [[A40, A41], [A50, A51], [A60, A61], [A70, A71]]]
+/// Rank 1 <-> Rank 3
+/// [[[A04, A05], [A14, A15], [A24, A25], [A34, A35]],
+///  [[A44, A45], [A54, A55], [A64, A65], [A74, A75]]]
+/// Rank 2 <-> Rank 0
+/// [[[A02, A03], [A12, A13], [A22, A23], [A32, A33]],
+///  [[A42, A43], [A52, A53], [A62, A63], [A72, A73]]]
+/// Rank 3 <-> Rank 1
+/// [[[A06, A07], [A16, A17], [A26, A27], [A36, A37]],
+///  [[A46, A47], [A56, A57], [A66, A67], [A76, A77]]]
+///
+/// After all2all communication with transpose
+/// Rank 0
+/// [[[A00, A01], [A10, A11], [A20, A21], [A30, A31]],
+///  [[A40, A41], [A50, A51], [A60, A61], [A70, A71]]]
+/// Rank 1
+/// [[[A04, A05], [A14, A15], [A24, A25], [A34, A35]],
+///  [[A44, A45], [A54, A55], [A64, A65], [A74, A75]]]
+/// Rank 2
+/// [[[A02, A03], [A12, A13], [A22, A23], [A32, A33]],
+///  [[A42, A43], [A52, A53], [A62, A63], [A72, A73]]]
+/// Rank 3
+/// [[[A06, A07], [A16, A17], [A26, A27], [A36, A37]],
+///  [[A46, A47], [A56, A57], [A66, A67], [A76, A77]]]
+/// \tparam T Data type
+/// \tparam LayoutType Layout of the data (LayoutLeft or LayoutRight)
+///
+/// \param[in] rank MPI rank
+/// \param[in] nprocs Number of MPI ranks
+/// \param[in] use_tpl_wrapper Whether to use template wrapper
+template <typename T, typename LayoutType>
+void test_all2all_view2D_row(int rank, int npx, int npy, bool use_tpl_wrapper) {
+  using float_type = KokkosFFT::Impl::base_floating_point_type<T>;
+  using View3DType = Kokkos::View<T***, LayoutType, execution_space>;
+
+  const std::size_t n0 = 8, n1 = 8;
+  const std::size_t n0_local = n0 / npx;
+  const std::size_t n1_local = n1 / (npx * npy);
+  int rx = rank / npy, ry = rank % npy;
+
+  int n0_buffer = 0, n1_buffer = 0, n2_buffer = 0;
+  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
+    n0_buffer = n0_local;
+    n1_buffer = n1_local;
+    n2_buffer = npx;
+  } else {
+    n0_buffer = npx;
+    n1_buffer = n0_local;
+    n2_buffer = n1_local;
+  }
+
+  View3DType send("send", n0_buffer, n1_buffer, n2_buffer),
+      recv("recv", n0_buffer, n1_buffer, n2_buffer),
+      ref("ref", n0_buffer, n1_buffer, n2_buffer);
+
+  auto h_send = Kokkos::create_mirror_view(send);
+  auto h_ref  = Kokkos::create_mirror_view(ref);
+  for (std::size_t i2 = 0; i2 < send.extent(2); i2++) {
+    for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
+      for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
+        if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
+          float_type value = static_cast<float_type>(
+              (ry * (n1 / npy) + i1) + (rx * (n0 / npx) + i0) * n1 +
+              i2 * send.extent(2));
+          float_type value_T = static_cast<float_type>(
+              i1 + rx * send.extent(1) + ry * (n1 / npy) + i0 * n1 +
+              i2 * (n0 / npx) * n1);
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
+        } else {
+          float_type value = static_cast<float_type>(
+              (ry * (n1 / npy) + i2) + (rx * (n0 / npx) + i1) * n1 +
+              i0 * send.extent(0));
+          float_type value_T = static_cast<float_type>(
+              i2 + rx * send.extent(0) + ry * (n1 / npy) + i1 * n1 +
+              i0 * (n0 / npx) * n1);
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(send, h_send);
+  Kokkos::deep_copy(ref, h_ref);
+
+  // Create a cartesian communicator
+  int dims[2]    = {npx, npy};
+  int periods[2] = {1, 1};
+  MPI_Comm cart_comm;
+  ::MPI_Cart_create(MPI_COMM_WORLD, 2, dims, periods, 0, &cart_comm);
+  ::MPI_Comm row_comm;
+
+  int remain_dims[2];
+
+  // keep Y‐axis for row_comm (all procs with same px)
+  remain_dims[0] = 1;
+  remain_dims[1] = 0;
+  ::MPI_Cart_sub(cart_comm, remain_dims, &row_comm);
+
+  execution_space exec;
+  if (use_tpl_wrapper) {
+    KokkosFFT::Distributed::Impl::TplComm<execution_space> comm(row_comm, exec);
+    KokkosFFT::Distributed::Impl::all2all(send, recv, comm);
+  } else {
+    KokkosFFT::Distributed::Impl::all2all(send, recv, row_comm);
+  }
+
+  auto h_recv = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), recv);
+
+  auto epsilon = std::numeric_limits<float_type>::epsilon() * 100;
+  for (std::size_t i2 = 0; i2 < send.extent(2); i2++) {
+    for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
+      for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
+        auto diff = Kokkos::abs(h_recv(i0, i1, i2) - h_ref(i0, i1, i2));
+        EXPECT_LE(diff, epsilon);
+      }
+    }
+  }
+
+  ::MPI_Comm_free(&row_comm);
+  ::MPI_Comm_free(&cart_comm);
+}
+
+/// \brief Test all2all communication for 2D Views
+/// For 8x8 matrix.
+/// Before MPI
+/// Rank 0
+/// [[A00, A01, A02, A03],
+///  [A10, A11, A12, A13],
+///  [A20, A21, A22, A23],
+///  [A30, A31, A32, A33]]
+/// Rank 1
+/// [[A04, A05, A06, A07],
+///  [A14, A15, A16, A17],
+///  [A24, A25, A26, A27],
+///  [A34, A35, A36, A37]]
+/// Rank 2
+/// [[A40, A41, A42, A43],
+///  [A50, A51, A52, A53],
+///  [A60, A61, A62, A63],
+///  [A70, A71, A72, A73]]
+/// Rank 3
+/// [[A44, A45, A46, A47],
+///  [A54, A55, A56, A57],
+///  [A64, A65, A66, A67],
+///  [A74, A75, A76, A77]]
+///
+/// Send buffer (Each rank has 2x2x4 matrix)
+/// Rank 0 <-> Rank 1
+/// [[[A00, A01, A02, A03],
+///   [A10, A11, A12, A13]],
+///  [[A20, A21, A22, A23],
+///   [A30, A31, A32, A33]]]
+/// Rank 1 <-> Rank 0
+/// [[[A04, A05, A06, A07],
+///   [A14, A15, A16, A17]],
+///  [[A24, A25, A26, A27],
+///   [A34, A35, A36, A37]]]
+/// Rank 2 <-> Rank 3
+/// [[[A40, A41, A42, A43],
+///   [A50, A51, A52, A53]],
+///  [[A60, A61, A62, A63],
+///   [A70, A71, A72, A73]]]
+/// Rank 3 <-> Rank 2
+/// [[[A44, A45, A46, A47],
+///   [A54, A55, A56, A57]],
+///  [[A64, A65, A66, A67],
+///   [A74, A75, A76, A77]]]
+///
+/// Receive buffer (Each rank has 2x2x4 matrix)
+/// Rank 0 <-> Rank 1
+/// [[[A00, A01, A02, A03],
+///   [A10, A11, A12, A13]],
+///  [[A04, A05, A06, A07],
+///   [A14, A15, A16, A17]]]
+/// Rank 1 <-> Rank 0
+/// [[[A20, A21, A22, A23],
+///   [A30, A31, A32, A33]],
+///  [[A24, A25, A26, A27],
+///   [A34, A35, A36, A37]]]
+/// Rank 2 <-> Rank 3
+/// [[[A40, A41, A42, A43],
+///   [A50, A51, A52, A53]],
+///  [[A44, A45, A46, A47],
+///   [A54, A55, A56, A57]]]
+/// Rank 3 <-> Rank 2
+/// [[[A60, A61, A62, A63],
+///   [A70, A71, A72, A73]],
+///  [[A64, A65, A66, A67],
+///   [A74, A75, A76, A77]]]
+///
+/// After all2all communication with transpose
+/// Rank 0
+/// [[A00, A01, A02, A03, A04, A05, A06, A07],
+///  [A10, A11, A12, A13, A14, A15, A16, A17]]
+/// Rank 1
+/// [[A40, A41, A42, A43, A44, A45, A46, A47],
+///  [A50, A51, A52, A53, A54, A55, A56, A57]]
+/// Rank 2
+/// [[A20, A21, A22, A23, A24, A25, A26, A27],
+///  [A30, A31, A32, A33, A34, A35, A36, A37]]
+/// Rank 3
+/// [[A60, A61, A62, A63, A64, A65, A66, A67],
+///  [A70, A71, A72, A73, A74, A75, A76, A77]]
+/// \tparam T Data type
+/// \tparam LayoutType Layout of the data (LayoutLeft or LayoutRight)
+///
+/// \param[in] rank MPI rank
+/// \param[in] nprocs Number of MPI ranks
+/// \param[in] use_tpl_wrapper Whether to use template wrapper
+template <typename T, typename LayoutType>
+void test_all2all_view2D_col(int rank, int npx, int npy, bool use_tpl_wrapper) {
+  using float_type = KokkosFFT::Impl::base_floating_point_type<T>;
+  using View3DType = Kokkos::View<T***, LayoutType, execution_space>;
+
+  const std::size_t n0 = 8, n1 = 8;
+  const std::size_t n0_local = n0 / (npx * npy);
+  const std::size_t n1_local = ((n1 - 1) / npy) + 1;
+  int rx = rank / npy, ry = rank % npy;
+
+  int n0_buffer = 0, n1_buffer = 0, n2_buffer = 0;
+  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
+    n0_buffer = n0_local;
+    n1_buffer = n1_local;
+    n2_buffer = npy;
+  } else {
+    n0_buffer = npy;
+    n1_buffer = n0_local;
+    n2_buffer = n1_local;
+  }
+
+  View3DType send("send", n0_buffer, n1_buffer, n2_buffer),
+      recv("recv", n0_buffer, n1_buffer, n2_buffer),
+      ref("ref", n0_buffer, n1_buffer, n2_buffer);
+
+  auto h_send = Kokkos::create_mirror_view(send);
+  auto h_ref  = Kokkos::create_mirror_view(ref);
+  for (std::size_t i2 = 0; i2 < send.extent(2); i2++) {
+    for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
+      for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
+        if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
+          float_type value = static_cast<float_type>(
+              (ry * send.extent(1) + i1) + (rx * (n0 / npx) + i0) * n1 +
+              i2 * send.extent(2) * n1);
+          float_type value_T =
+              static_cast<float_type>(i1 + (i0 + ry * send.extent(0)) * n1 +
+                                      (i2 + rx * n1) * (n0 / npx));
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
+        } else {
+          float_type value = static_cast<float_type>(
+              (ry * send.extent(2) + i2) + (rx * (n0 / npx) + i1) * n1 +
+              i0 * send.extent(0) * n1);
+          float_type value_T =
+              static_cast<float_type>(i2 + (i1 + ry * send.extent(0)) * n1 +
+                                      (i0 + rx * n1) * (n0 / npx));
+          if constexpr (KokkosFFT::Impl::is_complex_v<T>) {
+            h_send(i0, i1, i2) = T(value, value);
+            h_ref(i0, i1, i2)  = T(value_T, value_T);
+          } else {
+            h_send(i0, i1, i2) = value;
+            h_ref(i0, i1, i2)  = value_T;
+          }
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(send, h_send);
+  Kokkos::deep_copy(ref, h_ref);
+
+  // Create a cartesian communicator
+  int dims[2]    = {npx, npy};
+  int periods[2] = {1, 1};
+  MPI_Comm cart_comm;
+  ::MPI_Cart_create(MPI_COMM_WORLD, 2, dims, periods, 0, &cart_comm);
+
+  ::MPI_Comm col_comm;
+
+  int remain_dims[2];
+
+  // keep X‐axis for col_comm (all procs with same py)
+  remain_dims[0] = 0;
+  remain_dims[1] = 1;
+  ::MPI_Cart_sub(cart_comm, remain_dims, &col_comm);
+
+  execution_space exec;
+  if (use_tpl_wrapper) {
+    KokkosFFT::Distributed::Impl::TplComm<execution_space> comm(col_comm, exec);
+    KokkosFFT::Distributed::Impl::all2all(send, recv, comm);
+  } else {
+    KokkosFFT::Distributed::Impl::all2all(send, recv, col_comm);
+  }
+
+  auto h_recv = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), recv);
+
+  auto epsilon = std::numeric_limits<float_type>::epsilon() * 100;
+  for (std::size_t i2 = 0; i2 < send.extent(2); i2++) {
+    for (std::size_t i1 = 0; i1 < send.extent(1); i1++) {
+      for (std::size_t i0 = 0; i0 < send.extent(0); i0++) {
+        auto diff = Kokkos::abs(h_recv(i0, i1, i2) - h_ref(i0, i1, i2));
+        EXPECT_LE(diff, epsilon);
+      }
+    }
+  }
+
+  ::MPI_Comm_free(&col_comm);
+  ::MPI_Comm_free(&cart_comm);
 }
 
 }  // namespace
 
 TYPED_TEST_SUITE(TestAll2All, test_types);
 
-TYPED_TEST(TestAll2All, View2D) {
+TYPED_TEST(TestAll2All, RView2D) {
   using float_type  = typename TestFixture::float_type;
   using layout_type = typename TestFixture::layout_type;
-  test_all2all_view2D<float_type, layout_type>(this->m_rank, this->m_nprocs);
+  test_all2all_view2D<float_type, layout_type>(this->m_rank, this->m_nprocs,
+                                               false);
+}
+
+TYPED_TEST(TestAll2All, CView2D) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+  test_all2all_view2D<complex_type, layout_type>(this->m_rank, this->m_nprocs,
+                                                 false);
+}
+
+TYPED_TEST(TestAll2All, RView2D_with_wrapper) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+  test_all2all_view2D<float_type, layout_type>(this->m_rank, this->m_nprocs,
+                                               true);
+}
+
+TYPED_TEST(TestAll2All, CView2D_with_wrapper) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+  test_all2all_view2D<complex_type, layout_type>(this->m_rank, this->m_nprocs,
+                                                 true);
 }
 
 TYPED_TEST(TestAll2All, View2D_incorrect_proc_size) {
   using float_type  = typename TestFixture::float_type;
   using layout_type = typename TestFixture::layout_type;
   test_all2all_view2D_incorrect_proc_size<float_type, layout_type>(
-      this->m_nprocs);
+      this->m_nprocs, false);
+}
+
+TYPED_TEST(TestAll2All, View2D_incorrect_proc_size_with_wrapper) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+  test_all2all_view2D_incorrect_proc_size<float_type, layout_type>(
+      this->m_nprocs, true);
+}
+
+TYPED_TEST(TestAll2All, RView2D_row) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_row<float_type, layout_type>(this->m_rank, this->m_npx,
+                                                   this->m_npx, false);
+}
+
+TYPED_TEST(TestAll2All, CView2D_row) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_row<complex_type, layout_type>(this->m_rank, this->m_npx,
+                                                     this->m_npx, false);
+}
+
+TYPED_TEST(TestAll2All, RView2D_row_with_wrapper) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_row<float_type, layout_type>(this->m_rank, this->m_npx,
+                                                   this->m_npx, true);
+}
+
+TYPED_TEST(TestAll2All, CView2D_row_with_wrapper) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_row<complex_type, layout_type>(this->m_rank, this->m_npx,
+                                                     this->m_npx, true);
+}
+
+TYPED_TEST(TestAll2All, RView2D_col) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_col<float_type, layout_type>(this->m_rank, this->m_npx,
+                                                   this->m_npx, false);
+}
+
+TYPED_TEST(TestAll2All, CView2D_col) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_col<complex_type, layout_type>(this->m_rank, this->m_npx,
+                                                     this->m_npx, false);
+}
+
+TYPED_TEST(TestAll2All, RView2D_col_with_wrapper) {
+  using float_type  = typename TestFixture::float_type;
+  using layout_type = typename TestFixture::layout_type;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_col<float_type, layout_type>(this->m_rank, this->m_npx,
+                                                   this->m_npx, true);
+}
+
+TYPED_TEST(TestAll2All, CView2D_col_with_wrapper) {
+  using float_type   = typename TestFixture::float_type;
+  using layout_type  = typename TestFixture::layout_type;
+  using complex_type = Kokkos::complex<float_type>;
+
+  if (this->m_nprocs == 1 || this->m_npx * this->m_npx != this->m_nprocs) {
+    GTEST_SKIP() << "The number of MPI processes should be a perfect square "
+                    "for this test";
+  }
+
+  test_all2all_view2D_col<complex_type, layout_type>(this->m_rank, this->m_npx,
+                                                     this->m_npx, true);
 }

--- a/distributed/unit_test/Test_MPI_Types.cpp
+++ b/distributed/unit_test/Test_MPI_Types.cpp
@@ -8,9 +8,12 @@
 #include "KokkosFFT_Distributed_MPI_Types.hpp"
 
 namespace {
-using test_types =
-    ::testing::Types<int, std::size_t, float, double, Kokkos::complex<float>,
-                     Kokkos::complex<double>>;
+using test_types = ::testing::Types<
+    char, unsigned char, short, unsigned short, int, unsigned int, long,
+    unsigned long, long long, unsigned long long, std::int8_t, std::uint8_t,
+    std::int16_t, std::uint16_t, std::int32_t, std::uint32_t, std::int64_t,
+    std::uint64_t, std::size_t, std::ptrdiff_t, float, double,
+    Kokkos::complex<float>, Kokkos::complex<double>>;
 
 template <typename T>
 struct TestMPIType : public ::testing::Test {
@@ -19,20 +22,68 @@ struct TestMPIType : public ::testing::Test {
 
 template <typename T>
 void test_mpi_data_type() {
-  MPI_Datatype mpi_type = KokkosFFT::Distributed::Impl::MPIDataType<T>::type();
+  MPI_Datatype mpi_type = KokkosFFT::Distributed::Impl::mpi_datatype_v<T>;
 
-  if constexpr (std::is_same_v<T, int>) {
+  if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(mpi_type, MPI_CHAR);
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    ASSERT_EQ(mpi_type, MPI_UNSIGNED_CHAR);
+  } else if constexpr (std::is_same_v<T, short>) {
+    ASSERT_EQ(mpi_type, MPI_SHORT);
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    ASSERT_EQ(mpi_type, MPI_UNSIGNED_SHORT);
+  } else if constexpr (std::is_same_v<T, int>) {
     ASSERT_EQ(mpi_type, MPI_INT32_T);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
+  } else if constexpr (std::is_same_v<T, unsigned int>) {
+    ASSERT_EQ(mpi_type, MPI_UINT32_T);
+  } else if constexpr (std::is_same_v<T, long>) {
+    ASSERT_EQ(mpi_type, MPI_LONG);
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    ASSERT_EQ(mpi_type, MPI_UNSIGNED_LONG);
+  } else if constexpr (std::is_same_v<T, long long>) {
+    ASSERT_EQ(mpi_type, MPI_LONG_LONG);
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    ASSERT_EQ(mpi_type, MPI_UNSIGNED_LONG_LONG);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(mpi_type, MPI_INT8_T);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(mpi_type, MPI_UINT8_T);
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    ASSERT_EQ(mpi_type, MPI_INT16_T);
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    ASSERT_EQ(mpi_type, MPI_UINT16_T);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(mpi_type, MPI_INT32_T);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(mpi_type, MPI_UINT32_T);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(mpi_type, MPI_INT64_T);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
     ASSERT_EQ(mpi_type, MPI_UINT64_T);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == sizeof(unsigned int)) {
+      ASSERT_EQ(mpi_type, MPI_UNSIGNED);
+    } else if constexpr (sizeof(std::size_t) == sizeof(unsigned long)) {
+      ASSERT_EQ(mpi_type, MPI_UNSIGNED_LONG);
+    } else if constexpr (sizeof(std::size_t) == sizeof(unsigned long long)) {
+      ASSERT_EQ(mpi_type, MPI_UNSIGNED_LONG_LONG);
+    }
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == sizeof(int)) {
+      ASSERT_EQ(mpi_type, MPI_INT);
+    } else if constexpr (sizeof(std::ptrdiff_t) == sizeof(long)) {
+      ASSERT_EQ(mpi_type, MPI_LONG);
+    } else if constexpr (sizeof(std::ptrdiff_t) == sizeof(long long)) {
+      ASSERT_EQ(mpi_type, MPI_LONG_LONG);
+    }
   } else if constexpr (std::is_same_v<T, float>) {
     ASSERT_EQ(mpi_type, MPI_FLOAT);
   } else if constexpr (std::is_same_v<T, double>) {
     ASSERT_EQ(mpi_type, MPI_DOUBLE);
   } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
-    ASSERT_EQ(mpi_type, MPI_CXX_FLOAT_COMPLEX);
+    ASSERT_EQ(mpi_type, MPI_COMPLEX);
   } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-    ASSERT_EQ(mpi_type, MPI_CXX_DOUBLE_COMPLEX);
+    ASSERT_EQ(mpi_type, MPI_DOUBLE_COMPLEX);
   }
 }
 

--- a/distributed/unit_test/Test_TplComm.cpp
+++ b/distributed/unit_test/Test_TplComm.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Distributed_All2All.hpp"

--- a/distributed/unit_test/Test_TplComm.cpp
+++ b/distributed/unit_test/Test_TplComm.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Distributed_All2All.hpp"
+
+namespace {
+#if defined(KOKKOS_ENABLE_SERIAL)
+using execution_spaces =
+    ::testing::Types<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace,
+                     Kokkos::DefaultExecutionSpace>;
+#else
+using execution_spaces = ::testing::Types<Kokkos::DefaultHostExecutionSpace,
+                                          Kokkos::DefaultExecutionSpace>;
+#endif
+
+// Basically the same fixtures, used for labeling tests
+template <typename T>
+struct TestTplComm : public ::testing::Test {
+  using execution_space_type = T;
+
+  virtual void SetUp() {
+    GTEST_SKIP() << "Skipping all tests for this fixture";
+  }
+};
+
+template <typename ExecutionSpace>
+void test_is_comm_constructible() {
+  using CommType = KokkosFFT::Distributed::Impl::TplComm<ExecutionSpace>;
+
+  // Constructors
+  static_assert(
+      std::is_constructible_v<CommType, MPI_Comm, const ExecutionSpace&>);
+  static_assert(std::is_constructible_v<CommType, MPI_Comm>);
+
+  // Should not be default constructible
+  static_assert(!std::is_default_constructible_v<CommType>);
+
+  // Should not be copyable
+  static_assert(!std::is_copy_constructible_v<CommType>);
+  static_assert(!std::is_copy_assignable_v<CommType>);
+
+  // Should be movable
+  static_assert(std::is_move_constructible_v<CommType>);
+  static_assert(std::is_move_assignable_v<CommType>);
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestTplComm, execution_spaces);
+
+// Tests for constructibility
+TYPED_TEST(TestTplComm, is_constructible) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  test_is_comm_constructible<execution_space_type>();
+}


### PR DESCRIPTION
This PR aims at introducing a thin MPI wrapper to abstract communication layer.
Also, tests for All2all have been improved. 
See also [this](https://github.com/yasahi-hpc/distributed-FFT-for-kokkos/blob/main/distributed/src/KokkosFFT_Distributed_All2All.hpp) how the wrapper is implemented.

- [x] `ScopedMPIComm` is introduced
- [x] Original `alltoall` wrapper has been moved from `KokkosFFT_Distributed_All2All.hpp`  to `KokkosFFT_Distributed_MPI_All2All.hpp`
- [x] Add tests with sub-communicators in `Test_All2All.cpp`  