### PR TITLE
Refactor assert helper

### DIFF
--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -71,14 +71,15 @@ inline std::stringstream error_info(const char* file_name, int line,
 /// detailed source location information and the provided error message.
 ///
 /// Example:
-/// \code{cpp}
+/// \code{.cpp}
 /// KOKKOSFFT_THROW_IF(true, "An error occurred");
 /// // throws std::runtime_error with message:
-/// // "example.cpp(10) `main`: An error occurred"
+/// // "file: example.cpp(10) `main`: An error occurred"
 /// \endcode
 ///
 /// \param[in] expression The boolean expression representing the precondition
-/// to check \param[in] msg The error message to include in the exception
+/// to check
+/// \param[in] msg The error message to include in the exception
 /// \param[in] file_name The name of the source file where the error occurs
 /// \param[in] line The line number in the source file where the error occurs
 /// \param[in] function_name The name of the function where the error occurs
@@ -108,7 +109,7 @@ inline void check_precondition(const bool expression,
 /// \code{cpp}
 /// KOKKOSFFT_CHECK_CUFFT_CALL(cufftPlan1d(&plan, n, CUFFT_R2C, batch));
 /// // On failure, throws std::runtime_error with message:
-/// // "example.cpp(10) `main`:
+/// // "file: example.cpp(10) `main`:
 /// //  cufftPlan1d(&plan, n, CUFFT_R2C, batch) failed with error code 1
 /// (CUFFT_INVALID_PLAN)"
 /// \endcode

--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -40,7 +40,7 @@ namespace Impl {
 /// name, used internally for exceptions thrown by KokkosFFT.
 ///
 /// Example:
-/// \code{cpp}
+/// \code{.cpp}
 /// auto ss = error_info("example.cpp", 10, "main");
 /// \endcode
 ///
@@ -106,7 +106,7 @@ inline void check_precondition(const bool expression,
 /// it does not indicate success.
 ///
 /// Example:
-/// \code{cpp}
+/// \code{.cpp}
 /// KOKKOSFFT_CHECK_CUFFT_CALL(cufftPlan1d(&plan, n, CUFFT_R2C, batch));
 /// // On failure, throws std::runtime_error with message:
 /// // "file: example.cpp(10) `main`:

--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -34,6 +34,22 @@
 namespace KokkosFFT {
 namespace Impl {
 
+/// \brief Generates a formatted error message with source location information.
+///
+/// Produces a stringstream containing file name, line number, and function
+/// name, used internally for exceptions thrown by KokkosFFT.
+///
+/// Example:
+/// \code{cpp}
+/// auto ss = error_info("example.cpp", 10, "main");
+/// \endcode
+///
+/// \param[in] file_name The name of the source file where the error occurs
+/// \param[in] line The line number in the source file where the error occurs
+/// \param[in] function_name The name of the function where the error occurs
+/// \param[in] column The column number in the source file where the error
+/// occurs (default: -1)
+/// \return A stringstream containing the formatted error message
 inline std::stringstream error_info(const char* file_name, int line,
                                     const char* function_name,
                                     const int column = -1) {
@@ -49,6 +65,26 @@ inline std::stringstream error_info(const char* file_name, int line,
   return ss;
 }
 
+/// \brief Checks a precondition and throws an exception if it is not met.
+///
+/// When \p expression evaluates to true, throws a std::runtime_error with
+/// detailed source location information and the provided error message.
+///
+/// Example:
+/// \code{cpp}
+/// KOKKOSFFT_THROW_IF(true, "An error occurred");
+/// // throws std::runtime_error with message:
+/// // "example.cpp(10) `main`: An error occurred"
+/// \endcode
+///
+/// \param[in] expression The boolean expression representing the precondition
+/// to check \param[in] msg The error message to include in the exception
+/// \param[in] file_name The name of the source file where the error occurs
+/// \param[in] line The line number in the source file where the error occurs
+/// \param[in] function_name The name of the function where the error occurs
+/// \param[in] column The column number in the source file where the error
+/// occurs (default: -1)
+/// \throws std::runtime_error if \p expression is true
 inline void check_precondition(const bool expression,
                                const std::string_view& msg,
                                const char* file_name, int line,
@@ -61,6 +97,36 @@ inline void check_precondition(const bool expression,
   throw std::runtime_error(ss.str());
 }
 
+/// \brief Checks the return status of an FFT library call and throws on
+/// failure.
+///
+/// Validates the status returned by an FFT library call (cuFFT, hipFFT, or
+/// rocFFT) and throws a std::runtime_error with detailed error information if
+/// it does not indicate success.
+///
+/// Example:
+/// \code{cpp}
+/// KOKKOSFFT_CHECK_CUFFT_CALL(cufftPlan1d(&plan, n, CUFFT_R2C, batch));
+/// // On failure, throws std::runtime_error with message:
+/// // "example.cpp(10) `main`:
+/// //  cufftPlan1d(&plan, n, CUFFT_R2C, batch) failed with error code 1
+/// (CUFFT_INVALID_PLAN)"
+/// \endcode
+///
+/// \tparam FFTStatusType The type of the FFT library status code
+/// \tparam ResultToStringFunc The type of the function converting a status code
+/// to a string
+///
+/// \param[in] status The return status of the FFT library call
+/// \param[in] command_name The string representation of the FFT library call
+/// \param[in] status_success The status value indicating a successful call
+/// \param[in] result_to_string A function that converts the status to a string
+/// \param[in] file_name The name of the source file where the error occurs
+/// \param[in] line The line number in the source file where the error occurs
+/// \param[in] function_name The name of the function where the error occurs
+/// \param[in] column The column number in the source file where the error
+/// occurs (default: -1)
+/// \throws std::runtime_error if \p status does not equal \p status_success
 template <typename FFTStatusType, typename ResultToStringFunc>
 void check_fft_call(FFTStatusType status, const char* command_name,
                     FFTStatusType status_success,

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -11,7 +11,7 @@
 #include <numeric>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_traits.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Mapping.hpp"
 

--- a/common/src/KokkosFFT_Mapping.hpp
+++ b/common/src/KokkosFFT_Mapping.hpp
@@ -9,7 +9,7 @@
 #include <tuple>
 #include <numeric>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -11,7 +11,7 @@
 #include <tuple>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_traits.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -12,7 +12,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <limits>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_common_types.hpp"
 

--- a/fft/src/KokkosFFT_Cuda_asserts.hpp
+++ b/fft/src/KokkosFFT_Cuda_asserts.hpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <cufft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 
 #if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
 #include <source_location>

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -9,7 +9,7 @@
 #include "KokkosFFT_Cuda_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -7,7 +7,7 @@
 
 #include <cufft.h>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Cuda_types.hpp"
 #include "KokkosFFT_Cuda_asserts.hpp"
 

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -9,7 +9,7 @@
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Cuda_asserts.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)

--- a/fft/src/KokkosFFT_HIP_asserts.hpp
+++ b/fft/src/KokkosFFT_HIP_asserts.hpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <hipfft/hipfft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 
 #if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
 #include <source_location>

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -9,7 +9,7 @@
 #include "KokkosFFT_HIP_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/fft/src/KokkosFFT_HIP_transform.hpp
+++ b/fft/src/KokkosFFT_HIP_transform.hpp
@@ -7,7 +7,7 @@
 
 #include <hipfft/hipfft.h>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_HIP_types.hpp"
 #include "KokkosFFT_HIP_asserts.hpp"
 

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -9,7 +9,7 @@
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_HIP_asserts.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -7,6 +7,7 @@
 
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_default_types.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_utils.hpp"

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -15,6 +15,7 @@
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_transpose.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"
 #include "KokkosFFT_Padding.hpp"

--- a/fft/src/KokkosFFT_ROCM_asserts.hpp
+++ b/fft/src/KokkosFFT_ROCM_asserts.hpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <rocfft/rocfft.h>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 
 #if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
 #include <source_location>

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -9,7 +9,7 @@
 #include "KokkosFFT_ROCM_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_ROCM_transform.hpp
+++ b/fft/src/KokkosFFT_ROCM_transform.hpp
@@ -8,7 +8,7 @@
 #include <complex>
 #include <rocfft/rocfft.h>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_ROCM_types.hpp"
 #include "KokkosFFT_ROCM_asserts.hpp"
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -13,7 +13,7 @@
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_traits.hpp"
-#include "KokkosFFT_asserts.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_ROCM_asserts.hpp"
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -14,6 +14,7 @@
 #endif
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_SYCL_types.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_traits.hpp"
 #include "KokkosFFT_utils.hpp"

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -14,6 +14,7 @@
 #include <oneapi/mkl/dfti.hpp>
 #endif
 #include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -8,6 +8,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Plans.hpp"


### PR DESCRIPTION
- [x] Rename header from `KokkosFFT_asserts.hpp` to `KokkosFFT_Asserts.hpp`
- [x] Add docstrings to the functions in `KokkosFFT_Asserts.hpp`
- [x] Fix: missing includes of `KokkosFFT_Asserts.hpp`