### PR TITLE
Rename KokkosFFT_transpose.hpp to KokkosFFT_Transpose.hpp

### DIFF
--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -5,8 +5,12 @@
 #ifndef KOKKOSFFT_TRANSPOSE_HPP
 #define KOKKOSFFT_TRANSPOSE_HPP
 
+#include <array>
+#include <limits>
 #include <numeric>
 #include <tuple>
+#include <type_traits>
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Padding.hpp"
@@ -19,6 +23,23 @@ struct BoundsCheck {
   struct On {};
   struct Off {};
 };
+
+/// \brief Check if transpose is needed or not
+/// If a map is contiguous and in ascending order (e.g. {0, 1, 2}),
+/// we do not need transpose
+/// \tparam IndexType The integer type used for map
+/// \tparam DIM The dimensionality of the axes
+///
+/// \param[in] map The map used for permutation
+/// \return true if transpose is needed, false otherwise
+template <typename IndexType, std::size_t DIM>
+bool is_transpose_needed(const std::array<IndexType, DIM>& map) {
+  static_assert(std::is_integral_v<IndexType>,
+                "is_transpose_needed: IndexType must be an integral type.");
+  std::array<IndexType, DIM> contiguous_map;
+  std::iota(contiguous_map.begin(), contiguous_map.end(), 0);
+  return map != contiguous_map;
+}
 
 /// \brief Transpose functor for out-of-place transpose operations.
 /// This struct implements a functor that applies a transpose on a Kokkos view.
@@ -94,18 +115,14 @@ struct Transpose {
         IndexType src_idx[], std::index_sequence<Is...>) const {
       if constexpr (std::is_same_v<ArgBoundsCheck, BoundsCheck::On>) {
         // Bounds check
-        bool in_bounds = true;
         for (std::size_t i = 0; i < InViewType::rank(); ++i) {
-          if (src_idx[m_map[i]] >= IndexType(m_out.extent(i)))
-            in_bounds = false;
+          if (src_idx[m_map[i]] >= IndexType(m_out.extent(i))) {
+            // Quick return for out-of-bounds
+            return;
+          }
         }
-
-        if (in_bounds) {
-          m_out(src_idx[m_map[Is]]...) = m_in(src_idx[Is]...);
-        }
-      } else {
-        m_out(src_idx[m_map[Is]]...) = m_in(src_idx[Is]...);
       }
+      m_out(src_idx[m_map[Is]]...) = m_in(src_idx[Is]...);
     }
   };
 };

--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -8,7 +8,7 @@
 #include <array>
 #include <limits>
 #include <numeric>
-#include <tuple>
+#include <utility>
 #include <type_traits>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_common_types.hpp"

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -147,22 +147,6 @@ bool are_valid_axes(const ViewType& /*view*/,
   return is_valid;
 }
 
-/// \brief Check if transpose is needed or not
-/// If a map is contiguous and in ascending order (e.g. {0, 1, 2}),
-/// we do not need transpose
-/// \tparam IndexType The integer type used for map
-/// \tparam DIM The dimensionality of the axes
-///
-/// \param[in] map The map used for permutation
-template <typename IndexType, std::size_t DIM>
-bool is_transpose_needed(const std::array<IndexType, DIM>& map) {
-  static_assert(std::is_integral_v<IndexType>,
-                "is_transpose_needed: IndexType must be an integral type.");
-  std::array<IndexType, DIM> contiguous_map;
-  std::iota(contiguous_map.begin(), contiguous_map.end(), 0);
-  return map != contiguous_map;
-}
-
 template <typename ContainerType, typename ValueType>
 std::size_t get_index(const ContainerType& values, const ValueType value) {
   using value_type = KokkosFFT::Impl::base_container_value_type<ContainerType>;

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -507,30 +507,6 @@ void test_convert_negative_axes_4d() {
   }
 }
 
-template <typename IndexType>
-void test_is_transpose_needed() {
-  std::array<IndexType, 1> map1D = {0};
-  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map1D));
-
-  std::array<IndexType, 2> map2D = {0, 1}, map2D_axis0 = {1, 0};
-  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map2D));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map2D_axis0));
-
-  std::array<IndexType, 3> map3D     = {0, 1, 2};
-  std::array<IndexType, 3> map3D_021 = {0, 2, 1};
-  std::array<IndexType, 3> map3D_102 = {1, 0, 2};
-  std::array<IndexType, 3> map3D_120 = {1, 2, 0};
-  std::array<IndexType, 3> map3D_201 = {2, 0, 1};
-  std::array<IndexType, 3> map3D_210 = {2, 1, 0};
-
-  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map3D));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_021));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_102));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_120));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_201));
-  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_210));
-}
-
 template <typename ContainerType>
 void test_is_found() {
   using IntType   = KokkosFFT::Impl::base_container_value_type<ContainerType>;
@@ -997,11 +973,6 @@ TYPED_TEST(TestConvertNegativeAxes, 3DView) {
 TYPED_TEST(TestConvertNegativeAxes, 4DView) {
   using value_type = typename TestFixture::value_type;
   test_convert_negative_axes_4d<value_type>();
-}
-
-TYPED_TEST(ContainerTypes, is_transpose_needed) {
-  using value_type = typename TestFixture::value_type;
-  test_is_transpose_needed<value_type>();
 }
 
 TYPED_TEST(ContainerTypes, is_found_from_vector) {

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#include <algorithm>
-#include <random>
+#include <utility>
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
+#include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Mapping.hpp"
 #include "KokkosFFT_Transpose.hpp"
 #include "Test_Utils.hpp"

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
 #include "KokkosFFT_Mapping.hpp"
-#include "KokkosFFT_transpose.hpp"
+#include "KokkosFFT_Transpose.hpp"
 #include "Test_Utils.hpp"
 
 namespace {
@@ -15,6 +15,10 @@ using execution_space = Kokkos::DefaultExecutionSpace;
 
 template <std::size_t DIM>
 using axes_type = std::array<int, DIM>;
+
+// Int like types
+using int_types = ::testing::Types<int, std::size_t>;
+
 using layout_types =
     ::testing::Types<std::pair<Kokkos::LayoutLeft, Kokkos::LayoutLeft>,
                      std::pair<Kokkos::LayoutLeft, Kokkos::LayoutRight>,
@@ -22,6 +26,11 @@ using layout_types =
                      std::pair<Kokkos::LayoutRight, Kokkos::LayoutRight>>;
 
 // Basically the same fixtures, used for labeling tests
+template <typename T>
+struct TestIsTransposeNeeded : public ::testing::Test {
+  using value_type = T;
+};
+
 template <typename T>
 struct TestTranspose1D : public ::testing::Test {
   using layout_type1 = typename T::first_type;
@@ -92,6 +101,27 @@ void make_transposed(const ViewType1& x, const ViewType2& xT,
     }
   }
   Kokkos::deep_copy(xT, h_xT);
+}
+
+template <typename IndexType>
+void test_is_transpose_needed() {
+  std::array<IndexType, 1> map1D{0};
+  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map1D));
+
+  std::array<IndexType, 2> map2D{0, 1}, map2D_axis0{1, 0};
+  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map2D));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map2D_axis0));
+
+  std::array<IndexType, 3> map3D{0, 1, 2}, map3D_021{0, 2, 1},
+      map3D_102{1, 0, 2}, map3D_120{1, 2, 0}, map3D_201{2, 0, 1},
+      map3D_210{2, 1, 0};
+
+  EXPECT_FALSE(KokkosFFT::Impl::is_transpose_needed(map3D));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_021));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_102));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_120));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_201));
+  EXPECT_TRUE(KokkosFFT::Impl::is_transpose_needed(map3D_210));
 }
 
 // Tests for transpose
@@ -1252,9 +1282,16 @@ void test_transpose_3d_8dview(bool bounds_check) {
 
 }  // namespace
 
+TYPED_TEST_SUITE(TestIsTransposeNeeded, int_types);
+
 TYPED_TEST_SUITE(TestTranspose1D, layout_types);
 TYPED_TEST_SUITE(TestTranspose2D, layout_types);
 TYPED_TEST_SUITE(TestTranspose3D, layout_types);
+
+TYPED_TEST(TestIsTransposeNeeded, is_transpose_needed) {
+  using value_type = typename TestFixture::value_type;
+  test_is_transpose_needed<value_type>();
+}
 
 TYPED_TEST(TestTranspose1D, 1DView) {
   using layout_type1 = typename TestFixture::layout_type1;

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -14,7 +14,7 @@
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_transpose.hpp"
+#include "KokkosFFT_Transpose.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"


### PR DESCRIPTION
- [x] Rename header from `KokkosFFT_transpose.hpp` to `KokkosFFT_Transpose.hpp`
- [x] Move `is_transpose_needed` from `KokkosFFT_utils.hpp` to `KokkosFFT_Transpose.hpp`
- [x] Fix: missing includes of `KokkosFFT_Transpose.hpp`
- [x] Quick return when out-of-bound access happens