### PR TITLE
fix: run ctest under /work/build

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -361,7 +361,7 @@ jobs:
             -m "${{ env.APPTAINER_MODULE }}" \
             -e gpu \
             -g a100 \
-            apptainer run --nv --bind $PWD/build:/work/build -H /work/build base_${{ matrix.backend.image }}_apptainer_latest.sif \
+            apptainer exec --nv --bind $PWD/build:/work/build --pwd /work/build base_${{ matrix.backend.image }}_apptainer_latest.sif \
             ctest --output-on-failure
         if: ${{ matrix.backend.use_apptainer }}
 


### PR DESCRIPTION
This PR aims at fixing the ruche CI to run ctest under `/work/build`