### PR TITLE
Add rfft/irfft example

### DIFF
--- a/docs/api/real/irfft.rst
+++ b/docs/api/real/irfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::irfft
 
 .. note::
 
-   The input must be a complex-valued view, and the output must be a real-valued view. The input size along the transform axis is ``n/2 + 1``, where ``n`` is the output size along that axis.
+   The input must be a complex-valued view, and the output must be a real-valued view. The input length along the transform axis is ``n/2 + 1``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
 
 Examples
 ========

--- a/docs/api/real/irfft.rst
+++ b/docs/api/real/irfft.rst
@@ -6,3 +6,21 @@ KokkosFFT::irfft
 ----------------
 
 .. doxygenfunction:: KokkosFFT::irfft(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
+
+.. note::
+
+   The input must be a complex-valued view, and the output must be a real-valued view. The input size along the transform axis is ``n/2 + 1``, where ``n`` is the output size along that axis.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/real/docs_irfft.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+  1 2 3 4

--- a/docs/api/real/rfft.rst
+++ b/docs/api/real/rfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::rfft
 
 .. note::
 
-   The input must be a real-valued view, and the output must be a complex-valued view. The output size along the transform axis is ``n/2 + 1``, where ``n`` is the input size along that axis.
+   The input must be a real-valued view, and the output must be a complex-valued view. The output length along the transform axis is ``n/2 + 1``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
 
 Examples
 ========

--- a/docs/api/real/rfft.rst
+++ b/docs/api/real/rfft.rst
@@ -6,3 +6,21 @@ KokkosFFT::rfft
 ---------------
 
 .. doxygenfunction:: KokkosFFT::rfft(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
+
+.. note::
+
+   The input must be a real-valued view, and the output must be a complex-valued view. The output size along the transform axis is ``n/2 + 1``, where ``n`` is the input size along that axis.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/real/docs_rfft.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (10,0) (-2,2) (-2,0)

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
+# Standard FFT examples
 add_executable(docs_fft standard/docs_fft.cpp)
 target_link_libraries(docs_fft PUBLIC KokkosFFT::fft)
 
@@ -19,3 +20,10 @@ target_link_libraries(docs_fftn PUBLIC KokkosFFT::fft)
 
 add_executable(docs_ifftn standard/docs_ifftn.cpp)
 target_link_libraries(docs_ifftn PUBLIC KokkosFFT::fft)
+
+# Real FFT examples
+add_executable(docs_rfft real/docs_rfft.cpp)
+target_link_libraries(docs_rfft PUBLIC KokkosFFT::fft)
+
+add_executable(docs_irfft real/docs_irfft.cpp)
+target_link_libraries(docs_irfft PUBLIC KokkosFFT::fft)

--- a/examples/docs/real/docs_irfft.cpp
+++ b/examples/docs/real/docs_irfft.cpp
@@ -7,7 +7,7 @@
 #include <Kokkos_Complex.hpp>
 #include <KokkosFFT.hpp>
 
-/// \brief Example of ifft usage in documentation
+/// \brief Example of irfft usage in documentation
 /// x_hat = [10, -2+2j, -2]
 /// x = [1, 2, 3, 4]
 int main(int argc, char* argv[]) {

--- a/examples/docs/real/docs_irfft.cpp
+++ b/examples/docs/real/docs_irfft.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of ifft usage in documentation
+/// x_hat = [10, -2+2j, -2]
+/// x = [1, 2, 3, 4]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View1D         = Kokkos::View<double*, ExecutionSpace>;
+  using ComplexView1D  = Kokkos::View<Kokkos::complex<double>*, ExecutionSpace>;
+
+  const int n0 = 4;
+
+  ComplexView1D x_hat("x_hat", n0 / 2 + 1);
+  View1D x("x", n0);
+  auto h_x_hat = Kokkos::create_mirror_view(x_hat);
+  h_x_hat(0)   = Kokkos::complex<double>(10, 0);
+  h_x_hat(1)   = Kokkos::complex<double>(-2, 2);
+  h_x_hat(2)   = Kokkos::complex<double>(-2, 0);
+  Kokkos::deep_copy(x_hat, h_x_hat);
+
+  ExecutionSpace exec;
+  KokkosFFT::irfft(exec, x_hat, x);
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  for (int i = 0; i < n0; ++i) {
+    std::cout << " " << h_x(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/real/docs_rfft.cpp
+++ b/examples/docs/real/docs_rfft.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of rfft usage in documentation
+/// x = [1, 2, 3, 4]
+/// x_hat = [10, -2+2j, -2]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View1D         = Kokkos::View<double*, ExecutionSpace>;
+  using ComplexView1D  = Kokkos::View<Kokkos::complex<double>*, ExecutionSpace>;
+
+  const int n0 = 4;
+
+  View1D x("x", n0);
+  ComplexView1D x_hat("x_hat", n0 / 2 + 1);
+  auto h_x = Kokkos::create_mirror_view(x);
+  for (int i = 0; i < n0; ++i) {
+    h_x(i) = i + 1;
+  }
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::rfft(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < n0 / 2 + 1; ++i) {
+    std::cout << " " << h_x_hat(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_rfft.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_irfft.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.
