### PR TITLE
Refactor padding helper

### DIFF
--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -12,20 +12,30 @@
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_traits.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-/// \brief Partially copy the input view to the output view to pad or crop the
-/// input view to the output view.
-/// \tparam ExecutionSpace The type of Kokkos execution space.
-/// \tparam InViewType The input view type
-/// \tparam OutViewType The output view type
-/// \tparam Is The index sequence for the dimensions of the view
+/// \brief Crop or pad the input view into the output view by copying the
+/// overlapping region (the per-dimension minimum of both extents).
 ///
-/// \param[in] exec_space execution space instance
-/// \param[in] in The input view
-/// \param[in,out] out The output view
-/// \param[in] Is The index sequence for the dimensions of the view
+/// For every dimension \c i the copied range is
+/// <tt>[0, min(in.extent(i), out.extent(i)))</tt>.
+/// If \p out is larger than \p in in some dimension the extra elements retain
+/// their previous values (typically zero after construction).
+///
+/// \tparam ExecutionSpace Kokkos execution space type
+/// \tparam InViewType     Type of the source Kokkos::View
+/// \tparam OutViewType    Type of the destination Kokkos::View
+/// \tparam Is             Non-type parameter pack of \c std::size_t indices
+/// (<tt>0, 1, …, rank-1</tt>), deduced from the \c std::index_sequence tag
+/// argument and used to expand per-dimension subview ranges at compile time
+///
+/// \param[in]     exec_space Kokkos execution space instance
+/// \param[in]     in         Source view to copy from
+/// \param[in,out] out        Destination view to copy into
+/// \param[in]     (unnamed)  \c std::index_sequence<Is...> tag that carries the
+/// index pack; pass \c std::make_index_sequence<rank>{}
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t... Is>
 void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
@@ -45,17 +55,19 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::deep_copy(exec_space, sub_out, sub_in);
 }
 
-/// \brief Crop or pad the input view to the output view.
-/// This function partially copies the input view to the output view to pad or
-/// crop the input view to the output view. The extents of the copied region are
-/// determined by the minimum of the extents of the input and output views.
-/// \tparam ExecutionSpace The type of Kokkos execution space.
-/// \tparam InViewType The input view type
-/// \tparam OutViewType The output view type
+/// \brief Crop or pad the input view into the output view.
 ///
-/// \param[in] exec_space execution space instance
-/// \param[in] in The input view
-/// \param[in,out] out The output view
+/// Delegates to \c crop_or_pad_impl by automatically generating the index
+/// sequence from the view rank. For every dimension \c i the copied range is
+/// <tt>[0, min(in.extent(i), out.extent(i)))</tt>.
+///
+/// \tparam ExecutionSpace Kokkos execution space type
+/// \tparam InViewType     Type of the source Kokkos::View
+/// \tparam OutViewType    Type of the destination Kokkos::View
+///
+/// \param[in]     exec_space Kokkos execution space instance
+/// \param[in]     in         Source view to copy from
+/// \param[in,out] out        Destination view to copy into
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
                  const OutViewType& out) {

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -5,32 +5,27 @@
 #ifndef KOKKOSFFT_PADDING_HPP
 #define KOKKOSFFT_PADDING_HPP
 
+#include <algorithm>
+#include <array>
+#include <utility>
 #include <tuple>
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_asserts.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
-
-template <typename ViewType, std::size_t DIM>
-auto is_crop_or_pad_needed(const ViewType& view,
-                           const shape_type<DIM>& modified_shape) {
-  static_assert(ViewType::rank() == DIM,
-                "is_crop_or_pad_needed: Rank of View must be equal to Rank "
-                "of extended shape.");
-
-  constexpr int rank = static_cast<int>(ViewType::rank());
-  bool not_same      = false;
-  for (int i = 0; i < rank; i++) {
-    if (modified_shape.at(i) != view.extent(i)) {
-      not_same = true;
-      break;
-    }
-  }
-
-  return not_same;
-}
-
+/// \brief Partially copy the input view to the output view to pad or crop the
+/// input view to the output view.
+/// \tparam ExecutionSpace The type of Kokkos execution space.
+/// \tparam InViewType The input view type
+/// \tparam OutViewType The output view type
+/// \tparam Is The index sequence for the dimensions of the view
+///
+/// \param[in] exec_space execution space instance
+/// \param[in] in The input view
+/// \param[in,out] out The output view
+/// \param[in] Is The index sequence for the dimensions of the view
 template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           std::size_t... Is>
 void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
@@ -38,7 +33,7 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
   constexpr std::size_t rank = InViewType::rank();
   using extents_type         = std::array<std::size_t, rank>;
 
-  extents_type extents;
+  extents_type extents{};
   for (std::size_t i = 0; i < rank; i++) {
     extents.at(i) = std::min(in.extent(i), out.extent(i));
   }
@@ -50,6 +45,17 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
   Kokkos::deep_copy(exec_space, sub_out, sub_in);
 }
 
+/// \brief Crop or pad the input view to the output view.
+/// This function partially copies the input view to the output view to pad or
+/// crop the input view to the output view. The extents of the copied region are
+/// determined by the minimum of the extents of the input and output views.
+/// \tparam ExecutionSpace The type of Kokkos execution space.
+/// \tparam InViewType The input view type
+/// \tparam OutViewType The output view type
+///
+/// \param[in] exec_space execution space instance
+/// \param[in] in The input view
+/// \param[in,out] out The output view
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
                  const OutViewType& out) {

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -45,7 +45,7 @@ void crop_or_pad_impl(const ExecutionSpace& exec_space, const SrcViewType& src,
 
   extents_type extents{};
   for (std::size_t i = 0; i < rank; i++) {
-    extents.at(i) = std::min(src.extent(i), dst.extent(i));
+    extents[i] = std::min(src.extent(i), dst.extent(i));
   }
 
   auto sub_src = Kokkos::subview(

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -20,63 +20,63 @@ namespace Impl {
 /// overlapping region (the per-dimension minimum of both extents).
 ///
 /// For every dimension \c i the copied range is
-/// <tt>[0, min(in.extent(i), out.extent(i)))</tt>.
-/// If \p out is larger than \p in in some dimension the extra elements retain
+/// <tt>[0, min(src.extent(i), dst.extent(i)))</tt>.
+/// If \p dst is larger than \p src in some dimension the extra elements retain
 /// their previous values (typically zero after construction).
 ///
 /// \tparam ExecutionSpace Kokkos execution space type
-/// \tparam InViewType     Type of the source Kokkos::View
-/// \tparam OutViewType    Type of the destination Kokkos::View
+/// \tparam SrcViewType    Type of the source Kokkos::View
+/// \tparam DstViewType    Type of the destination Kokkos::View
 /// \tparam Is             Non-type parameter pack of \c std::size_t indices
 /// (<tt>0, 1, …, rank-1</tt>), deduced from the \c std::index_sequence tag
 /// argument and used to expand per-dimension subview ranges at compile time
 ///
 /// \param[in]     exec_space Kokkos execution space instance
-/// \param[in]     in         Source view to copy from
-/// \param[in,out] out        Destination view to copy into
+/// \param[in]     src        Source view to copy from
+/// \param[in,out] dst        Destination view to copy into
 /// \param[in]     (unnamed)  \c std::index_sequence<Is...> tag that carries the
 /// index pack; pass \c std::make_index_sequence<rank>{}
-template <typename ExecutionSpace, typename InViewType, typename OutViewType,
+template <typename ExecutionSpace, typename SrcViewType, typename DstViewType,
           std::size_t... Is>
-void crop_or_pad_impl(const ExecutionSpace& exec_space, const InViewType& in,
-                      const OutViewType& out, std::index_sequence<Is...>) {
-  constexpr std::size_t rank = InViewType::rank();
+void crop_or_pad_impl(const ExecutionSpace& exec_space, const SrcViewType& src,
+                      const DstViewType& dst, std::index_sequence<Is...>) {
+  constexpr std::size_t rank = SrcViewType::rank();
   using extents_type         = std::array<std::size_t, rank>;
 
   extents_type extents{};
   for (std::size_t i = 0; i < rank; i++) {
-    extents.at(i) = std::min(in.extent(i), out.extent(i));
+    extents.at(i) = std::min(src.extent(i), dst.extent(i));
   }
 
-  auto sub_in = Kokkos::subview(
-      in, std::make_pair(std::size_t(0), std::get<Is>(extents))...);
-  auto sub_out = Kokkos::subview(
-      out, std::make_pair(std::size_t(0), std::get<Is>(extents))...);
-  Kokkos::deep_copy(exec_space, sub_out, sub_in);
+  auto sub_src = Kokkos::subview(
+      src, std::make_pair(std::size_t(0), std::get<Is>(extents))...);
+  auto sub_dst = Kokkos::subview(
+      dst, std::make_pair(std::size_t(0), std::get<Is>(extents))...);
+  Kokkos::deep_copy(exec_space, sub_dst, sub_src);
 }
 
 /// \brief Crop or pad the input view into the output view.
 ///
 /// Delegates to \c crop_or_pad_impl by automatically generating the index
 /// sequence from the view rank. For every dimension \c i the copied range is
-/// <tt>[0, min(in.extent(i), out.extent(i)))</tt>.
+/// <tt>[0, min(src.extent(i), dst.extent(i)))</tt>.
 ///
 /// \tparam ExecutionSpace Kokkos execution space type
-/// \tparam InViewType     Type of the source Kokkos::View
-/// \tparam OutViewType    Type of the destination Kokkos::View
+/// \tparam SrcViewType    Type of the source Kokkos::View
+/// \tparam DstViewType    Type of the destination Kokkos::View
 ///
 /// \param[in]     exec_space Kokkos execution space instance
-/// \param[in]     in         Source view to copy from
-/// \param[in,out] out        Destination view to copy into
-template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void crop_or_pad(const ExecutionSpace& exec_space, const InViewType& in,
-                 const OutViewType& out) {
+/// \param[in]     src        Source view to copy from
+/// \param[in,out] dst        Destination view to copy into
+template <typename ExecutionSpace, typename SrcViewType, typename DstViewType>
+void crop_or_pad(const ExecutionSpace& exec_space, const SrcViewType& src,
+                 const DstViewType& dst) {
   KOKKOSFFT_STATIC_ASSERT_VIEWS_ARE_OPERATABLE(
-      (KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
-                                               OutViewType>),
+      (KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, SrcViewType,
+                                               DstViewType>),
       "crop_or_pad");
-  crop_or_pad_impl(exec_space, in, out,
-                   std::make_index_sequence<InViewType::rank()>{});
+  crop_or_pad_impl(exec_space, src, dst,
+                   std::make_index_sequence<SrcViewType::rank()>{});
 }
 }  // namespace Impl
 }  // namespace KokkosFFT

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -9,7 +9,7 @@
 #include <tuple>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_utils.hpp"
-#include "KokkosFFT_padding.hpp"
+#include "KokkosFFT_Padding.hpp"
 #include "KokkosFFT_Layout.hpp"
 
 namespace KokkosFFT {

--- a/common/unit_test/Test_Padding.cpp
+++ b/common/unit_test/Test_Padding.cpp
@@ -6,7 +6,7 @@
 #include <Kokkos_Random.hpp>
 #include <random>
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_padding.hpp"
+#include "KokkosFFT_Padding.hpp"
 #include "Test_Utils.hpp"
 
 namespace {
@@ -916,58 +916,6 @@ TYPED_TEST(GetModifiedShape3D, 7DView) {
 TYPED_TEST(GetModifiedShape3D, 8DView) {
   using float_type = typename TestFixture::float_type;
   test_reshape3D_8DView<float_type>();
-}
-
-TEST(IsCropOrPadNeeded, 1DView) {
-  const int len = 30, len_pad = 32, len_crop = 28;
-  View1D<double> x("x", len);
-
-  EXPECT_FALSE(KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_type<1>{len}));
-  EXPECT_TRUE(
-      KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_type<1>{len_pad}));
-  EXPECT_TRUE(
-      KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_type<1>{len_crop}));
-}
-
-TEST(IsCropOrPadNeeded, 2DView) {
-  const int n0 = 30, n1 = 15;
-  View2D<double> x("x", n0, n1);
-
-  for (int i0 = -1; i0 <= 1; i0++) {
-    for (int i1 = -1; i1 <= 1; i1++) {
-      std::size_t n0_new = static_cast<std::size_t>(n0 + i0);
-      std::size_t n1_new = static_cast<std::size_t>(n1 + i1);
-
-      shape_type<2> shape_new = {n0_new, n1_new};
-      if (i0 == 0 && i1 == 0) {
-        EXPECT_FALSE(KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_new));
-      } else {
-        EXPECT_TRUE(KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_new));
-      }
-    }
-  }
-}
-
-TEST(IsCropOrPadNeeded, 3DView) {
-  const int n0 = 30, n1 = 15, n2 = 8;
-  View3D<double> x("x", n0, n1, n2);
-
-  for (int i0 = -1; i0 <= 1; i0++) {
-    for (int i1 = -1; i1 <= 1; i1++) {
-      for (int i2 = -1; i2 <= 1; i2++) {
-        std::size_t n0_new = static_cast<std::size_t>(n0 + i0);
-        std::size_t n1_new = static_cast<std::size_t>(n1 + i1);
-        std::size_t n2_new = static_cast<std::size_t>(n2 + i2);
-
-        shape_type<3> shape_new = {n0_new, n1_new, n2_new};
-        if (i0 == 0 && i1 == 0 && i2 == 0) {
-          EXPECT_FALSE(KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_new));
-        } else {
-          EXPECT_TRUE(KokkosFFT::Impl::is_crop_or_pad_needed(x, shape_new));
-        }
-      }
-    }
-  }
 }
 
 TEST(CropOrPad1D, 1DView) {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -17,7 +17,7 @@
 #include "KokkosFFT_transpose.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"
-#include "KokkosFFT_padding.hpp"
+#include "KokkosFFT_Padding.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_utils.hpp"
 
@@ -198,7 +198,7 @@ class Plan {
     std::tie(m_map, m_map_inv) = Impl::get_map_axes(in, axes);
     m_is_transpose_needed      = Impl::is_transpose_needed(m_map);
     m_shape                    = Impl::get_modified_shape(in, out, s, m_axes);
-    m_is_crop_or_pad_needed    = Impl::is_crop_or_pad_needed(in, m_shape);
+    m_is_crop_or_pad_needed    = m_in_extents != m_shape;
     m_is_inplace               = Impl::are_aliasing(in.data(), out.data());
     KOKKOSFFT_THROW_IF(m_is_inplace && m_is_crop_or_pad_needed,
                        "In-place transform is not supported with reshape. "


### PR DESCRIPTION
- [x] Rename header from `KokkosFFT_padding.hpp` to `KokkosFFT_Padding.hpp`
- [x] Refactor headers in `KokkosFFT_Padding.hpp`
- [x] Remove `is_crop_or_pad_needed` which can be simply achieved by `in_extents != extents`
- [x] Remove tests for `is_crop_or_pad_needed`
- [x] Add docstings to `crop_or_pad` and `crop_or_pad_impl`