### PR TITLE
Allow inplace FFT even with internal transpose

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -87,6 +87,50 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
   return modified_shape;
 }
 
+/// \brief Compute padded extents from the extents in Fourier space
+///
+/// Example, if the first FFT dimension is the 2nd dimension
+/// in extents (real): (8, 7, 8)
+/// out extents (complex): (8, 7, 5)
+/// axes: (0, 1, 2)
+/// FFT is operated from 2nd axis, so we have
+/// padded extents (real): (8, 7, 10)
+///
+/// if input is complex, then just return in_extents
+///
+/// \tparam iType The integer type used for extents
+/// \tparam DIM The number of dimensions of the extents.
+/// \tparam FFT_DIM The number of dimensions of the FFT.
+///
+/// \param[in] extents Extents of the input View
+/// \param[in] extents Extents of the output View
+/// \param[in] axes Axes of the transform
+/// \param[in] is_R2C Whether it is real to complex or not
+/// \return A extents of the padded view
+template <typename iType, std::size_t DIM, std::size_t FFT_DIM>
+auto compute_padded_extents(const std::array<iType, DIM>& in_extents,
+                            const std::array<iType, DIM>& out_extents,
+                            const std::array<iType, FFT_DIM>& axes,
+                            bool is_R2C) {
+  static_assert(std::is_integral_v<iType>,
+                "compute_padded_extents: iType must be an integral type");
+  static_assert(
+      FFT_DIM >= 1 && FFT_DIM <= KokkosFFT::MAX_FFT_DIM,
+      "compute_padded_extents: the Rank of FFT axes must be between 1 and 3");
+  static_assert(
+      DIM >= FFT_DIM,
+      "compute_padded_extents: View rank must be larger than or equal to "
+      "the Rank of FFT axes");
+
+  if (!is_R2C) return in_extents;
+
+  std::array<iType, DIM> padded_extents = out_extents;
+  auto last_axis                        = axes.back();
+  padded_extents.at(last_axis) *= 2;
+
+  return padded_extents;
+}
+
 /// \brief Compute input, output and fft extents required for FFT
 /// libraries based on the input view, output view, axes and shape.
 /// Extents are converted into Layout Right

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -96,15 +96,18 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
 /// FFT is operated from 2nd axis, so we have
 /// padded extents (real): (8, 7, 10)
 ///
-/// if input is complex, then just return extents
+/// if ValueType is complex, then just return extents
 ///
-/// \tparam ValueType The value type of the input view
+/// \tparam ValueType The type used to determine whether padding is required;
+/// real types are padded, while complex types return extents unchanged
 /// \tparam iType The integer type used for extents
-/// \tparam DIM The number of dimensions of the extents.
-/// \tparam FFT_DIM The number of dimensions of the FFT.
+/// \tparam DIM The number of dimensions of the extents
+/// \tparam FFT_DIM The number of dimensions of the FFT
 ///
-/// \param[in] extents Extents of the View
+/// \param[in] extents Extents to be padded if ValueType is real
 /// \param[in] axes Axes of the transform
+/// \return Padded extents if ValueType is real, otherwise returns extents
+/// unchanged
 template <typename ValueType, typename iType, std::size_t DIM,
           std::size_t FFT_DIM>
 auto compute_padded_extents(const std::array<iType, DIM>& extents,

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -96,22 +96,19 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
 /// FFT is operated from 2nd axis, so we have
 /// padded extents (real): (8, 7, 10)
 ///
-/// if input is complex, then just return in_extents
+/// if input is complex, then just return extents
 ///
+/// \tparam ValueType The value type of the input view
 /// \tparam iType The integer type used for extents
 /// \tparam DIM The number of dimensions of the extents.
 /// \tparam FFT_DIM The number of dimensions of the FFT.
 ///
-/// \param[in] in_extents Extents of the input View
-/// \param[in] out_extents Extents of the output View
+/// \param[in] extents Extents of the View
 /// \param[in] axes Axes of the transform
-/// \param[in] is_R2C Whether it is real to complex or not
-/// \return A extents of the padded view
-template <typename iType, std::size_t DIM, std::size_t FFT_DIM>
-auto compute_padded_extents(const std::array<iType, DIM>& in_extents,
-                            const std::array<iType, DIM>& out_extents,
-                            const std::array<iType, FFT_DIM>& axes,
-                            bool is_R2C) {
+template <typename ValueType, typename iType, std::size_t DIM,
+          std::size_t FFT_DIM>
+auto compute_padded_extents(const std::array<iType, DIM>& extents,
+                            const std::array<iType, FFT_DIM>& axes) {
   static_assert(std::is_integral_v<iType>,
                 "compute_padded_extents: iType must be an integral type");
   static_assert(
@@ -122,9 +119,9 @@ auto compute_padded_extents(const std::array<iType, DIM>& in_extents,
       "compute_padded_extents: View rank must be larger than or equal to "
       "the Rank of FFT axes");
 
-  if (!is_R2C) return in_extents;
+  if constexpr (is_complex_v<ValueType>) return extents;
 
-  std::array<iType, DIM> padded_extents = out_extents;
+  std::array<iType, DIM> padded_extents = extents;
   auto last_axis                        = axes.back();
   padded_extents.at(last_axis) *= 2;
 

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -102,8 +102,8 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
 /// \tparam DIM The number of dimensions of the extents.
 /// \tparam FFT_DIM The number of dimensions of the FFT.
 ///
-/// \param[in] extents Extents of the input View
-/// \param[in] extents Extents of the output View
+/// \param[in] in_extents Extents of the input View
+/// \param[in] out_extents Extents of the output View
 /// \param[in] axes Axes of the transform
 /// \param[in] is_R2C Whether it is real to complex or not
 /// \return A extents of the padded view

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -83,17 +83,14 @@ void test_padded_extents() {
   extents3D_type in_extents3{n0, n1, n2}, out_extents3_ax0{n0h, n1, n2},
       out_extents3_ax1{n0, n1h, n2}, out_extents3_ax2{n0, n1, n2h};
 
-  axes1D_type ax0{0}, ax1{1}, ax2{2};
-  axes2D_type ax01{0, 1}, ax02{0, 2}, ax10{1, 0}, ax12{1, 2}, ax20{2, 0},
-      ax21{2, 1};
+  axes1D_type ax0{0};
+  axes2D_type ax01{0, 1}, ax10{1, 0};
   axes3D_type ax012{0, 1, 2}, ax021{0, 2, 1}, ax102{1, 0, 2}, ax120{1, 2, 0},
       ax201{2, 0, 1}, ax210{2, 1, 0};
 
-  std::vector<axes1D_type> all1D_axes{ax0};
-  std::vector<axes2D_type> all2D_axes{ax01, ax10};
-  std::vector<axes3D_type> all3D_axes{ax012, ax021, ax102, ax120, ax201, ax210};
-
   if constexpr (is_R2C) {
+    axes1D_type ax1{1}, ax2{2};
+    axes2D_type ax02{0, 2}, ax12{1, 2}, ax20{2, 0}, ax21{2, 1};
     auto ref_padded_extents1     = out_extents1;
     auto ref_padded_extents2_ax0 = out_extents2_ax0;
     auto ref_padded_extents2_ax1 = out_extents2_ax1;

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -11,9 +11,15 @@
 
 namespace {
 using execution_space = Kokkos::DefaultExecutionSpace;
+using test_int_types  = ::testing::Types<int, std::size_t>;
 using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 
 // Basically the same fixtures, used for labeling tests
+template <typename T>
+struct TestPaddedExtents : public ::testing::Test {
+  using value_type = T;
+};
+
 template <typename T>
 struct TestGetExtents1D : public ::testing::Test {
   using layout_type = T;
@@ -52,6 +58,151 @@ void test_extent_after_transform() {
     auto n1h = KokkosFFT::Impl::extent_after_transform(n1, is_R2C);
     EXPECT_EQ(n0h, n0);
     EXPECT_EQ(n1h, n1);
+  }
+}
+
+// Tests for padded_extents
+template <typename T, typename iType>
+void test_padded_extents() {
+  using extents1D_type = std::array<iType, 1>;
+  using extents2D_type = std::array<iType, 2>;
+  using extents3D_type = std::array<iType, 3>;
+  using axes1D_type    = std::array<iType, 1>;
+  using axes2D_type    = std::array<iType, 2>;
+  using axes3D_type    = std::array<iType, 3>;
+
+  constexpr bool is_R2C = KokkosFFT::Impl::is_real_v<T>;
+  const iType n0 = 5, n1 = 6, n2 = 7;
+  const iType n0h = KokkosFFT::Impl::extent_after_transform(n0, is_R2C),
+              n1h = KokkosFFT::Impl::extent_after_transform(n1, is_R2C),
+              n2h = KokkosFFT::Impl::extent_after_transform(n2, is_R2C);
+
+  extents1D_type in_extents1{n0}, out_extents1{n0h};
+  extents2D_type in_extents2{n0, n1}, out_extents2_ax0{n0h, n1},
+      out_extents2_ax1{n0, n1h};
+  extents3D_type in_extents3{n0, n1, n2}, out_extents3_ax0{n0h, n1, n2},
+      out_extents3_ax1{n0, n1h, n2}, out_extents3_ax2{n0, n1, n2h};
+
+  axes1D_type ax0{0}, ax1{1}, ax2{2};
+  axes2D_type ax01{0, 1}, ax02{0, 2}, ax10{1, 0}, ax12{1, 2}, ax20{2, 0},
+      ax21{2, 1};
+  axes3D_type ax012{0, 1, 2}, ax021{0, 2, 1}, ax102{1, 0, 2}, ax120{1, 2, 0},
+      ax201{2, 0, 1}, ax210{2, 1, 0};
+
+  std::vector<axes1D_type> all1D_axes{ax0};
+  std::vector<axes2D_type> all2D_axes{ax01, ax10};
+  std::vector<axes3D_type> all3D_axes{ax012, ax021, ax102, ax120, ax201, ax210};
+
+  if constexpr (is_R2C) {
+    auto ref_padded_extents1     = out_extents1;
+    auto ref_padded_extents2_ax0 = out_extents2_ax0;
+    auto ref_padded_extents2_ax1 = out_extents2_ax1;
+    auto ref_padded_extents3_ax0 = out_extents3_ax0;
+    auto ref_padded_extents3_ax1 = out_extents3_ax1;
+    auto ref_padded_extents3_ax2 = out_extents3_ax2;
+
+    ref_padded_extents1.at(0) *= 2;
+    ref_padded_extents2_ax0.at(0) *= 2;
+    ref_padded_extents2_ax1.at(1) *= 2;
+    ref_padded_extents3_ax0.at(0) *= 2;
+    ref_padded_extents3_ax1.at(1) *= 2;
+    ref_padded_extents3_ax2.at(2) *= 2;
+
+    auto padded_extents1 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents1, out_extents1, ax0, is_R2C);
+    EXPECT_EQ(padded_extents1, ref_padded_extents1);
+
+    auto padded_extents2_ax0 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents2, out_extents2_ax0, ax0, is_R2C);
+    auto padded_extents2_ax1 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents2, out_extents2_ax1, ax1, is_R2C);
+    auto padded_extents2_ax01 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents2, out_extents2_ax1, ax01, is_R2C);
+    auto padded_extents2_ax10 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents2, out_extents2_ax0, ax10, is_R2C);
+    EXPECT_EQ(padded_extents2_ax0, ref_padded_extents2_ax0);
+    EXPECT_EQ(padded_extents2_ax1, ref_padded_extents2_ax1);
+    EXPECT_EQ(padded_extents2_ax01, ref_padded_extents2_ax1);
+    EXPECT_EQ(padded_extents2_ax10, ref_padded_extents2_ax0);
+
+    auto padded_extents3_ax0 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax0, ax0, is_R2C);
+    auto padded_extents3_ax1 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax1, ax1, is_R2C);
+    auto padded_extents3_ax2 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax2, ax2, is_R2C);
+    auto padded_extents3_ax01 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax1, ax01, is_R2C);
+    auto padded_extents3_ax02 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax2, ax02, is_R2C);
+    auto padded_extents3_ax10 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax0, ax10, is_R2C);
+    auto padded_extents3_ax12 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax2, ax12, is_R2C);
+    auto padded_extents3_ax20 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax0, ax20, is_R2C);
+    auto padded_extents3_ax21 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax1, ax21, is_R2C);
+    auto padded_extents3_ax012 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax2, ax012, is_R2C);
+    auto padded_extents3_ax021 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax1, ax021, is_R2C);
+    auto padded_extents3_ax102 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax2, ax102, is_R2C);
+    auto padded_extents3_ax120 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax0, ax120, is_R2C);
+    auto padded_extents3_ax201 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax1, ax201, is_R2C);
+    auto padded_extents3_ax210 = KokkosFFT::Impl::compute_padded_extents(
+        in_extents3, out_extents3_ax0, ax210, is_R2C);
+    EXPECT_EQ(padded_extents3_ax0, ref_padded_extents3_ax0);
+    EXPECT_EQ(padded_extents3_ax1, ref_padded_extents3_ax1);
+    EXPECT_EQ(padded_extents3_ax2, ref_padded_extents3_ax2);
+    EXPECT_EQ(padded_extents3_ax01, ref_padded_extents3_ax1);
+    EXPECT_EQ(padded_extents3_ax02, ref_padded_extents3_ax2);
+    EXPECT_EQ(padded_extents3_ax10, ref_padded_extents3_ax0);
+    EXPECT_EQ(padded_extents3_ax12, ref_padded_extents3_ax2);
+    EXPECT_EQ(padded_extents3_ax20, ref_padded_extents3_ax0);
+    EXPECT_EQ(padded_extents3_ax21, ref_padded_extents3_ax1);
+    EXPECT_EQ(padded_extents3_ax012, ref_padded_extents3_ax2);
+    EXPECT_EQ(padded_extents3_ax021, ref_padded_extents3_ax1);
+    EXPECT_EQ(padded_extents3_ax102, ref_padded_extents3_ax2);
+    EXPECT_EQ(padded_extents3_ax120, ref_padded_extents3_ax0);
+    EXPECT_EQ(padded_extents3_ax201, ref_padded_extents3_ax1);
+    EXPECT_EQ(padded_extents3_ax210, ref_padded_extents3_ax0);
+  } else {
+    // For complex data, just return the input
+    std::vector<axes1D_type> all_axes1D{ax0};
+    std::vector<axes2D_type> all_axes2D{ax01, ax10};
+    std::vector<axes3D_type> all_axes3D{ax012, ax021, ax102,
+                                        ax120, ax201, ax210};
+
+    for (auto axes1D : all_axes1D) {
+      auto padded_extents1 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents1, out_extents1, axes1D, is_R2C);
+      EXPECT_EQ(padded_extents1, in_extents1);
+    }
+
+    for (auto axes2D : all_axes2D) {
+      auto padded_extents2_ax0 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents2, out_extents2_ax0, axes2D, is_R2C);
+      auto padded_extents2_ax1 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents2, out_extents2_ax1, axes2D, is_R2C);
+      EXPECT_EQ(padded_extents2_ax0, in_extents2);
+      EXPECT_EQ(padded_extents2_ax1, in_extents2);
+    }
+
+    for (auto axes3D : all_axes3D) {
+      auto padded_extents3_ax0 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents3, out_extents3_ax0, axes3D, is_R2C);
+      auto padded_extents3_ax1 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents3, out_extents3_ax1, axes3D, is_R2C);
+      auto padded_extents3_ax2 = KokkosFFT::Impl::compute_padded_extents(
+          in_extents3, out_extents3_ax2, axes3D, is_R2C);
+      EXPECT_EQ(padded_extents3_ax0, in_extents3);
+      EXPECT_EQ(padded_extents3_ax1, in_extents3);
+      EXPECT_EQ(padded_extents3_ax2, in_extents3);
+    }
   }
 }
 
@@ -835,6 +986,7 @@ void test_extents_2d_view_3d(bool is_static = true) {
 
 }  // namespace
 
+TYPED_TEST_SUITE(TestPaddedExtents, test_int_types);
 TYPED_TEST_SUITE(TestGetExtents1D, test_types);
 TYPED_TEST_SUITE(TestGetExtents2D, test_types);
 TYPED_TEST_SUITE(TestGetDynExtents1D, test_types);
@@ -849,6 +1001,19 @@ TEST(TestGetOutputExtent, R2C) {
 TEST(TestGetOutputExtent, C2C) {
   using float_type = Kokkos::complex<double>;
   test_extent_after_transform<float_type>();
+}
+
+// Padded extents
+TYPED_TEST(TestPaddedExtents, R2C) {
+  using float_type = double;
+  using int_type   = typename TestFixture::value_type;
+  test_padded_extents<float_type, int_type>();
+}
+
+TYPED_TEST(TestPaddedExtents, C2C) {
+  using float_type = Kokkos::complex<double>;
+  using int_type   = typename TestFixture::value_type;
+  test_padded_extents<float_type, int_type>();
 }
 
 // get_extents with static dimension

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -77,11 +77,10 @@ void test_padded_extents() {
               n1h = KokkosFFT::Impl::extent_after_transform(n1, is_R2C),
               n2h = KokkosFFT::Impl::extent_after_transform(n2, is_R2C);
 
-  extents1D_type in_extents1{n0}, out_extents1{n0h};
-  extents2D_type in_extents2{n0, n1}, out_extents2_ax0{n0h, n1},
-      out_extents2_ax1{n0, n1h};
-  extents3D_type in_extents3{n0, n1, n2}, out_extents3_ax0{n0h, n1, n2},
-      out_extents3_ax1{n0, n1h, n2}, out_extents3_ax2{n0, n1, n2h};
+  extents1D_type out_extents1{n0h};
+  extents2D_type out_extents2_ax0{n0h, n1}, out_extents2_ax1{n0, n1h};
+  extents3D_type out_extents3_ax0{n0h, n1, n2}, out_extents3_ax1{n0, n1h, n2},
+      out_extents3_ax2{n0, n1, n2h};
 
   axes1D_type ax0{0};
   axes2D_type ax01{0, 1}, ax10{1, 0};
@@ -105,53 +104,53 @@ void test_padded_extents() {
     ref_padded_extents3_ax1.at(1) *= 2;
     ref_padded_extents3_ax2.at(2) *= 2;
 
-    auto padded_extents1 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents1, out_extents1, ax0, is_R2C);
+    auto padded_extents1 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents1, ax0);
     EXPECT_EQ(padded_extents1, ref_padded_extents1);
 
-    auto padded_extents2_ax0 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents2, out_extents2_ax0, ax0, is_R2C);
-    auto padded_extents2_ax1 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents2, out_extents2_ax1, ax1, is_R2C);
-    auto padded_extents2_ax01 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents2, out_extents2_ax1, ax01, is_R2C);
-    auto padded_extents2_ax10 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents2, out_extents2_ax0, ax10, is_R2C);
+    auto padded_extents2_ax0 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax0, ax0);
+    auto padded_extents2_ax1 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax1, ax1);
+    auto padded_extents2_ax01 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax1, ax01);
+    auto padded_extents2_ax10 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax0, ax10);
     EXPECT_EQ(padded_extents2_ax0, ref_padded_extents2_ax0);
     EXPECT_EQ(padded_extents2_ax1, ref_padded_extents2_ax1);
     EXPECT_EQ(padded_extents2_ax01, ref_padded_extents2_ax1);
     EXPECT_EQ(padded_extents2_ax10, ref_padded_extents2_ax0);
 
-    auto padded_extents3_ax0 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax0, ax0, is_R2C);
-    auto padded_extents3_ax1 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax1, ax1, is_R2C);
-    auto padded_extents3_ax2 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax2, ax2, is_R2C);
-    auto padded_extents3_ax01 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax1, ax01, is_R2C);
-    auto padded_extents3_ax02 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax2, ax02, is_R2C);
-    auto padded_extents3_ax10 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax0, ax10, is_R2C);
-    auto padded_extents3_ax12 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax2, ax12, is_R2C);
-    auto padded_extents3_ax20 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax0, ax20, is_R2C);
-    auto padded_extents3_ax21 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax1, ax21, is_R2C);
-    auto padded_extents3_ax012 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax2, ax012, is_R2C);
-    auto padded_extents3_ax021 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax1, ax021, is_R2C);
-    auto padded_extents3_ax102 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax2, ax102, is_R2C);
-    auto padded_extents3_ax120 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax0, ax120, is_R2C);
-    auto padded_extents3_ax201 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax1, ax201, is_R2C);
-    auto padded_extents3_ax210 = KokkosFFT::Impl::compute_padded_extents(
-        in_extents3, out_extents3_ax0, ax210, is_R2C);
+    auto padded_extents3_ax0 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, ax0);
+    auto padded_extents3_ax1 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, ax1);
+    auto padded_extents3_ax2 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, ax2);
+    auto padded_extents3_ax01 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, ax01);
+    auto padded_extents3_ax02 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, ax02);
+    auto padded_extents3_ax10 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, ax10);
+    auto padded_extents3_ax12 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, ax12);
+    auto padded_extents3_ax20 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, ax20);
+    auto padded_extents3_ax21 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, ax21);
+    auto padded_extents3_ax012 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, ax012);
+    auto padded_extents3_ax021 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, ax021);
+    auto padded_extents3_ax102 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, ax102);
+    auto padded_extents3_ax120 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, ax120);
+    auto padded_extents3_ax201 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, ax201);
+    auto padded_extents3_ax210 =
+        KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, ax210);
     EXPECT_EQ(padded_extents3_ax0, ref_padded_extents3_ax0);
     EXPECT_EQ(padded_extents3_ax1, ref_padded_extents3_ax1);
     EXPECT_EQ(padded_extents3_ax2, ref_padded_extents3_ax2);
@@ -175,30 +174,30 @@ void test_padded_extents() {
                                         ax120, ax201, ax210};
 
     for (auto axes1D : all_axes1D) {
-      auto padded_extents1 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents1, out_extents1, axes1D, is_R2C);
-      EXPECT_EQ(padded_extents1, in_extents1);
+      auto padded_extents1 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents1, axes1D);
+      EXPECT_EQ(padded_extents1, out_extents1);
     }
 
     for (auto axes2D : all_axes2D) {
-      auto padded_extents2_ax0 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents2, out_extents2_ax0, axes2D, is_R2C);
-      auto padded_extents2_ax1 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents2, out_extents2_ax1, axes2D, is_R2C);
-      EXPECT_EQ(padded_extents2_ax0, in_extents2);
-      EXPECT_EQ(padded_extents2_ax1, in_extents2);
+      auto padded_extents2_ax0 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax0, axes2D);
+      auto padded_extents2_ax1 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents2_ax1, axes2D);
+      EXPECT_EQ(padded_extents2_ax0, out_extents2_ax0);
+      EXPECT_EQ(padded_extents2_ax1, out_extents2_ax1);
     }
 
     for (auto axes3D : all_axes3D) {
-      auto padded_extents3_ax0 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents3, out_extents3_ax0, axes3D, is_R2C);
-      auto padded_extents3_ax1 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents3, out_extents3_ax1, axes3D, is_R2C);
-      auto padded_extents3_ax2 = KokkosFFT::Impl::compute_padded_extents(
-          in_extents3, out_extents3_ax2, axes3D, is_R2C);
-      EXPECT_EQ(padded_extents3_ax0, in_extents3);
-      EXPECT_EQ(padded_extents3_ax1, in_extents3);
-      EXPECT_EQ(padded_extents3_ax2, in_extents3);
+      auto padded_extents3_ax0 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax0, axes3D);
+      auto padded_extents3_ax1 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax1, axes3D);
+      auto padded_extents3_ax2 =
+          KokkosFFT::Impl::compute_padded_extents<T>(out_extents3_ax2, axes3D);
+      EXPECT_EQ(padded_extents3_ax0, out_extents3_ax0);
+      EXPECT_EQ(padded_extents3_ax1, out_extents3_ax1);
+      EXPECT_EQ(padded_extents3_ax2, out_extents3_ax2);
     }
   }
 }

--- a/distributed/src/KokkosFFT_Distributed_Extents.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Extents.hpp
@@ -14,32 +14,6 @@
 namespace KokkosFFT {
 namespace Distributed {
 namespace Impl {
-
-/// \brief Compute padded extents from the extents in Fourier space
-///
-/// Example, if the first FFT dimension is the 2nd dimension
-/// in extents (real): (8, 7, 8)
-/// out extents (complex): (8, 7, 5)
-/// axes: (0, 1, 2)
-/// FFT is operated from 2nd axis, so we have
-/// padded extents (real): (8, 7, 10)
-///
-/// \tparam DIM The number of dimensions of the extents.
-///
-/// \param[in] in_extents Extents of the global input View.
-/// \param[in] out_extents Extents of the global output View.
-/// \param[in] axes Axes of the transform
-/// \return A extents of the permuted view
-template <std::size_t DIM>
-auto compute_padded_extents(const std::array<std::size_t, DIM> &extents,
-                            const std::array<std::size_t, DIM> &axes) {
-  std::array<std::size_t, DIM> padded_extents = extents;
-  auto last_axis                              = axes.back();
-  padded_extents.at(last_axis) *= 2;
-
-  return padded_extents;
-}
-
 /// \brief Calculate the buffer extents based on the global extents,
 /// the in-topology, and the out-topology.
 ///

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -250,18 +250,20 @@ class Plan {
         constexpr std::size_t rank = InViewType::rank();
         auto non_negative_axes     = Impl::convert_base_int_type<std::size_t>(
             Impl::convert_negative_axes(m_axes, rank));
-        auto in_padded_extents = Impl::compute_padded_extents<in_value_type>(
-            m_in_extents, non_negative_axes);
-        auto out_padded_extents = Impl::compute_padded_extents<out_value_type>(
-            m_out_extents, non_negative_axes);
 
-        if (in_padded_extents != m_in_extents) {
+        if constexpr (Impl::is_real_v<in_value_type> &&
+                      Impl::is_complex_v<out_value_type>) {
+          auto in_padded_extents = Impl::compute_padded_extents<in_value_type>(
+              m_out_extents, non_negative_axes);
           in_padded =
               InViewType(in_tmp.data(),
                          Impl::create_layout<LayoutType>(in_padded_extents));
           to_bounds_check = true;
-        }
-        if (out_padded_extents != m_out_extents) {
+        } else if constexpr (Impl::is_complex_v<in_value_type> &&
+                             Impl::is_real_v<out_value_type>) {
+          auto out_padded_extents =
+              Impl::compute_padded_extents<out_value_type>(m_in_extents,
+                                                           non_negative_axes);
           out_padded = OutViewType(
               out.data(), Impl::create_layout<LayoutType>(out_padded_extents));
         }

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -62,11 +62,10 @@ template <typename ExecutionSpace, typename InViewType, typename OutViewType,
 class Plan {
  private:
   static_assert(
-      KokkosFFT::Impl::is_allowed_space_v<ExecutionSpace>,
+      Impl::is_allowed_space_v<ExecutionSpace>,
       "Plan: Backend FFT library is not available for the ExecutionSpace");
   KOKKOSFFT_STATIC_ASSERT_VIEWS_ARE_OPERATABLE(
-      (KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
-                                               OutViewType>),
+      (Impl::are_operatable_views_v<ExecutionSpace, InViewType, OutViewType>),
       "Plan");
   static_assert(DIM >= 1 && DIM <= KokkosFFT::MAX_FFT_DIM,
                 "Plan: the Rank of FFT axes must be between 1 and MAX_FFT_DIM");
@@ -84,15 +83,15 @@ class Plan {
   using out_value_type = typename OutViewType::non_const_value_type;
 
   //! The real value type of input/output views
-  using float_type = KokkosFFT::Impl::base_floating_point_type<in_value_type>;
+  using float_type = Impl::base_floating_point_type<in_value_type>;
 
   //! The layout type of input/output views
   using layout_type = typename InViewType::array_layout;
 
   //! The type of FFT plan
   using fft_plan_type =
-      typename KokkosFFT::Impl::FFTPlanType<ExecutionSpace, in_value_type,
-                                            out_value_type>::type;
+      typename Impl::FFTPlanType<ExecutionSpace, in_value_type,
+                                 out_value_type>::type;
 
   //! The type of extents of FFT
   using fft_extents_type = std::vector<std::size_t>;
@@ -172,38 +171,35 @@ class Plan {
                 const OutViewType& out, KokkosFFT::Direction direction,
                 axis_type<DIM> axes, shape_type<DIM> s = {})
       : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
-    KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, m_axes),
+    KOKKOSFFT_THROW_IF(!Impl::are_valid_axes(in, m_axes),
                        "axes are invalid for in/out views");
-    if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
+    if constexpr (Impl::is_real_v<in_value_type>) {
       KOKKOSFFT_THROW_IF(m_direction != KokkosFFT::Direction::forward,
                          "real to complex transform is constructed "
                          "with backward direction.");
     }
 
-    if constexpr (KokkosFFT::Impl::is_real_v<out_value_type>) {
+    if constexpr (Impl::is_real_v<out_value_type>) {
       KOKKOSFFT_THROW_IF(m_direction != KokkosFFT::Direction::backward,
                          "complex to real transform is constructed "
                          "with forward direction.");
     }
 
-    m_in_extents               = KokkosFFT::Impl::extract_extents(in);
-    m_out_extents              = KokkosFFT::Impl::extract_extents(out);
-    std::tie(m_map, m_map_inv) = KokkosFFT::Impl::get_map_axes(in, axes);
-    m_is_transpose_needed      = KokkosFFT::Impl::is_transpose_needed(m_map);
-    m_shape = KokkosFFT::Impl::get_modified_shape(in, out, s, m_axes);
-    m_is_crop_or_pad_needed =
-        KokkosFFT::Impl::is_crop_or_pad_needed(in, m_shape);
-    m_is_inplace = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
-    KOKKOSFFT_THROW_IF(m_is_inplace && m_is_transpose_needed,
-                       "In-place transform is not supported with transpose. "
-                       "Please use out-of-place transform.");
+    m_in_extents               = Impl::extract_extents(in);
+    m_out_extents              = Impl::extract_extents(out);
+    std::tie(m_map, m_map_inv) = Impl::get_map_axes(in, axes);
+    m_is_transpose_needed      = Impl::is_transpose_needed(m_map);
+    m_shape                    = Impl::get_modified_shape(in, out, s, m_axes);
+    m_is_crop_or_pad_needed    = Impl::is_crop_or_pad_needed(in, m_shape);
+    m_is_inplace               = Impl::are_aliasing(in.data(), out.data());
     KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
 
-    KokkosFFT::Impl::setup<ExecutionSpace, float_type>();
-    m_fft_extents = KokkosFFT::Impl::create_plan(
-        exec_space, m_plan, in, out, direction, axes, s, m_is_inplace);
+    Impl::setup<ExecutionSpace, float_type>();
+    bool is_truely_inplace = m_is_inplace && !m_is_transpose_needed;
+    m_fft_extents = Impl::create_plan(exec_space, m_plan, in, out, direction,
+                                      axes, s, is_truely_inplace);
   }
 
   ~Plan() noexcept = default;
@@ -221,17 +217,17 @@ class Plan {
     good(in, out);
 
     using ManageableInViewType =
-        typename KokkosFFT::Impl::manageable_view_type<InViewType>::type;
+        typename Impl::manageable_view_type<InViewType>::type;
     using ManageableOutViewType =
-        typename KokkosFFT::Impl::manageable_view_type<OutViewType>::type;
+        typename Impl::manageable_view_type<OutViewType>::type;
 
     ManageableInViewType in_s;
     InViewType in_tmp;
     if (m_is_crop_or_pad_needed) {
       using LayoutType = typename ManageableInViewType::array_layout;
-      in_s             = ManageableInViewType(
-          "in_s", KokkosFFT::Impl::create_layout<LayoutType>(m_shape));
-      KokkosFFT::Impl::crop_or_pad(m_exec_space, in, in_s);
+      in_s             = ManageableInViewType("in_s",
+                                              Impl::create_layout<LayoutType>(m_shape));
+      Impl::crop_or_pad(m_exec_space, in, in_s);
       in_tmp = in_s;
     } else {
       in_tmp = in;
@@ -240,19 +236,37 @@ class Plan {
     if (m_is_transpose_needed) {
       using LayoutType = typename ManageableInViewType::array_layout;
       ManageableInViewType const in_T(
-          "in_T",
-          KokkosFFT::Impl::create_layout<LayoutType>(
-              KokkosFFT::Impl::compute_transpose_extents(in_tmp, m_map)));
+          "in_T", Impl::create_layout<LayoutType>(
+                      Impl::compute_transpose_extents(in_tmp, m_map)));
       ManageableOutViewType const out_T(
-          "out_T", KokkosFFT::Impl::create_layout<LayoutType>(
-                       KokkosFFT::Impl::compute_transpose_extents(out, m_map)));
+          "out_T", Impl::create_layout<LayoutType>(
+                       Impl::compute_transpose_extents(out, m_map)));
 
-      KokkosFFT::Impl::transpose(m_exec_space, in_tmp, in_T, m_map);
-      KokkosFFT::Impl::transpose(m_exec_space, out, out_T, m_map);
+      if (m_is_inplace) {
+        // It is ensured that both in_value_type and out_value_type cannot be
+        // real at the same time
+        constexpr std::size_t rank = InViewType::rank();
+        auto non_negative_axes     = Impl::convert_base_int_type<std::size_t>(
+            Impl::convert_negative_axes(m_axes, rank));
+        auto in_padded_extents = Impl::compute_padded_extents(
+            m_in_extents, m_out_extents, non_negative_axes,
+            Impl::is_real_v<in_value_type>);
+        auto out_padded_extents = Impl::compute_padded_extents(
+            m_out_extents, m_in_extents, non_negative_axes,
+            Impl::is_real_v<out_value_type>);
 
-      execute_fft(in_T, out_T, norm);
-
-      KokkosFFT::Impl::transpose(m_exec_space, out_T, out, m_map_inv);
+        InViewType in_padded(
+            in_tmp.data(), Impl::create_layout<LayoutType>(in_padded_extents));
+        OutViewType out_padded(
+            out.data(), Impl::create_layout<LayoutType>(out_padded_extents));
+        Impl::transpose(m_exec_space, in_padded, in_T, m_map);
+        execute_fft(in_T, out_T, norm);
+        Impl::transpose(m_exec_space, out_T, out_padded, m_map_inv);
+      } else {
+        Impl::transpose(m_exec_space, in_tmp, in_T, m_map);
+        execute_fft(in_T, out_T, norm);
+        Impl::transpose(m_exec_space, out_T, out, m_map_inv);
+      }
     } else {
       execute_fft(in_tmp, out, norm);
     }
@@ -261,30 +275,31 @@ class Plan {
  private:
   void execute_fft(const InViewType& in, const OutViewType& out,
                    KokkosFFT::Normalization norm) const {
-    auto* idata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-        execSpace, in_value_type>::type*>(in.data());
-    auto* odata = reinterpret_cast<typename KokkosFFT::Impl::fft_data_type<
-        execSpace, out_value_type>::type*>(out.data());
+    auto* idata = reinterpret_cast<
+        typename Impl::fft_data_type<execSpace, in_value_type>::type*>(
+        in.data());
+    auto* odata = reinterpret_cast<
+        typename Impl::fft_data_type<execSpace, out_value_type>::type*>(
+        out.data());
 
-    auto const direction =
-        KokkosFFT::Impl::direction_type<execSpace>(m_direction);
-    KokkosFFT::Impl::exec_plan(*m_plan, idata, odata, direction);
+    auto const direction = Impl::direction_type<execSpace>(m_direction);
+    Impl::exec_plan(*m_plan, idata, odata, direction);
 
-    if constexpr (KokkosFFT::Impl::is_complex_v<in_value_type> &&
-                  KokkosFFT::Impl::is_real_v<out_value_type>) {
+    if constexpr (Impl::is_complex_v<in_value_type> &&
+                  Impl::is_real_v<out_value_type>) {
       if (m_is_inplace) {
         // For the in-place Complex to Real transform, the output must be
         // reshaped to fit the original size (in.size() * 2) for correct
         // normalization
         Kokkos::View<out_value_type*, execSpace> out_tmp(out.data(),
                                                          in.size() * 2);
-        KokkosFFT::Impl::normalize<normalization_float_type>(
+        Impl::normalize<normalization_float_type>(
             m_exec_space, out_tmp, m_direction, norm, m_fft_extents);
         return;
       }
     }
-    KokkosFFT::Impl::normalize<normalization_float_type>(
-        m_exec_space, out, m_direction, norm, m_fft_extents);
+    Impl::normalize<normalization_float_type>(m_exec_space, out, m_direction,
+                                              norm, m_fft_extents);
   }
 
   /// \brief Sanity check of the plan used to call FFT interface with
@@ -294,8 +309,8 @@ class Plan {
   /// \param in [in] Input data
   /// \param out [in] Output data
   void good(const InViewType& in, const OutViewType& out) const {
-    auto in_extents  = KokkosFFT::Impl::extract_extents(in);
-    auto out_extents = KokkosFFT::Impl::extract_extents(out);
+    auto in_extents  = Impl::extract_extents(in);
+    auto out_extents = Impl::extract_extents(out);
 
     KOKKOSFFT_THROW_IF(in_extents != m_in_extents,
                        "extents of input View for plan and "
@@ -305,7 +320,7 @@ class Plan {
                        "extents of output View for plan and "
                        "execution are not identical.");
 
-    bool is_inplace = KokkosFFT::Impl::are_aliasing(in.data(), out.data());
+    bool is_inplace = Impl::are_aliasing(in.data(), out.data());
     KOKKOSFFT_THROW_IF(is_inplace != m_is_inplace,
                        "If the plan is in-place, the input and output Views "
                        "must be identical.");

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -241,7 +241,9 @@ class Plan {
       ManageableOutViewType const out_T(
           "out_T", Impl::create_layout<LayoutType>(
                        Impl::compute_transpose_extents(out, m_map)));
-
+      InViewType in_padded   = in_tmp;
+      OutViewType out_padded = out;
+      bool is_inpadded = false, is_outpadded = false;
       if (m_is_inplace) {
         // It is ensured that both in_value_type and out_value_type cannot be
         // real at the same time
@@ -255,18 +257,21 @@ class Plan {
             m_out_extents, m_in_extents, non_negative_axes,
             Impl::is_real_v<out_value_type>);
 
-        InViewType in_padded(
-            in_tmp.data(), Impl::create_layout<LayoutType>(in_padded_extents));
-        OutViewType out_padded(
-            out.data(), Impl::create_layout<LayoutType>(out_padded_extents));
-        Impl::transpose(m_exec_space, in_padded, in_T, m_map);
-        execute_fft(in_T, out_T, norm);
-        Impl::transpose(m_exec_space, out_T, out_padded, m_map_inv);
-      } else {
-        Impl::transpose(m_exec_space, in_tmp, in_T, m_map);
-        execute_fft(in_T, out_T, norm);
-        Impl::transpose(m_exec_space, out_T, out, m_map_inv);
+        if (in_padded_extents != m_in_extents) {
+          in_padded =
+              InViewType(in_tmp.data(),
+                         Impl::create_layout<LayoutType>(in_padded_extents));
+          is_inpadded = true;
+        }
+        if (out_padded_extents != m_out_extents) {
+          out_padded = OutViewType(
+              out.data(), Impl::create_layout<LayoutType>(out_padded_extents));
+          is_outpadded = true;
+        }
       }
+      Impl::transpose(m_exec_space, in_padded, in_T, m_map, is_inpadded);
+      execute_fft(in_T, out_T, norm);
+      Impl::transpose(m_exec_space, out_T, out_padded, m_map_inv, is_outpadded);
     } else {
       execute_fft(in_tmp, out, norm);
     }
@@ -287,7 +292,7 @@ class Plan {
 
     if constexpr (Impl::is_complex_v<in_value_type> &&
                   Impl::is_real_v<out_value_type>) {
-      if (m_is_inplace) {
+      if (m_is_inplace && !m_is_transpose_needed) {
         // For the in-place Complex to Real transform, the output must be
         // reshaped to fit the original size (in.size() * 2) for correct
         // normalization

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -243,35 +243,32 @@ class Plan {
                        Impl::compute_transpose_extents(out, m_map)));
       InViewType in_padded   = in_tmp;
       OutViewType out_padded = out;
-      bool is_inpadded = false, is_outpadded = false;
+      bool to_bounds_check   = false;
       if (m_is_inplace) {
         // It is ensured that both in_value_type and out_value_type cannot be
         // real at the same time
         constexpr std::size_t rank = InViewType::rank();
         auto non_negative_axes     = Impl::convert_base_int_type<std::size_t>(
             Impl::convert_negative_axes(m_axes, rank));
-        auto in_padded_extents = Impl::compute_padded_extents(
-            m_in_extents, m_out_extents, non_negative_axes,
-            Impl::is_real_v<in_value_type>);
-        auto out_padded_extents = Impl::compute_padded_extents(
-            m_out_extents, m_in_extents, non_negative_axes,
-            Impl::is_real_v<out_value_type>);
+        auto in_padded_extents = Impl::compute_padded_extents<in_value_type>(
+            m_in_extents, non_negative_axes);
+        auto out_padded_extents = Impl::compute_padded_extents<out_value_type>(
+            m_out_extents, non_negative_axes);
 
         if (in_padded_extents != m_in_extents) {
           in_padded =
               InViewType(in_tmp.data(),
                          Impl::create_layout<LayoutType>(in_padded_extents));
-          is_inpadded = true;
+          to_bounds_check = true;
         }
         if (out_padded_extents != m_out_extents) {
           out_padded = OutViewType(
               out.data(), Impl::create_layout<LayoutType>(out_padded_extents));
-          is_outpadded = true;
         }
       }
-      Impl::transpose(m_exec_space, in_padded, in_T, m_map, is_inpadded);
+      Impl::transpose(m_exec_space, in_padded, in_T, m_map, to_bounds_check);
       execute_fft(in_T, out_T, norm);
-      Impl::transpose(m_exec_space, out_T, out_padded, m_map_inv, is_outpadded);
+      Impl::transpose(m_exec_space, out_T, out_padded, m_map_inv);
     } else {
       execute_fft(in_tmp, out, norm);
     }

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -197,9 +197,9 @@ class Plan {
                        "Please use out-of-place transform.");
 
     Impl::setup<ExecutionSpace, float_type>();
-    bool is_truely_inplace = m_is_inplace && !m_is_transpose_needed;
+    bool is_truly_inplace = m_is_inplace && !m_is_transpose_needed;
     m_fft_extents = Impl::create_plan(exec_space, m_plan, in, out, direction,
-                                      axes, s, is_truely_inplace);
+                                      axes, s, is_truly_inplace);
   }
 
   ~Plan() noexcept = default;

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -1692,8 +1692,6 @@ void test_fft2_2dfft_2dview_inplace(T atol) {
   KokkosFFT::fft2(exec, x, x_hat, KokkosFFT::Normalization::backward, axes);
   KokkosFFT::ifft2(exec, x_hat, inv_x_hat, KokkosFFT::Normalization::backward,
                    axes);
-
-  exec.fence();
   EXPECT_TRUE(allclose(exec, inv_x_hat, x_ref, 1.e-5, atol));
   exec.fence();
 
@@ -1703,8 +1701,6 @@ void test_fft2_2dfft_2dview_inplace(T atol) {
   // Out-of-place transforms (reference)
   KokkosFFT::rfft2(exec, xr_ref, xr_hat_ref, KokkosFFT::Normalization::backward,
                    axes);
-
-  exec.fence();
   EXPECT_TRUE(allclose(exec, xr_hat, xr_hat_ref, 1.e-5, atol));
   exec.fence();
 
@@ -1717,7 +1713,6 @@ void test_fft2_2dfft_2dview_inplace(T atol) {
   // Out-of-place transforms (reference)
   KokkosFFT::irfft2(exec, xr_hat_ref, inv_xr_hat_ref,
                     KokkosFFT::Normalization::backward, axes);
-
   exec.fence();
   auto sub_inv_xr_hat_padded = Kokkos::subview(inv_xr_hat_padded, Kokkos::ALL,
                                                Kokkos::pair<int, int>(0, n1));

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -1647,7 +1647,7 @@ void test_fft2_2dfft_2dview_shape(T atol = 1.0e-12) {
 }
 
 template <typename T, typename LayoutType>
-void test_fft2_2dfft_2dview_inplace([[maybe_unused]] T atol = 1.0e-12) {
+void test_fft2_2dfft_2dview_inplace(T atol) {
   const int n0 = 4, n1 = 6;
   using RealView2DType = Kokkos::View<T**, LayoutType, execution_space>;
   using ComplexView2DType =
@@ -1688,58 +1688,42 @@ void test_fft2_2dfft_2dview_inplace([[maybe_unused]] T atol = 1.0e-12) {
   using axes_type = KokkosFFT::axis_type<2>;
   axes_type axes  = {-2, -1};
 
-  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
-    // in-place transforms are not supported if transpose is needed
-    EXPECT_THROW(KokkosFFT::fft2(exec, x, x_hat,
-                                 KokkosFFT::Normalization::backward, axes),
-                 std::runtime_error);
-    EXPECT_THROW(KokkosFFT::ifft2(exec, x_hat, inv_x_hat,
-                                  KokkosFFT::Normalization::backward, axes),
-                 std::runtime_error);
-    EXPECT_THROW(KokkosFFT::rfft2(exec, xr, xr_hat,
-                                  KokkosFFT::Normalization::backward, axes),
-                 std::runtime_error);
-    EXPECT_THROW(KokkosFFT::irfft2(exec, xr_hat, inv_xr_hat,
-                                   KokkosFFT::Normalization::backward, axes),
-                 std::runtime_error);
-  } else {
-    // Identity tests for complex transforms
-    KokkosFFT::fft2(exec, x, x_hat, KokkosFFT::Normalization::backward, axes);
-    KokkosFFT::ifft2(exec, x_hat, inv_x_hat, KokkosFFT::Normalization::backward,
-                     axes);
+  // Identity tests for complex transforms
+  KokkosFFT::fft2(exec, x, x_hat, KokkosFFT::Normalization::backward, axes);
+  KokkosFFT::ifft2(exec, x_hat, inv_x_hat, KokkosFFT::Normalization::backward,
+                   axes);
 
-    Kokkos::fence();
-    EXPECT_TRUE(allclose(exec, inv_x_hat, x_ref, 1.e-5, atol));
+  exec.fence();
+  EXPECT_TRUE(allclose(exec, inv_x_hat, x_ref, 1.e-5, atol));
+  exec.fence();
 
-    // In-place transforms
-    KokkosFFT::rfft2(exec, xr, xr_hat, KokkosFFT::Normalization::backward,
-                     axes);
+  // In-place transforms
+  KokkosFFT::rfft2(exec, xr, xr_hat, KokkosFFT::Normalization::backward, axes);
 
-    // Out-of-place transforms (reference)
-    KokkosFFT::rfft2(exec, xr_ref, xr_hat_ref,
-                     KokkosFFT::Normalization::backward, axes);
+  // Out-of-place transforms (reference)
+  KokkosFFT::rfft2(exec, xr_ref, xr_hat_ref, KokkosFFT::Normalization::backward,
+                   axes);
 
-    Kokkos::fence();
-    EXPECT_TRUE(allclose(exec, xr_hat, xr_hat_ref, 1.e-5, atol));
+  exec.fence();
+  EXPECT_TRUE(allclose(exec, xr_hat, xr_hat_ref, 1.e-5, atol));
+  exec.fence();
 
-    // In-place transforms
-    Kokkos::fill_random(exec, xr_hat, random_pool, z);
-    Kokkos::deep_copy(xr_hat_ref, xr_hat);
-    KokkosFFT::irfft2(exec, xr_hat, inv_xr_hat,
-                      KokkosFFT::Normalization::backward, axes);
+  // In-place transforms
+  Kokkos::fill_random(exec, xr_hat, random_pool, z);
+  Kokkos::deep_copy(xr_hat_ref, xr_hat);
+  KokkosFFT::irfft2(exec, xr_hat, inv_xr_hat,
+                    KokkosFFT::Normalization::backward, axes);
 
-    // Out-of-place transforms (reference)
-    KokkosFFT::irfft2(exec, xr_hat_ref, inv_xr_hat_ref,
-                      KokkosFFT::Normalization::backward, axes);
+  // Out-of-place transforms (reference)
+  KokkosFFT::irfft2(exec, xr_hat_ref, inv_xr_hat_ref,
+                    KokkosFFT::Normalization::backward, axes);
 
-    Kokkos::fence();
-    auto sub_inv_xr_hat_padded = Kokkos::subview(inv_xr_hat_padded, Kokkos::ALL,
-                                                 Kokkos::pair<int, int>(0, n1));
-    Kokkos::deep_copy(inv_xr_hat_unpadded, sub_inv_xr_hat_padded);
+  exec.fence();
+  auto sub_inv_xr_hat_padded = Kokkos::subview(inv_xr_hat_padded, Kokkos::ALL,
+                                               Kokkos::pair<int, int>(0, n1));
+  Kokkos::deep_copy(inv_xr_hat_unpadded, sub_inv_xr_hat_padded);
 
-    EXPECT_TRUE(
-        allclose(exec, inv_xr_hat_unpadded, inv_xr_hat_ref, 1.e-5, atol));
-  }
+  EXPECT_TRUE(allclose(exec, inv_xr_hat_unpadded, inv_xr_hat_ref, 1.e-5, atol));
   exec.fence();
 }
 
@@ -3478,7 +3462,8 @@ TYPED_TEST(FFT2D, 2DFFT_2DView_inplace) {
   using float_type  = typename TestFixture::float_type;
   using layout_type = typename TestFixture::layout_type;
 
-  test_fft2_2dfft_2dview_inplace<float_type, layout_type>();
+  float_type atol = std::is_same_v<float_type, float> ? 1.0e-5 : 1.0e-12;
+  test_fft2_2dfft_2dview_inplace<float_type, layout_type>(atol);
 }
 
 // batched fft2 on 3D Views


### PR DESCRIPTION
This PR aims at allowing inplace FFT even with internal transpose operations.
Internally, we use out-of-place FFT library calls, but the API takes the same in/out Views.

- [x] Move `compute_padded_extents` from `distributed` to `common` with small updates
- [x] Add unit-tests for that
- [x] Add a special branch to manage inplace transform with transpose
- [x] Relax the unit-tests `test_fft2_2dfft_2dview_inplace` to test `LayoutLeft` which requires transpose operations