### PR TITLE
Add MD operation helper

### DIFF
--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -9,6 +9,7 @@
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Layout.hpp"
+#include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
@@ -78,45 +79,11 @@ auto get_shifts(const ViewType& x, axis_type<DIM> axes, int direction = 1) {
 template <typename ExecutionSpace, typename ViewType, typename IndexType>
 struct Roll {
  private:
-  // Since MDRangePolicy is not available for 7D and 8D views, we need to
-  // handle them separately. We can use a 6D MDRangePolicy and iterate over
-  // the last two dimensions in the operator() function.
-  static constexpr std::size_t m_rank_truncated =
-      std::min(ViewType::rank(), std::size_t(6));
-
   using ArrayType          = Kokkos::Array<std::size_t, ViewType::rank()>;
   using LayoutType         = typename ViewType::array_layout;
   using ManageableViewType = typename manageable_view_type<ViewType>::type;
 
   ManageableViewType m_tmp;
-
-  /// \brief Retrieves the policy for the parallel execution.
-  /// If the view is 1D, a Kokkos::RangePolicy is used. For higher dimensions up
-  /// to 6D, a Kokkos::MDRangePolicy is used. For 7D and 8D views, we use 6D
-  /// MDRangePolicy
-  /// \param[in] space The Kokkos execution space used to launch the parallel
-  /// reduction.
-  /// \param[in] x The Kokkos view to be used for determining the policy.
-  auto get_policy(const ExecutionSpace space, const ViewType& x) const {
-    if constexpr (ViewType::rank() == 1) {
-      using range_policy_type =
-          Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>;
-      return range_policy_type(space, 0, x.extent(0));
-    } else {
-      using iterate_type =
-          Kokkos::Rank<m_rank_truncated, Kokkos::Iterate::Default,
-                       Kokkos::Iterate::Default>;
-      using mdrange_policy_type =
-          Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                Kokkos::IndexType<IndexType>>;
-      Kokkos::Array<std::size_t, m_rank_truncated> begins = {};
-      Kokkos::Array<std::size_t, m_rank_truncated> ends   = {};
-      for (std::size_t i = 0; i < m_rank_truncated; ++i) {
-        ends[i] = x.extent(i);
-      }
-      return mdrange_policy_type(space, begins, ends);
-    }
-  }
 
  public:
   /// \brief Constructor for the Roll functor.
@@ -128,8 +95,10 @@ struct Roll {
   Roll(const ViewType& x, const ArrayType& shifts,
        const ExecutionSpace exec_space = ExecutionSpace())
       : m_tmp("tmp", create_layout<LayoutType>(extract_extents(x))) {
-    Kokkos::parallel_for("KokkosFFT::roll", get_policy(exec_space, x),
-                         RollInternal(x, m_tmp, shifts));
+    Kokkos::parallel_for(
+        "KokkosFFT::roll",
+        KokkosFFT::Impl::get_mdpolicy<IndexType>(exec_space, x),
+        RollInternal(x, m_tmp, shifts));
     Kokkos::deep_copy(exec_space, x, m_tmp);
   }
 

--- a/common/src/KokkosFFT_MDOperations.hpp
+++ b/common/src/KokkosFFT_MDOperations.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_MDOPERATIONS_HPP
+#define KOKKOSFFT_MDOPERATIONS_HPP
+
+#include <algorithm>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_Layout.hpp"
+
+namespace KokkosFFT {
+namespace Impl {
+/// \brief Retrieves the policy for the parallel execution.
+/// If the view is 1D, a Kokkos::RangePolicy is used. For higher dimensions up
+/// to 6D, a Kokkos::MDRangePolicy is used. For 7D and 8D views, we use 6D
+/// MDRangePolicy
+///
+/// \tparam IndexType The type of index to be used in the policy (e.g., int,
+/// std::size_t) \tparam ExecutionSpace The Kokkos execution space to be used
+/// for the policy \tparam ViewType The type of the Kokkos view for which the
+/// policy is being created \param[in] space The Kokkos execution space used to
+/// launch the parallel reduction. \param[in] x The Kokkos view to be used for
+/// determining the policy. \return A Kokkos execution policy (either
+/// RangePolicy or MDRangePolicy) to loop over the elements of the view (up to
+/// 6D).
+template <typename IndexType, typename ExecutionSpace, typename ViewType>
+auto get_mdpolicy(const ExecutionSpace& space, const ViewType& x) {
+  constexpr std::size_t rank_truncated =
+      std::min(ViewType::rank(), std::size_t(6));
+  if constexpr (ViewType::rank() == 1) {
+    using range_policy_type =
+        Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>;
+    return range_policy_type(space, 0, x.extent(0));
+  } else {
+    using LayoutType = typename ViewType::array_layout;
+    static const Kokkos::Iterate outer_iteration_pattern =
+        layout_iterate_type_selector<LayoutType>::outer_iteration_pattern;
+    static const Kokkos::Iterate inner_iteration_pattern =
+        layout_iterate_type_selector<LayoutType>::inner_iteration_pattern;
+    using iterate_type = Kokkos::Rank<rank_truncated, outer_iteration_pattern,
+                                      inner_iteration_pattern>;
+    using mdrange_policy_type =
+        Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                              Kokkos::IndexType<IndexType>>;
+    Kokkos::Array<std::size_t, rank_truncated> begins{}, ends{};
+    for (std::size_t i = 0; i < rank_truncated; ++i) {
+      ends[i] = x.extent(i);
+    }
+    return mdrange_policy_type(space, begins, ends);
+  }
+}
+}  // namespace Impl
+}  // namespace KokkosFFT
+
+#endif

--- a/common/src/KokkosFFT_MDOperations.hpp
+++ b/common/src/KokkosFFT_MDOperations.hpp
@@ -5,9 +5,7 @@
 #ifndef KOKKOSFFT_MDOPERATIONS_HPP
 #define KOKKOSFFT_MDOPERATIONS_HPP
 
-#include <algorithm>
 #include <Kokkos_Core.hpp>
-#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Layout.hpp"
 
 namespace KokkosFFT {
@@ -18,13 +16,15 @@ namespace Impl {
 /// MDRangePolicy
 ///
 /// \tparam IndexType The type of index to be used in the policy (e.g., int,
-/// std::size_t) \tparam ExecutionSpace The Kokkos execution space to be used
-/// for the policy \tparam ViewType The type of the Kokkos view for which the
-/// policy is being created \param[in] space The Kokkos execution space used to
-/// launch the parallel reduction. \param[in] x The Kokkos view to be used for
-/// determining the policy. \return A Kokkos execution policy (either
-/// RangePolicy or MDRangePolicy) to loop over the elements of the view (up to
-/// 6D).
+/// std::size_t)
+/// \tparam ExecutionSpace The Kokkos execution space to be used for the policy
+/// \tparam ViewType The type of the Kokkos view for which the policy is being
+/// created
+/// \param[in] space The Kokkos execution space used to launch the parallel
+/// reduction.
+/// \param[in] x The Kokkos view to be used for determining the policy.
+/// \return A Kokkos execution policy (either RangePolicy or MDRangePolicy) to
+/// loop over the elements of the view (up to 6D).
 template <typename IndexType, typename ExecutionSpace, typename ViewType>
 auto get_mdpolicy(const ExecutionSpace& space, const ViewType& x) {
   constexpr std::size_t rank_truncated =

--- a/common/src/KokkosFFT_transpose.hpp
+++ b/common/src/KokkosFFT_transpose.hpp
@@ -11,6 +11,7 @@
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Padding.hpp"
 #include "KokkosFFT_Layout.hpp"
+#include "KokkosFFT_MDOperations.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
@@ -34,46 +35,7 @@ template <typename ExecutionSpace, typename InViewType, typename OutViewType,
           typename IndexType, typename ArgBoundsCheck = BoundsCheck::Off>
 struct Transpose {
  private:
-  // Since MDRangePolicy is not available for 7D and 8D views, we need to
-  // handle them separately. We can use a 6D MDRangePolicy and iterate over
-  // the last two dimensions in the operator() function.
-  static constexpr std::size_t m_rank_truncated =
-      std::min(InViewType::rank(), std::size_t(6));
-
   using ArrayType = Kokkos::Array<int, InViewType::rank()>;
-
-  /// \brief Retrieves the policy for the parallel execution.
-  /// If the view is 1D, a Kokkos::RangePolicy is used. For higher dimensions up
-  /// to 6D, a Kokkos::MDRangePolicy is used. For 7D and 8D views, we use 6D
-  /// MDRangePolicy
-  /// \param[in] space The Kokkos execution space used to launch the parallel
-  /// reduction.
-  /// \param[in] x The Kokkos view to be used for determining the policy.
-  auto get_policy(const ExecutionSpace space, const InViewType& x) const {
-    if constexpr (InViewType::rank() == 1) {
-      using range_policy_type =
-          Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>;
-      return range_policy_type(space, 0, x.extent(0));
-    } else {
-      using LayoutType = typename InViewType::array_layout;
-      static const Kokkos::Iterate outer_iteration_pattern =
-          layout_iterate_type_selector<LayoutType>::outer_iteration_pattern;
-      static const Kokkos::Iterate inner_iteration_pattern =
-          layout_iterate_type_selector<LayoutType>::inner_iteration_pattern;
-      using iterate_type =
-          Kokkos::Rank<m_rank_truncated, outer_iteration_pattern,
-                       inner_iteration_pattern>;
-      using mdrange_policy_type =
-          Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
-                                Kokkos::IndexType<IndexType>>;
-      Kokkos::Array<std::size_t, m_rank_truncated> begins = {};
-      Kokkos::Array<std::size_t, m_rank_truncated> ends   = {};
-      for (std::size_t i = 0; i < m_rank_truncated; ++i) {
-        ends[i] = x.extent(i);
-      }
-      return mdrange_policy_type(space, begins, ends);
-    }
-  }
 
  public:
   /// \brief Constructor for the Transpose functor.
@@ -85,8 +47,10 @@ struct Transpose {
   /// to ExecutionSpace()).
   Transpose(const InViewType& in, const OutViewType& out, const ArrayType& map,
             const ExecutionSpace exec_space = ExecutionSpace()) {
-    Kokkos::parallel_for("KokkosFFT::transpose", get_policy(exec_space, in),
-                         TransposeInternal(in, out, map));
+    Kokkos::parallel_for(
+        "KokkosFFT::transpose",
+        KokkosFFT::Impl::get_mdpolicy<IndexType>(exec_space, in),
+        TransposeInternal(in, out, map));
   }
 
   /// \brief Helper functor to perform the transpose operation

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   Test_Layout.cpp
   Test_Normalization.cpp
   Test_Mapping.cpp
+  Test_MDOperations.cpp
   Test_Transpose.cpp
   Test_Extents.cpp
   Test_Padding.cpp

--- a/common/unit_test/Test_MDOperations.cpp
+++ b/common/unit_test/Test_MDOperations.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "Test_Utils.hpp"
 

--- a/common/unit_test/Test_MDOperations.cpp
+++ b/common/unit_test/Test_MDOperations.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_MDOperations.hpp"
+#include "Test_Utils.hpp"
+
+namespace {
+#if defined(KOKKOS_ENABLE_SERIAL)
+using base_execution_space_types =
+    std::tuple<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace,
+               Kokkos::DefaultExecutionSpace>;
+#else
+using base_execution_space_types = std::tuple<Kokkos::DefaultHostExecutionSpace,
+                                              Kokkos::DefaultExecutionSpace>;
+#endif
+
+using base_int_types    = std::tuple<int, std::size_t>;
+using base_layout_types = std::tuple<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
+
+using test_types =
+    tuple_to_types_t<cartesian_product_t<base_execution_space_types,
+                                         base_int_types, base_layout_types>>;
+
+template <typename T>
+struct TestGetMDPolicy : public ::testing::Test {
+  using execution_space_type = typename std::tuple_element_t<0, T>;
+  using index_type           = typename std::tuple_element_t<1, T>;
+  using layout_type          = typename std::tuple_element_t<2, T>;
+};
+
+template <typename ExecutionSpace, typename IndexType, typename LayoutType,
+          std::size_t DIM>
+void test_get_mdpolicy() {
+  using data_type    = KokkosFFT::Impl::add_pointer_n_t<double, DIM>;
+  using ViewType     = Kokkos::View<data_type, LayoutType, ExecutionSpace>;
+  using extents_type = std::array<std::size_t, DIM>;
+
+  extents_type extents{};
+  for (std::size_t i = 0; i < extents.size(); i++) {
+    extents.at(i) = i % 2 == 0 ? 3 : 5;
+  }
+  auto layout = KokkosFFT::Impl::create_layout<LayoutType>(extents);
+
+  ExecutionSpace exec;
+  ViewType x("x", layout);
+  if constexpr (DIM == 1) {
+    // Range Policy
+    using range_policy_type =
+        Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>;
+    auto policy = KokkosFFT::Impl::get_mdpolicy<IndexType>(exec, x);
+    testing::StaticAssertTypeEq<decltype(policy), range_policy_type>();
+    ASSERT_EQ(policy.space(), exec);
+    ASSERT_EQ(policy.begin(), 0);
+    ASSERT_EQ(policy.end(), x.extent(0));
+  } else {
+    // MDRange policy
+    constexpr std::size_t rank_truncated = std::min(DIM, std::size_t(6));
+    static const Kokkos::Iterate outer_iteration_pattern =
+        KokkosFFT::Impl::layout_iterate_type_selector<
+            LayoutType>::outer_iteration_pattern;
+    static const Kokkos::Iterate inner_iteration_pattern =
+        KokkosFFT::Impl::layout_iterate_type_selector<
+            LayoutType>::inner_iteration_pattern;
+    using iterate_type = Kokkos::Rank<rank_truncated, outer_iteration_pattern,
+                                      inner_iteration_pattern>;
+    using mdrange_policy_type =
+        Kokkos::MDRangePolicy<ExecutionSpace, iterate_type,
+                              Kokkos::IndexType<IndexType>>;
+
+    using point_type = typename mdrange_policy_type::point_type;
+    auto policy      = KokkosFFT::Impl::get_mdpolicy<IndexType>(exec, x);
+    testing::StaticAssertTypeEq<decltype(policy), mdrange_policy_type>();
+
+    point_type ref_lower{}, ref_upper{};
+    for (std::size_t i = 0; i < rank_truncated; ++i) {
+      ref_lower[i] = 0;
+      ref_upper[i] = x.extent(i);
+    }
+
+    ASSERT_EQ(policy.space(), exec);
+    ASSERT_EQ(policy.m_lower, ref_lower);
+    ASSERT_EQ(policy.m_upper, ref_upper);
+  }
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestGetMDPolicy, test_types);
+
+// Test create policy for 1D
+TYPED_TEST(TestGetMDPolicy, Range1D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using index_type           = typename TestFixture::index_type;
+  using layout_type          = typename TestFixture::layout_type;
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 1>();
+}
+
+// Test create policy for 2D-8D
+TYPED_TEST(TestGetMDPolicy, Range2Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using index_type           = typename TestFixture::index_type;
+  using layout_type          = typename TestFixture::layout_type;
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 2>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 3>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 4>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 5>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 6>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 7>();
+  test_get_mdpolicy<execution_space_type, index_type, layout_type, 8>();
+}


### PR DESCRIPTION
This PR aims to extract a helper function to create a Range/MDRange policy for multidimensional operations.

- [x] Introduce a new header `KokkosFFT_MDOperations.hpp`
- [x] Introduce `get_mdpolicy` function with tests
- [x] Use `get_mdpolicy` in `Transpose` and `Roll` struct