### PR TITLE
Rename KokkosFFT_traits.hpp as KokkosFFT_Traits.hpp

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <numeric>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Mapping.hpp"

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -7,7 +7,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_utils.hpp"
 

--- a/common/src/KokkosFFT_Normalization.hpp
+++ b/common/src/KokkosFFT_Normalization.hpp
@@ -10,7 +10,7 @@
 #include <numeric>
 #include <tuple>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -12,7 +12,7 @@
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Asserts.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_Traits.hpp
+++ b/common/src/KokkosFFT_Traits.hpp
@@ -5,6 +5,9 @@
 #ifndef KOKKOSFFT_TRAITS_HPP
 #define KOKKOSFFT_TRAITS_HPP
 
+#include <type_traits>
+#include <array>
+#include <vector>
 #include <Kokkos_Core.hpp>
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <limits>
 #include "KokkosFFT_Asserts.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_common_types.hpp"
 
 namespace KokkosFFT {

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -6,7 +6,7 @@
 #include <Kokkos_Random.hpp>
 #include <vector>
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "Test_Utils.hpp"
 
 namespace {

--- a/common/unit_test/Test_Normalization.cpp
+++ b/common/unit_test/Test_Normalization.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_Normalization.hpp"

--- a/common/unit_test/Test_Traits.cpp
+++ b/common/unit_test/Test_Traits.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 #include <gtest/gtest.h>
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "Test_Utils.hpp"
 
 // All the tests in this file are compile time tests, so we skip all the tests

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -8,7 +8,7 @@
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_Cuda_types.hpp"
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 

--- a/fft/src/KokkosFFT_DynPlans.hpp
+++ b/fft/src/KokkosFFT_DynPlans.hpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Normalization.hpp"
 #include "KokkosFFT_utils.hpp"
 

--- a/fft/src/KokkosFFT_HIP_plans.hpp
+++ b/fft/src/KokkosFFT_HIP_plans.hpp
@@ -8,7 +8,7 @@
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_HIP_types.hpp"
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -9,7 +9,7 @@
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_transpose.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -8,7 +8,7 @@
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_ROCM_types.hpp"
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -12,7 +12,7 @@
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_ROCM_asserts.hpp"

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -16,7 +16,7 @@
 #include "KokkosFFT_SYCL_types.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -14,6 +14,7 @@
 #include <oneapi/mkl/dfti.hpp>
 #endif
 #include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_utils.hpp"
 

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -7,7 +7,7 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_traits.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_utils.hpp"

--- a/fft/src/KokkosFFT_default_types.hpp
+++ b/fft/src/KokkosFFT_default_types.hpp
@@ -14,6 +14,7 @@ static_assert(false,
 #endif
 
 #include "KokkosFFT_config.hpp"
+#include "KokkosFFT_Traits.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_CUFFT)
 #define KOKKOSFFT_HAS_DEVICE_TPL


### PR DESCRIPTION
- [x] Rename header from `KokkosFFT_traits.hpp` to `KokkosFFT_Traits.hpp`
- [x] Fix: missing includes of `KokkosFFT_Traits.hpp`