### PR TITLE
Remove compute transpose extents

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -146,8 +146,8 @@ auto compute_padded_extents(const std::array<iType, DIM>& extents,
 /// \param[in] map A map representing how the data is permuted
 /// \return A extents of the permuted view
 /// \throws std::runtime_error if the size of map is not equal to DIM
-/// or if map has duplicate values or if map has values out of the range [0,
-/// DIM)
+/// or if map has duplicate values or if map has values out of the range
+/// [0, DIM)
 template <typename ContainerType, typename iType, std::size_t DIM>
 auto compute_mapped_extents(const std::array<iType, DIM>& extents,
                             const ContainerType& map) {
@@ -163,14 +163,11 @@ auto compute_mapped_extents(const std::array<iType, DIM>& extents,
 
   auto safe_permute = [&extents](const value_type& mapped_idx) -> iType {
     if constexpr (std::is_signed_v<value_type>) {
-      KOKKOSFFT_THROW_IF(mapped_idx < 0,
-                         "map entries must be in [0, "
-                         "DIM)");
+      KOKKOSFFT_THROW_IF(mapped_idx < 0, "map entries must be in [0, DIM)");
     }
     auto non_negative_mapped_idx = static_cast<std::size_t>(mapped_idx);
     KOKKOSFFT_THROW_IF(non_negative_mapped_idx >= DIM,
-                       "map entries must be in [0, "
-                       "DIM)");
+                       "map entries must be in [0, DIM)");
     return extents.at(non_negative_mapped_idx);
   };
   std::array<iType, DIM> mapped_extents{};

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -131,6 +131,39 @@ auto compute_padded_extents(const std::array<iType, DIM>& extents,
   return padded_extents;
 }
 
+/// \brief Calculate the permuted extents based on the map
+///
+/// Example
+/// View extents: (n0, n1, n2, n3)
+/// map: (0, 2, 3, 1)
+/// Next extents: (n0, n2, n3, n1)
+///
+/// \tparam ContainerType The container type
+/// \tparam iType The integer type used for extents
+/// \tparam DIM The number of dimensions of the extents.
+///
+/// \param[in] extents Extents of the View.
+/// \param[in] map A map representing how the data is permuted
+/// \return A extents of the permuted view
+/// \throws std::runtime_error if the size of map is not equal to DIM
+template <typename ContainerType, typename iType, std::size_t DIM>
+auto compute_mapped_extents(const std::array<iType, DIM>& extents,
+                            const ContainerType& map) {
+  using value_type = std::remove_cv_t<
+      std::remove_reference_t<typename ContainerType::value_type>>;
+  static_assert(std::is_integral_v<value_type>,
+                "compute_mapped_extents: Map container value type must be an "
+                "integral type");
+  KOKKOSFFT_THROW_IF(map.size() != DIM,
+                     "extents size must be equal to map size.");
+  std::array<iType, DIM> mapped_extents{};
+  std::transform(
+      map.begin(), map.end(), mapped_extents.begin(),
+      [&](std::size_t mapped_idx) { return extents.at(mapped_idx); });
+
+  return mapped_extents;
+}
+
 /// \brief Compute input, output and fft extents required for FFT
 /// libraries based on the input view, output view, axes and shape.
 /// Extents are converted into Layout Right

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -7,7 +7,7 @@
 
 #include <vector>
 #include <tuple>
-#include <iostream>
+#include <algorithm>
 #include <numeric>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_traits.hpp"
@@ -156,10 +156,23 @@ auto compute_mapped_extents(const std::array<iType, DIM>& extents,
                 "integral type");
   KOKKOSFFT_THROW_IF(map.size() != DIM,
                      "extents size must be equal to map size.");
+  KOKKOSFFT_THROW_IF(has_duplicate_values(map),
+                     "map must not have duplicate values.");
+
+  auto safe_permute = [&extents](const value_type& mapped_idx) -> iType {
+    if constexpr (std::is_signed_v<value_type>) {
+      KOKKOSFFT_THROW_IF(mapped_idx < 0,
+                         "map entries must be in [0, "
+                         "DIM)");
+    }
+    auto non_negative_mapped_idx = static_cast<std::size_t>(mapped_idx);
+    KOKKOSFFT_THROW_IF(non_negative_mapped_idx >= DIM,
+                       "map entries must be in [0, "
+                       "DIM)");
+    return extents.at(non_negative_mapped_idx);
+  };
   std::array<iType, DIM> mapped_extents{};
-  std::transform(
-      map.begin(), map.end(), mapped_extents.begin(),
-      [&](std::size_t mapped_idx) { return extents.at(mapped_idx); });
+  std::transform(map.begin(), map.end(), mapped_extents.begin(), safe_permute);
 
   return mapped_extents;
 }

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -146,6 +146,8 @@ auto compute_padded_extents(const std::array<iType, DIM>& extents,
 /// \param[in] map A map representing how the data is permuted
 /// \return A extents of the permuted view
 /// \throws std::runtime_error if the size of map is not equal to DIM
+/// or if map has duplicate values or if map has values out of the range [0,
+/// DIM)
 template <typename ContainerType, typename iType, std::size_t DIM>
 auto compute_mapped_extents(const std::array<iType, DIM>& extents,
                             const ContainerType& map) {

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -14,21 +14,6 @@
 
 namespace KokkosFFT {
 namespace Impl {
-template <class ViewType>
-axis_type<ViewType::rank()> compute_transpose_extents(
-    ViewType const& view, axis_type<ViewType::rank()> const& map) {
-  static_assert(Kokkos::is_view_v<ViewType>,
-                "compute_transpose_extents: ViewType must be a Kokkos::View.");
-  constexpr std::size_t rank = ViewType::rank();
-
-  axis_type<rank> out_extents;
-  for (std::size_t i = 0; i < rank; ++i) {
-    out_extents.at(i) = view.extent(map.at(i));
-  }
-
-  return out_extents;
-}
-
 struct BoundsCheck {
   struct On {};
   struct Off {};

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -232,6 +232,34 @@ void test_compute_mapped_extents(iType n) {
   EXPECT_EQ(mapped_extents120, ref_mapped_extents120);
   EXPECT_EQ(mapped_extents201, ref_mapped_extents201);
   EXPECT_EQ(mapped_extents210, ref_mapped_extents210);
+
+  // Check if errors are correctly raised against invalid map
+  ContainerType overlapped_map{0, 1, 1};
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto extents011 =
+            KokkosFFT::Impl::compute_mapped_extents(extents, overlapped_map);
+      },
+      std::runtime_error);
+
+  // Check if errors are correctly raised against out-of-range map
+  ContainerType invalid_map{0, 1, 3};
+  EXPECT_THROW(
+      {
+        [[maybe_unused]] auto extents013 =
+            KokkosFFT::Impl::compute_mapped_extents(extents, invalid_map);
+      },
+      std::runtime_error);
+
+  if constexpr (std::is_signed_v<iType>) {
+    ContainerType negative_map{-1, 0, 1};
+    EXPECT_THROW(
+        {
+          [[maybe_unused]] auto extents_neg =
+              KokkosFFT::Impl::compute_mapped_extents(extents, negative_map);
+        },
+        std::runtime_error);
+  }
 }
 
 // Tests for 1D FFT

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -16,7 +16,7 @@ using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 
 // Basically the same fixtures, used for labeling tests
 template <typename T>
-struct TestPaddedExtents : public ::testing::Test {
+struct TestExtents : public ::testing::Test {
   using value_type = T;
 };
 
@@ -200,6 +200,38 @@ void test_padded_extents() {
       EXPECT_EQ(padded_extents3_ax2, out_extents3_ax2);
     }
   }
+}
+
+// Tests for mapped extents
+template <typename ContainerType, typename iType>
+void test_compute_mapped_extents(iType n) {
+  using extents_type = std::array<iType, 3>;
+  extents_type extents{n, 3, 8};
+  ContainerType map012{0, 1, 2}, map021{0, 2, 1}, map102{1, 0, 2},
+      map120{1, 2, 0}, map201{2, 0, 1}, map210{2, 1, 0};
+  auto mapped_extents012 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map012);
+  auto mapped_extents021 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map021);
+  auto mapped_extents102 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map102);
+  auto mapped_extents120 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map120);
+  auto mapped_extents201 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map201);
+  auto mapped_extents210 =
+      KokkosFFT::Impl::compute_mapped_extents(extents, map210);
+
+  extents_type ref_mapped_extents012{n, 3, 8}, ref_mapped_extents021{n, 8, 3},
+      ref_mapped_extents102{3, n, 8}, ref_mapped_extents120{3, 8, n},
+      ref_mapped_extents201{8, n, 3}, ref_mapped_extents210{8, 3, n};
+
+  EXPECT_EQ(mapped_extents012, ref_mapped_extents012);
+  EXPECT_EQ(mapped_extents021, ref_mapped_extents021);
+  EXPECT_EQ(mapped_extents102, ref_mapped_extents102);
+  EXPECT_EQ(mapped_extents120, ref_mapped_extents120);
+  EXPECT_EQ(mapped_extents201, ref_mapped_extents201);
+  EXPECT_EQ(mapped_extents210, ref_mapped_extents210);
 }
 
 // Tests for 1D FFT
@@ -982,7 +1014,7 @@ void test_extents_2d_view_3d(bool is_static = true) {
 
 }  // namespace
 
-TYPED_TEST_SUITE(TestPaddedExtents, test_int_types);
+TYPED_TEST_SUITE(TestExtents, test_int_types);
 TYPED_TEST_SUITE(TestGetExtents1D, test_types);
 TYPED_TEST_SUITE(TestGetExtents2D, test_types);
 TYPED_TEST_SUITE(TestGetDynExtents1D, test_types);
@@ -1000,16 +1032,33 @@ TEST(TestGetOutputExtent, C2C) {
 }
 
 // Padded extents
-TYPED_TEST(TestPaddedExtents, R2C) {
+TYPED_TEST(TestExtents, R2C) {
   using float_type = double;
   using int_type   = typename TestFixture::value_type;
   test_padded_extents<float_type, int_type>();
 }
 
-TYPED_TEST(TestPaddedExtents, C2C) {
+TYPED_TEST(TestExtents, C2C) {
   using float_type = Kokkos::complex<double>;
   using int_type   = typename TestFixture::value_type;
   test_padded_extents<float_type, int_type>();
+}
+
+// Mapped extents
+TYPED_TEST(TestExtents, mapped_extents_of_vector) {
+  using value_type  = typename TestFixture::value_type;
+  using vector_type = std::vector<value_type>;
+  for (value_type n = 1; n <= 6; ++n) {
+    test_compute_mapped_extents<vector_type, value_type>(n);
+  }
+}
+
+TYPED_TEST(TestExtents, mapped_extents_of_array) {
+  using value_type = typename TestFixture::value_type;
+  using array_type = std::array<value_type, 3>;
+  for (value_type n = 1; n <= 6; ++n) {
+    test_compute_mapped_extents<array_type, value_type>(n);
+  }
 }
 
 // get_extents with static dimension

--- a/distributed/src/KokkosFFT_Distributed_Extents.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Extents.hpp
@@ -97,39 +97,6 @@ auto compute_buffer_extents(
                                             out_topology.array());
 }
 
-/// \brief Calculate the permuted extents based on the map
-///
-/// Example
-/// View extents: (n0, n1, n2, n3)
-/// map: (0, 2, 3, 1)
-/// Next extents: (n0, n2, n3, n1)
-///
-/// \tparam ContainerType The container type
-/// \tparam iType The integer type used for extents
-/// \tparam DIM The number of dimensions of the extents.
-///
-/// \param[in] extents Extents of the View.
-/// \param[in] map A map representing how the data is permuted
-/// \return A extents of the permuted view
-/// \throws std::runtime_error if the size of map is not equal to DIM
-template <typename ContainerType, typename iType, std::size_t DIM>
-auto compute_mapped_extents(const std::array<iType, DIM> &extents,
-                            const ContainerType &map) {
-  using value_type = std::remove_cv_t<
-      std::remove_reference_t<typename ContainerType::value_type>>;
-  static_assert(std::is_integral_v<value_type>,
-                "compute_mapped_extents: Map container value type must be an "
-                "integral type");
-  KOKKOSFFT_THROW_IF(map.size() != DIM,
-                     "extents size must be equal to map size.");
-  std::array<iType, DIM> mapped_extents{};
-  std::transform(
-      map.begin(), map.end(), mapped_extents.begin(),
-      [&](std::size_t mapped_idx) { return extents.at(mapped_idx); });
-
-  return mapped_extents;
-}
-
 /// \brief Compute the larger extents. Larger one corresponds to
 /// the extents to FFT library. This is a helper for vendor library
 /// which supports 2D or 3D non-batched FFTs.

--- a/distributed/src/KokkosFFT_Distributed_MPI_Extents.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_Extents.hpp
@@ -356,8 +356,8 @@ bool are_valid_extents(
   auto gin_extents  = compute_global_extents(in, in_topology, comm);
   auto gout_extents = compute_global_extents(out, out_topology, comm);
 
-  auto in_extents  = compute_mapped_extents(gin_extents, map);
-  auto out_extents = compute_mapped_extents(gout_extents, map);
+  auto in_extents  = KokkosFFT::Impl::compute_mapped_extents(gin_extents, map);
+  auto out_extents = KokkosFFT::Impl::compute_mapped_extents(gout_extents, map);
 
   auto mismatched_extents = [&in, &out, &in_extents, &out_extents](
                                 std::string_view msg) -> std::string {

--- a/distributed/src/KokkosFFT_Distributed_MPI_Extents.hpp
+++ b/distributed/src/KokkosFFT_Distributed_MPI_Extents.hpp
@@ -12,6 +12,7 @@
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
 #include <KokkosFFT.hpp>
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Distributed_Types.hpp"
 #include "KokkosFFT_Distributed_MPI_Types.hpp"
 #include "KokkosFFT_Distributed_Extents.hpp"

--- a/distributed/unit_test/Test_Extents.cpp
+++ b/distributed/unit_test/Test_Extents.cpp
@@ -74,38 +74,6 @@ void test_buffer_extents() {
 }
 
 template <typename ContainerType, typename iType>
-void test_compute_mapped_extents(iType nprocs) {
-  using extents_type   = std::array<iType, 3>;
-  extents_type extents = {nprocs, 3, 8};
-  ContainerType map012{0, 1, 2}, map021{0, 2, 1}, map102{1, 0, 2},
-      map120{1, 2, 0}, map201{2, 0, 1}, map210{2, 1, 0};
-  auto mapped_extents012 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map012);
-  auto mapped_extents021 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map021);
-  auto mapped_extents102 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map102);
-  auto mapped_extents120 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map120);
-  auto mapped_extents201 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map201);
-  auto mapped_extents210 =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map210);
-
-  extents_type ref_mapped_extents012{nprocs, 3, 8},
-      ref_mapped_extents021{nprocs, 8, 3}, ref_mapped_extents102{3, nprocs, 8},
-      ref_mapped_extents120{3, 8, nprocs}, ref_mapped_extents201{8, nprocs, 3},
-      ref_mapped_extents210{8, 3, nprocs};
-
-  EXPECT_EQ(mapped_extents012, ref_mapped_extents012);
-  EXPECT_EQ(mapped_extents021, ref_mapped_extents021);
-  EXPECT_EQ(mapped_extents102, ref_mapped_extents102);
-  EXPECT_EQ(mapped_extents120, ref_mapped_extents120);
-  EXPECT_EQ(mapped_extents201, ref_mapped_extents201);
-  EXPECT_EQ(mapped_extents210, ref_mapped_extents210);
-}
-
-template <typename ContainerType, typename iType>
 void test_compute_fft_extents(iType nprocs) {
   using extents_type = std::array<iType, 3>;
   extents_type in_extents{nprocs, 3, 8}, out_extents{nprocs, 3, 5};
@@ -146,22 +114,6 @@ TYPED_TEST(TestExtents, BufferExtents) {
   using layout_type = typename TestFixture::layout_type;
 
   test_buffer_extents<value_type, layout_type>();
-}
-
-TYPED_TEST(TestExtents, mapped_extents_of_vector) {
-  using value_type  = typename TestFixture::value_type;
-  using vector_type = std::vector<value_type>;
-  for (value_type nprocs = 1; nprocs <= 6; ++nprocs) {
-    test_compute_mapped_extents<vector_type, value_type>(nprocs);
-  }
-}
-
-TYPED_TEST(TestExtents, mapped_extents_of_array) {
-  using value_type = typename TestFixture::value_type;
-  using array_type = std::array<value_type, 3>;
-  for (value_type nprocs = 1; nprocs <= 6; ++nprocs) {
-    test_compute_mapped_extents<array_type, value_type>(nprocs);
-  }
 }
 
 TYPED_TEST(TestExtents, fft_extents_of_array) {

--- a/distributed/unit_test/Test_Pack.cpp
+++ b/distributed/unit_test/Test_Pack.cpp
@@ -128,14 +128,14 @@ void test_pack_view2D(std::size_t rank, std::size_t nprocs, int order = 0) {
   SrcView2DType u_t0(
       "u_t0", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t0)),
       u_p_t0("u_p_t0", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t0, src_map)));
 
   // Data in Topology 1 (Y-pencil): original and permuted data
   SrcView2DType u_t1(
       "u_t1", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t1)),
       u_p_t1("u_p_t1", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t1, src_map)));
 
   // Buffers
@@ -295,21 +295,21 @@ void test_pack_view3D(std::size_t rank, std::size_t nprocs, int order = 0) {
   SrcView3DType u_t0(
       "u_t0", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t0)),
       u_p_t0("u_p_t0", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t0, src_map)));
 
   // Data in Topology 1 (Y-slab): original and permuted data
   SrcView3DType u_t1(
       "u_t1", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t1)),
       u_p_t1("u_p_t1", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t1, src_map)));
 
   // Data in Topology 2 (X-slab): original and permuted data
   SrcView3DType u_t2(
       "u_t2", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t2)),
       u_p_t2("u_p_t2", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t2, src_map)));
 
   // Buffers

--- a/distributed/unit_test/Test_Pack.cpp
+++ b/distributed/unit_test/Test_Pack.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Distributed_PackUnpack.hpp"
 #include "KokkosFFT_Distributed_Extents.hpp"
 #include "Test_Utils.hpp"

--- a/distributed/unit_test/Test_TransBlock.cpp
+++ b/distributed/unit_test/Test_TransBlock.cpp
@@ -48,8 +48,7 @@ template <typename Layout, typename IndexType, typename MapIndexType,
           std::size_t N>
 Layout create_mapped_layout(const std::array<IndexType, N>& extents,
                             const std::array<MapIndexType, N>& map) {
-  auto mapped_extents =
-      KokkosFFT::Distributed::Impl::compute_mapped_extents(extents, map);
+  auto mapped_extents = KokkosFFT::Impl::compute_mapped_extents(extents, map);
   return KokkosFFT::Impl::create_layout<Layout>(mapped_extents);
 }
 

--- a/distributed/unit_test/Test_TransBlock.cpp
+++ b/distributed/unit_test/Test_TransBlock.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Distributed_TransBlock.hpp"
 #include "KokkosFFT_Distributed_MPI_Extents.hpp"
 #include "KokkosFFT_Distributed_Extents.hpp"

--- a/distributed/unit_test/Test_Unpack.cpp
+++ b/distributed/unit_test/Test_Unpack.cpp
@@ -69,23 +69,21 @@ void test_unpack_view2D(std::size_t rank, std::size_t nprocs, int order = 0) {
   SrcView2DType u_t0(
       "u_t0", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t0)),
       u_p_t0("u_p_t0", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t0, dst_map))),
-      u_p_t0_ref("u_p_t0_ref",
-                 KokkosFFT::Impl::create_layout<LayoutType>(
-                     KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                         local_extents_t0, dst_map)));
+      u_p_t0_ref("u_p_t0_ref", KokkosFFT::Impl::create_layout<LayoutType>(
+                                   KokkosFFT::Impl::compute_mapped_extents(
+                                       local_extents_t0, dst_map)));
 
   // Data in Topology 1 (Y-pencil): original and permuted data
   SrcView2DType u_t1(
       "u_t1", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t1)),
       u_p_t1("u_p_t1", KokkosFFT::Impl::create_layout<LayoutType>(
-                           KokkosFFT::Distributed::Impl::compute_mapped_extents(
+                           KokkosFFT::Impl::compute_mapped_extents(
                                local_extents_t1, dst_map))),
-      u_p_t1_ref("u_p_t1_ref",
-                 KokkosFFT::Impl::create_layout<LayoutType>(
-                     KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                         local_extents_t1, dst_map)));
+      u_p_t1_ref("u_p_t1_ref", KokkosFFT::Impl::create_layout<LayoutType>(
+                                   KokkosFFT::Impl::compute_mapped_extents(
+                                       local_extents_t1, dst_map)));
 
   // Buffers
   auto buffer_extents =
@@ -239,50 +237,41 @@ void test_unpack_view3D(std::size_t rank, std::size_t nprocs, int order = 0) {
   // Data in Topology 0 (Z-slab): original and permuted data
   SrcView3DType u_t0(
       "u_t0", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t0)),
-      u_p_t0_01("u_p_t0_01",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t0, dst_map))),
-      u_p_t0_02("u_p_t0_02",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t0, dst_map))),
-      u_p_t0_ref("u_p_t0_ref",
-                 KokkosFFT::Impl::create_layout<LayoutType>(
-                     KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                         local_extents_t0, dst_map)));
+      u_p_t0_01("u_p_t0_01", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t0, dst_map))),
+      u_p_t0_02("u_p_t0_02", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t0, dst_map))),
+      u_p_t0_ref("u_p_t0_ref", KokkosFFT::Impl::create_layout<LayoutType>(
+                                   KokkosFFT::Impl::compute_mapped_extents(
+                                       local_extents_t0, dst_map)));
 
   // Data in Topology 1 (Y-slab): original and permuted data
   SrcView3DType u_t1(
       "u_t1", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t1)),
-      u_p_t1_10("u_p_t1_10",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t1, dst_map))),
-      u_p_t1_12("u_p_t1_12",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t1, dst_map))),
-      u_p_t1_ref("u_p_t1_ref",
-                 KokkosFFT::Impl::create_layout<LayoutType>(
-                     KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                         local_extents_t1, dst_map)));
+      u_p_t1_10("u_p_t1_10", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t1, dst_map))),
+      u_p_t1_12("u_p_t1_12", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t1, dst_map))),
+      u_p_t1_ref("u_p_t1_ref", KokkosFFT::Impl::create_layout<LayoutType>(
+                                   KokkosFFT::Impl::compute_mapped_extents(
+                                       local_extents_t1, dst_map)));
 
   // Data in Topology 2 (X-slab): original and permuted data
   SrcView3DType u_t2(
       "u_t2", KokkosFFT::Impl::create_layout<LayoutType>(local_extents_t2)),
-      u_p_t2_20("u_p_t2_20",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t2, dst_map))),
-      u_p_t2_21("u_p_t2_21",
-                KokkosFFT::Impl::create_layout<LayoutType>(
-                    KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                        local_extents_t2, dst_map))),
-      u_p_t2_ref("u_p_t2_ref",
-                 KokkosFFT::Impl::create_layout<LayoutType>(
-                     KokkosFFT::Distributed::Impl::compute_mapped_extents(
-                         local_extents_t2, dst_map)));
+      u_p_t2_20("u_p_t2_20", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t2, dst_map))),
+      u_p_t2_21("u_p_t2_21", KokkosFFT::Impl::create_layout<LayoutType>(
+                                 KokkosFFT::Impl::compute_mapped_extents(
+                                     local_extents_t2, dst_map))),
+      u_p_t2_ref("u_p_t2_ref", KokkosFFT::Impl::create_layout<LayoutType>(
+                                   KokkosFFT::Impl::compute_mapped_extents(
+                                       local_extents_t2, dst_map)));
 
   // Buffers
   auto buffer_extents_t01 =

--- a/distributed/unit_test/Test_Unpack.cpp
+++ b/distributed/unit_test/Test_Unpack.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Distributed_PackUnpack.hpp"
 #include "KokkosFFT_Distributed_Extents.hpp"
 #include "Test_Utils.hpp"

--- a/examples/10_HasegawaWakatani/10_hasegawa_wakatani.cpp
+++ b/examples/10_HasegawaWakatani/10_hasegawa_wakatani.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <random>
+#include <iostream>
 #include <filesystem>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Complex.hpp>

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -234,13 +234,14 @@ class Plan {
     }
 
     if (m_is_transpose_needed) {
-      using LayoutType = typename ManageableInViewType::array_layout;
+      using LayoutType    = typename ManageableInViewType::array_layout;
+      auto in_tmp_extents = Impl::extract_extents(in_tmp);
       ManageableInViewType const in_T(
           "in_T", Impl::create_layout<LayoutType>(
-                      Impl::compute_transpose_extents(in_tmp, m_map)));
+                      Impl::compute_mapped_extents(in_tmp_extents, m_map)));
       ManageableOutViewType const out_T(
           "out_T", Impl::create_layout<LayoutType>(
-                       Impl::compute_transpose_extents(out, m_map)));
+                       Impl::compute_mapped_extents(m_out_extents, m_map)));
       InViewType in_padded   = in_tmp;
       OutViewType out_padded = out;
       bool to_bounds_check   = false;

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -15,6 +15,7 @@
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_transpose.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"
 #include "KokkosFFT_padding.hpp"
 #include "KokkosFFT_Layout.hpp"

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -142,6 +142,11 @@ class Plan {
   extents_type m_in_extents, m_out_extents;
   ///@}
 
+  ///@{
+  //! extents of input/output views after mapping
+  extents_type m_in_mapped_extents, m_out_mapped_extents;
+  ///@}
+
  public:
   /// \brief Constructor for one-dimensional FFT
   ///
@@ -171,7 +176,11 @@ class Plan {
   explicit Plan(const ExecutionSpace& exec_space, const InViewType& in,
                 const OutViewType& out, KokkosFFT::Direction direction,
                 axis_type<DIM> axes, shape_type<DIM> s = {})
-      : m_exec_space(exec_space), m_axes(axes), m_direction(direction) {
+      : m_exec_space(exec_space),
+        m_axes(axes),
+        m_direction(direction),
+        m_in_extents(Impl::extract_extents(in)),
+        m_out_extents(Impl::extract_extents(out)) {
     KOKKOSFFT_THROW_IF(!Impl::are_valid_axes(in, m_axes),
                        "axes are invalid for in/out views");
     if constexpr (Impl::is_real_v<in_value_type>) {
@@ -186,8 +195,6 @@ class Plan {
                          "with forward direction.");
     }
 
-    m_in_extents               = Impl::extract_extents(in);
-    m_out_extents              = Impl::extract_extents(out);
     std::tie(m_map, m_map_inv) = Impl::get_map_axes(in, axes);
     m_is_transpose_needed      = Impl::is_transpose_needed(m_map);
     m_shape                    = Impl::get_modified_shape(in, out, s, m_axes);
@@ -196,6 +203,12 @@ class Plan {
     KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "
                        "Please use out-of-place transform.");
+
+    if (m_is_transpose_needed) {
+      auto in_tmp_extents = m_is_crop_or_pad_needed ? m_shape : m_in_extents;
+      m_in_mapped_extents = Impl::compute_mapped_extents(in_tmp_extents, m_map);
+      m_out_mapped_extents = Impl::compute_mapped_extents(m_out_extents, m_map);
+    }
 
     Impl::setup<ExecutionSpace, float_type>();
     bool is_truly_inplace = m_is_inplace && !m_is_transpose_needed;
@@ -235,14 +248,12 @@ class Plan {
     }
 
     if (m_is_transpose_needed) {
-      using LayoutType    = typename ManageableInViewType::array_layout;
-      auto in_tmp_extents = Impl::extract_extents(in_tmp);
+      using LayoutType = typename ManageableInViewType::array_layout;
       ManageableInViewType const in_T(
-          "in_T", Impl::create_layout<LayoutType>(
-                      Impl::compute_mapped_extents(in_tmp_extents, m_map)));
+          "in_T", Impl::create_layout<LayoutType>(m_in_mapped_extents));
       ManageableOutViewType const out_T(
-          "out_T", Impl::create_layout<LayoutType>(
-                       Impl::compute_mapped_extents(m_out_extents, m_map)));
+          "out_T", Impl::create_layout<LayoutType>(m_out_mapped_extents));
+
       InViewType in_padded   = in_tmp;
       OutViewType out_padded = out;
       bool to_bounds_check   = false;
@@ -253,16 +264,14 @@ class Plan {
         auto non_negative_axes     = Impl::convert_base_int_type<std::size_t>(
             Impl::convert_negative_axes(m_axes, rank));
 
-        if constexpr (Impl::is_real_v<in_value_type> &&
-                      Impl::is_complex_v<out_value_type>) {
+        if constexpr (Impl::is_real_v<in_value_type>) {
           auto in_padded_extents = Impl::compute_padded_extents<in_value_type>(
               m_out_extents, non_negative_axes);
           in_padded =
               InViewType(in_tmp.data(),
                          Impl::create_layout<LayoutType>(in_padded_extents));
           to_bounds_check = true;
-        } else if constexpr (Impl::is_complex_v<in_value_type> &&
-                             Impl::is_real_v<out_value_type>) {
+        } else if constexpr (Impl::is_real_v<out_value_type>) {
           auto out_padded_extents =
               Impl::compute_padded_extents<out_value_type>(m_in_extents,
                                                            non_negative_axes);


### PR DESCRIPTION
This PR aims at using `computed_mapped_extents` instead of `compute_transpose_extents`.

- [x] Move `computed_mapped_extents ` from `distributed` to `common`
- [x] Move unit-tests for that from `distributed` to `common`
- [x] Replace  `computed_transpose_extents` with `computed_mapped_extents`
- [x] Remove `computed_transpose_extents`