### PR TITLE
Add fftn/ifftn examples

### DIFF
--- a/docs/api/standard/fftn.rst
+++ b/docs/api/standard/fftn.rst
@@ -10,3 +10,27 @@ KokkosFFT::fftn
 .. note::
 
    For the real input, we internally convert it to complex and perform ``fftn`` on it.
+
+Examples
+========
+
+In this example, we use the 3D View with `LayoutRight` to avoid the internal transpose. 
+This allows `fftn` to perform 3D FFT on the outermost dimension without transpose.
+
+.. literalinclude:: ../../../examples/docs/docs_fftn.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (78,0) (-6,0)
+ (-12,0) (0,0)
+
+ (-24,13.8564) (0,0)
+ (0,0) (0,0)
+
+ (-24,-13.8564) (0,0)
+ (0,0) (0,0)

--- a/docs/api/standard/ifftn.rst
+++ b/docs/api/standard/ifftn.rst
@@ -6,3 +6,27 @@ KokkosFFT::ifftn
 ----------------
 
 .. doxygenfunction:: KokkosFFT::ifftn(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)
+
+Examples
+========
+
+In this example, we use the 3D View with `LayoutRight` to avoid the internal transpose. 
+This allows `ifftn` to perform 3D FFT on the outermost dimension without transpose.
+
+.. literalinclude:: ../../../examples/docs/docs_ifftn.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (1,0) (2,0)
+ (3,0) (4,0)
+
+ (5,0) (6,0)
+ (7,0) (8,0)
+
+ (9,0) (10,0)
+ (11,0) (12,0)

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -13,3 +13,9 @@ target_link_libraries(docs_fft2 PUBLIC KokkosFFT::fft)
 
 add_executable(docs_ifft2 docs_ifft2.cpp)
 target_link_libraries(docs_ifft2 PUBLIC KokkosFFT::fft)
+
+add_executable(docs_fftn docs_fftn.cpp)
+target_link_libraries(docs_fftn PUBLIC KokkosFFT::fft)
+
+add_executable(docs_ifftn docs_ifftn.cpp)
+target_link_libraries(docs_ifftn PUBLIC KokkosFFT::fft)

--- a/examples/docs/docs_fftn.cpp
+++ b/examples/docs/docs_fftn.cpp
@@ -8,7 +8,7 @@
 #include <KokkosFFT.hpp>
 
 /// \brief Example of fftn usage in documentation
-/// x= [[[1, 2],
+/// x = [[[1, 2],
 ///      [3, 4]],
 ///     [[5, 6],
 ///      [7, 8]],

--- a/examples/docs/docs_fftn.cpp
+++ b/examples/docs/docs_fftn.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of fftn usage in documentation
+/// x= [[[1, 2],
+///      [3, 4]],
+///     [[5, 6],
+///      [7, 8]],
+///     [[9, 10],
+///      [11, 12]]]
+/// x_hat = [[[78, -6],
+///           [-12, 0]],
+///          [[-24+13.8564j, 0],
+///           [0, 0]],
+///          [[-24-13.8564j, 0],
+///           [0, 0]]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View3D = Kokkos::View<Kokkos::complex<double>***, Kokkos::LayoutRight,
+                              ExecutionSpace>;
+
+  const int n0 = 3, n1 = 2, n2 = 2;
+
+  View3D x("x", n0, n1, n2), x_hat("x_hat", n0, n1, n2);
+  auto h_x = Kokkos::create_mirror_view(x);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2; ++k) {
+        h_x(i, j, k) = Kokkos::complex<double>(i * n1 * n2 + j * n2 + k + 1);
+      }
+    }
+  }
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::fftn(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2; ++k) {
+        std::cout << " " << h_x_hat(i, j, k);
+      }
+      std::cout << "\n";
+    }
+    if (i < n0 - 1) std::cout << "\n";
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/docs_ifftn.cpp
+++ b/examples/docs/docs_ifftn.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of fftn usage in documentation
+/// x = [[[78, -6],
+///       [-12, 0]],
+///      [[-24+13.85640646j, 0],
+///       [0, 0]],
+///      [[-24-13.85640646j, 0],
+///       [0, 0]]]
+/// x_hat = [[[1, 2],
+///           [3, 4]],
+///          [[5, 6],
+///           [7, 8]],
+///          [[9, 10],
+///           [11, 12]]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View3D = Kokkos::View<Kokkos::complex<double>***, Kokkos::LayoutRight,
+                              ExecutionSpace>;
+
+  const int n0 = 3, n1 = 2, n2 = 2;
+
+  View3D x("x", n0, n1, n2), x_hat("x_hat", n0, n1, n2);
+  auto h_x     = Kokkos::create_mirror_view(x);
+  h_x(0, 0, 0) = Kokkos::complex<double>(78, 0);
+  h_x(0, 0, 1) = Kokkos::complex<double>(-6, 0);
+  h_x(0, 1, 0) = Kokkos::complex<double>(-12, 0);
+  h_x(1, 0, 0) = Kokkos::complex<double>(-24, 13.85640646);
+  h_x(2, 0, 0) = Kokkos::complex<double>(-24, -13.85640646);
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::ifftn(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2; ++k) {
+        std::cout << " " << h_x_hat(i, j, k);
+      }
+      std::cout << "\n";
+    }
+    if (i < n0 - 1) std::cout << "\n";
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/docs_ifftn.cpp
+++ b/examples/docs/docs_ifftn.cpp
@@ -7,7 +7,7 @@
 #include <Kokkos_Complex.hpp>
 #include <KokkosFFT.hpp>
 
-/// \brief Example of fftn usage in documentation
+/// \brief Example of ifftn usage in documentation
 /// x = [[[78, -6],
 ///       [-12, 0]],
 ///      [[-24+13.85640646j, 0],


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_fftn.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_ifftn.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.
