### PR TITLE
Add md operator helper

### DIFF
--- a/common/src/KokkosFFT_MDOperations.hpp
+++ b/common/src/KokkosFFT_MDOperations.hpp
@@ -56,8 +56,9 @@ auto get_mdpolicy(const ExecutionSpace& space, const ViewType& x) {
 /// on each element of the view.
 ///
 /// \tparam ViewType The type of the Kokkos view on which the unary operator is
-/// applied. \tparam UnaryOperatorType The type of the unary operator to be
-/// applied on each element of the view.
+/// applied.
+/// \tparam UnaryOperatorType The type of the unary operator to be applied on
+/// each element of the view.
 template <typename ViewType, typename UnaryOperatorType>
 struct MDUnaryOp {
  private:
@@ -93,7 +94,8 @@ struct MDUnaryOp {
 /// \brief A helper function to apply a unary operator on each element of the
 /// view with Range/MDRangePolicy based on the rank of the view. For 1D views, a
 /// RangePolicy is used, while for higher-dimensional views, an MDRangePolicy is
-/// used. \tparam IndexType The type of the index used in the Kokkos policies.
+/// used.
+/// \tparam IndexType The type of the index used in the Kokkos policies.
 /// \tparam ExecutionSpace The type of the Kokkos execution space.
 /// \tparam ViewType The type of the Kokkos view.
 /// \tparam UnaryOperatorType The type of the unary operator.

--- a/common/src/KokkosFFT_MDOperations.hpp
+++ b/common/src/KokkosFFT_MDOperations.hpp
@@ -51,6 +51,64 @@ auto get_mdpolicy(const ExecutionSpace& space, const ViewType& x) {
     return mdrange_policy_type(space, begins, ends);
   }
 }
+
+/// \brief A helper functor for md_unary_operation that applies a unary operator
+/// on each element of the view.
+///
+/// \tparam ViewType The type of the Kokkos view on which the unary operator is
+/// applied. \tparam UnaryOperatorType The type of the unary operator to be
+/// applied on each element of the view.
+template <typename ViewType, typename UnaryOperatorType>
+struct MDUnaryOp {
+ private:
+  const ViewType m_x;
+  const UnaryOperatorType m_op;
+
+ public:
+  /// \brief Constructor for the MDUnaryOp functor.
+  /// \param[in] x The Kokkos view on which the unary operator will be applied.
+  /// \param[in] op The unary operator to be applied on each element of the
+  /// view.
+  MDUnaryOp(const ViewType& x, const UnaryOperatorType& op)
+      : m_x(x), m_op(op) {}
+
+  template <typename... IndicesType>
+  KOKKOS_INLINE_FUNCTION void operator()(const IndicesType... indices) const {
+    if constexpr (ViewType::rank() <= 6) {
+      m_x(indices...) = m_op(m_x(indices...));
+    } else if constexpr (ViewType::rank() == 7) {
+      for (std::size_t i6 = 0; i6 < m_x.extent(6); i6++) {
+        m_x(indices..., i6) = m_op(m_x(indices..., i6));
+      }
+    } else if constexpr (ViewType::rank() == 8) {
+      for (std::size_t i6 = 0; i6 < m_x.extent(6); i6++) {
+        for (std::size_t i7 = 0; i7 < m_x.extent(7); i7++) {
+          m_x(indices..., i6, i7) = m_op(m_x(indices..., i6, i7));
+        }
+      }
+    }
+  }
+};
+
+/// \brief A helper function to apply a unary operator on each element of the
+/// view with Range/MDRangePolicy based on the rank of the view. For 1D views, a
+/// RangePolicy is used, while for higher-dimensional views, an MDRangePolicy is
+/// used. \tparam IndexType The type of the index used in the Kokkos policies.
+/// \tparam ExecutionSpace The type of the Kokkos execution space.
+/// \tparam ViewType The type of the Kokkos view.
+/// \tparam UnaryOperatorType The type of the unary operator.
+/// \param[in] label The label for the Kokkos parallel operation.
+/// \param[in] exec The Kokkos execution space.
+/// \param[in] x The Kokkos view on which the unary operator will be applied.
+/// \param[in] op The unary operator to be applied on each element of the view.
+template <typename IndexType, typename ExecutionSpace, typename ViewType,
+          typename UnaryOperatorType>
+void md_unary_operation(const std::string& label, const ExecutionSpace& exec,
+                        const ViewType& x, UnaryOperatorType op) {
+  const auto policy = get_mdpolicy<IndexType>(exec, x);
+  Kokkos::parallel_for(label, policy, MDUnaryOp(x, op));
+}
+
 }  // namespace Impl
 }  // namespace KokkosFFT
 

--- a/common/src/KokkosFFT_Normalization.hpp
+++ b/common/src/KokkosFFT_Normalization.hpp
@@ -9,8 +9,11 @@
 #include <cmath>
 #include <numeric>
 #include <tuple>
+#include <limits>
 #include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_MDOperations.hpp"
+#include "KokkosFFT_UnaryOps.hpp"
 
 namespace KokkosFFT {
 namespace Impl {
@@ -24,16 +27,30 @@ namespace Impl {
 /// \param[in,out] inout Input/output view to be normalized
 /// \param[in] coef Normalization coefficient
 template <typename ExecutionSpace, typename ViewType, typename T>
-void normalize_impl(const ExecutionSpace& exec_space, ViewType& inout,
+void normalize_impl(const ExecutionSpace& exec_space, const ViewType& inout,
                     const T coef) {
-  std::size_t size = inout.size();
-  auto* data       = inout.data();
+  using LayoutType = typename ViewType::array_layout;
 
-  Kokkos::parallel_for(
-      "KokkosFFT::normalize",
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<std::size_t>>(
-          exec_space, 0, size),
-      KOKKOS_LAMBDA(std::size_t i) { data[i] *= coef; });
+  if constexpr (std::is_same_v<LayoutType, Kokkos::LayoutLeft> ||
+                std::is_same_v<LayoutType, Kokkos::LayoutRight>) {
+    std::size_t size = inout.size();
+    auto* data       = inout.data();
+
+    Kokkos::parallel_for(
+        "KokkosFFT::normalize",
+        Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<std::size_t>>(
+            exec_space, 0, size),
+        KOKKOS_LAMBDA(std::size_t i) { data[i] *= coef; });
+  } else {
+    Multiply multiply(coef);
+    if (inout.span() >= std::size_t(std::numeric_limits<int>::max())) {
+      md_unary_operation<int64_t>("KokkosFFT::normalize", exec_space, inout,
+                                  multiply);
+    } else {
+      md_unary_operation<int>("KokkosFFT::normalize", exec_space, inout,
+                              multiply);
+    }
+  }
 }
 
 /// \brief Internal function to compute the normalization coefficient 1/N

--- a/common/src/KokkosFFT_UnaryOps.hpp
+++ b/common/src/KokkosFFT_UnaryOps.hpp
@@ -21,7 +21,11 @@ struct Conjugate {
   /// input value unchanged.
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto operator()(const T& x) const {
-    return is_complex_v<T> ? Kokkos::conj(x) : x;
+    if constexpr (is_complex_v<T>) {
+      return Kokkos::conj(x);
+    } else {
+      return x;
+    }
   }
 };
 

--- a/common/src/KokkosFFT_UnaryOps.hpp
+++ b/common/src/KokkosFFT_UnaryOps.hpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#ifndef KOKKOSFFT_UNARYOPS_HPP
+#define KOKKOSFFT_UNARYOPS_HPP
+
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Traits.hpp"
+
+namespace KokkosFFT {
+namespace Impl {
+
+/// \brief Functor to compute the conjugate of a complex number.
+struct Conjugate {
+  /// \brief Applies the conjugate operation to the input value if it is
+  /// complex, otherwise returns the input value unchanged. \tparam T The type
+  /// of the input value. \param[in] x The input value. \return The conjugate of
+  /// the input value if it is complex, otherwise the input value unchanged.
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto operator()(const T& x) const {
+    return is_complex_v<T> ? Kokkos::conj(x) : x;
+  }
+};
+
+/// \brief Functor to add a scalar to each element of a view.
+/// \tparam ScalarType1 The type of the scalar to be added.
+template <typename ScalarType1>
+struct Add {
+  static_assert(is_admissible_value_type_v<ScalarType1>,
+                "Add: ScalarType1 must be an admissible value type.");
+  ScalarType1 m_scalar;
+
+  /// \brief Constructor for the Add functor.
+  /// \param[in] scalar The scalar value to be added to each element of the view
+  Add(const ScalarType1& scalar) : m_scalar(scalar) {}
+
+  /// \brief Applies the addition operation to the input value.
+  /// \tparam ScalarType2 The type of the input value.
+  /// \param[in] x The input value.
+  /// \return The result of adding the scalar to the input value.
+  template <typename ScalarType2>
+  KOKKOS_INLINE_FUNCTION auto operator()(const ScalarType2& x) const {
+    static_assert(is_admissible_value_type_v<ScalarType2>,
+                  "Add: ScalarType2 must be an admissible value type.");
+    return x + m_scalar;
+  }
+};
+
+/// \brief Functor to subtract a scalar from each element of a view.
+/// \tparam ScalarType1 The type of the scalar to be subtracted.
+template <typename ScalarType1>
+struct Subtract {
+  static_assert(is_admissible_value_type_v<ScalarType1>,
+                "Subtract: ScalarType1 must be an admissible value type.");
+  ScalarType1 m_scalar;
+  /// \brief Constructor for the Subtract functor.
+  /// \param[in] scalar The scalar value to be subtracted from each element of
+  /// the view.
+  Subtract(const ScalarType1& scalar) : m_scalar(scalar) {}
+
+  /// \brief Applies the subtraction operation to the input value.
+  /// \tparam ScalarType2 The type of the input value.
+  /// \param[in] x The input value.
+  /// \return The result of subtracting the scalar from the input value.
+  template <typename ScalarType2>
+  KOKKOS_INLINE_FUNCTION auto operator()(const ScalarType2& x) const {
+    static_assert(is_admissible_value_type_v<ScalarType2>,
+                  "Subtract: ScalarType2 must be an admissible value type.");
+    return x - m_scalar;
+  }
+};
+
+/// \brief Functor to multiply each element of a view by a scalar.
+/// \tparam ScalarType1 The type of the scalar to be multiplied.
+template <typename ScalarType1>
+struct Multiply {
+  static_assert(is_admissible_value_type_v<ScalarType1>,
+                "Multiply: ScalarType1 must be an admissible value type.");
+  ScalarType1 m_scalar;
+
+  /// \brief Constructor for the Multiply functor.
+  /// \param[in] scalar The scalar value to be multiplied with each element of
+  /// the view.
+  Multiply(const ScalarType1& scalar) : m_scalar(scalar) {}
+
+  /// \brief Applies the multiplication operation to the input value.
+  /// \tparam ScalarType2 The type of the input value.
+  /// \param[in] x The input value.
+  /// \return The result of multiplying the input value by the scalar.
+  template <typename ScalarType2>
+  KOKKOS_INLINE_FUNCTION auto operator()(const ScalarType2& x) const {
+    static_assert(is_admissible_value_type_v<ScalarType2>,
+                  "Multiply: ScalarType2 must be an admissible value type.");
+    return x * m_scalar;
+  }
+};
+
+/// \brief Functor to divide each element of a view by a scalar.
+/// \tparam ScalarType1 The type of the scalar to be divided.
+template <typename ScalarType1>
+struct Divide {
+  static_assert(is_admissible_value_type_v<ScalarType1>,
+                "Divide: ScalarType1 must be an admissible value type.");
+  ScalarType1 m_scalar;
+
+  /// \brief Constructor for the Divide functor.
+  /// \param[in] scalar The scalar value to divide each element of the view by.
+  Divide(const ScalarType1& scalar) : m_scalar(scalar) {}
+
+  /// \brief Applies the division operation to the input value.
+  /// \tparam ScalarType2 The type of the input value.
+  /// \param[in] x The input value.
+  /// \return The result of dividing the input value by the scalar.
+  template <typename ScalarType2>
+  KOKKOS_INLINE_FUNCTION auto operator()(const ScalarType2& x) const {
+    static_assert(is_admissible_value_type_v<ScalarType2>,
+                  "Divide: ScalarType2 must be an admissible value type.");
+    return x / m_scalar;
+  }
+};
+
+}  // namespace Impl
+}  // namespace KokkosFFT
+
+#endif

--- a/common/src/KokkosFFT_UnaryOps.hpp
+++ b/common/src/KokkosFFT_UnaryOps.hpp
@@ -14,9 +14,11 @@ namespace Impl {
 /// \brief Functor to compute the conjugate of a complex number.
 struct Conjugate {
   /// \brief Applies the conjugate operation to the input value if it is
-  /// complex, otherwise returns the input value unchanged. \tparam T The type
-  /// of the input value. \param[in] x The input value. \return The conjugate of
-  /// the input value if it is complex, otherwise the input value unchanged.
+  /// complex, otherwise returns the input value unchanged.
+  /// \tparam T The type of the input value.
+  /// \param[in] x The input value.
+  /// \return The conjugate of the input value if it is complex, otherwise the
+  /// input value unchanged.
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto operator()(const T& x) const {
     return is_complex_v<T> ? Kokkos::conj(x) : x;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -184,30 +184,6 @@ inline std::vector<ElementType> arange(const ElementType start,
   return result;
 }
 
-template <typename ExecutionSpace, typename InViewType, typename OutViewType>
-void conjugate(const ExecutionSpace& exec_space, const InViewType& in,
-               OutViewType& out) {
-  KOKKOSFFT_STATIC_ASSERT_VIEWS_ARE_OPERATABLE(
-      (KokkosFFT::Impl::are_operatable_views_v<ExecutionSpace, InViewType,
-                                               OutViewType>),
-      "conjugate");
-
-  using out_value_type = typename OutViewType::non_const_value_type;
-  static_assert(KokkosFFT::Impl::is_complex_v<out_value_type>,
-                "conjugate: OutViewType must be complex");
-  std::size_t size = in.size();
-  out              = OutViewType("out", in.layout());
-
-  auto* in_data  = in.data();
-  auto* out_data = out.data();
-
-  Kokkos::parallel_for(
-      "KokkosFFT::conjugate",
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<std::size_t>>(
-          exec_space, 0, size),
-      KOKKOS_LAMBDA(std::size_t i) { out_data[i] = Kokkos::conj(in_data[i]); });
-}
-
 template <typename ViewType>
 auto extract_extents(const ViewType& view) {
   static_assert(Kokkos::is_view_v<ViewType>,

--- a/common/unit_test/Test_MDOperations.cpp
+++ b/common/unit_test/Test_MDOperations.cpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_MDOperations.hpp"
+#include "KokkosFFT_UnaryOps.hpp"
 #include "Test_Utils.hpp"
 
 namespace {
@@ -25,11 +26,23 @@ using test_types =
     tuple_to_types_t<cartesian_product_t<base_execution_space_types,
                                          base_int_types, base_layout_types>>;
 
+using test_ops_types = tuple_to_types_t<
+    cartesian_product_t<base_execution_space_types, base_layout_types>>;
+
 template <typename T>
 struct TestGetMDPolicy : public ::testing::Test {
   using execution_space_type = typename std::tuple_element_t<0, T>;
   using index_type           = typename std::tuple_element_t<1, T>;
   using layout_type          = typename std::tuple_element_t<2, T>;
+};
+
+template <typename T>
+struct TestMDUnaryOperation : public ::testing::Test {
+  using execution_space_type = typename std::tuple_element_t<0, T>;
+  using layout_type          = typename std::tuple_element_t<1, T>;
+
+  const double m_init_scalar = 1.0;
+  const double m_scalar      = 2.0;
 };
 
 template <typename ExecutionSpace, typename IndexType, typename LayoutType,
@@ -87,23 +100,41 @@ void test_get_mdpolicy() {
   }
 }
 
+template <typename ExecutionSpace, typename LayoutType, std::size_t DIM,
+          typename T, typename UnaryOpType>
+void test_md_unary_operation(UnaryOpType op, T init_scalar, T ref_scalar) {
+  using data_type    = KokkosFFT::Impl::add_pointer_n_t<T, DIM>;
+  using ViewType     = Kokkos::View<data_type, LayoutType, ExecutionSpace>;
+  using extents_type = std::array<std::size_t, DIM>;
+
+  extents_type extents{};
+  for (std::size_t i = 0; i < extents.size(); i++) {
+    extents.at(i) = i % 2 == 0 ? 3 : 5;
+  }
+  auto layout = KokkosFFT::Impl::create_layout<LayoutType>(extents);
+
+  ExecutionSpace exec;
+  ViewType x("x", layout), x_ref("x_ref", layout);
+  Kokkos::deep_copy(exec, x, init_scalar);
+  Kokkos::deep_copy(exec, x_ref, ref_scalar);
+
+  KokkosFFT::Impl::md_unary_operation<int>("TestMDUnaryOperation", exec, x, op);
+
+  EXPECT_TRUE(allclose(exec, x, x_ref, 1.e-5, 1.e-12));
+  exec.fence();
+}
+
 }  // namespace
 
 TYPED_TEST_SUITE(TestGetMDPolicy, test_types);
+TYPED_TEST_SUITE(TestMDUnaryOperation, test_ops_types);
 
-// Test create policy for 1D
-TYPED_TEST(TestGetMDPolicy, Range1D) {
+// Test create policy for 1D-8D
+TYPED_TEST(TestGetMDPolicy, Range1Dto8D) {
   using execution_space_type = typename TestFixture::execution_space_type;
   using index_type           = typename TestFixture::index_type;
   using layout_type          = typename TestFixture::layout_type;
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 1>();
-}
-
-// Test create policy for 2D-8D
-TYPED_TEST(TestGetMDPolicy, Range2Dto8D) {
-  using execution_space_type = typename TestFixture::execution_space_type;
-  using index_type           = typename TestFixture::index_type;
-  using layout_type          = typename TestFixture::layout_type;
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 2>();
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 3>();
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 4>();
@@ -111,4 +142,139 @@ TYPED_TEST(TestGetMDPolicy, Range2Dto8D) {
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 6>();
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 7>();
   test_get_mdpolicy<execution_space_type, index_type, layout_type, 8>();
+}
+
+// Test conj operation for 1D-8D
+TYPED_TEST(TestMDUnaryOperation, Conj1Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using layout_type          = typename TestFixture::layout_type;
+  using complex_type         = Kokkos::complex<double>;
+  const complex_type init_scalar(this->m_init_scalar, this->m_init_scalar);
+  const complex_type ref_scalar(this->m_init_scalar, -this->m_init_scalar);
+
+  KokkosFFT::Impl::Conjugate conj_op;
+  test_md_unary_operation<execution_space_type, layout_type, 1>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 2>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 3>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 4>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 5>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 6>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 7>(
+      conj_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 8>(
+      conj_op, init_scalar, ref_scalar);
+}
+
+// Test add operation for 1D-8D
+TYPED_TEST(TestMDUnaryOperation, Add1Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using layout_type          = typename TestFixture::layout_type;
+  const double init_scalar   = this->m_init_scalar;
+  const double scalar        = this->m_scalar;
+  const double ref_scalar    = init_scalar + scalar;
+
+  KokkosFFT::Impl::Add add_op(scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 1>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 2>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 3>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 4>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 5>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 6>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 7>(
+      add_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 8>(
+      add_op, init_scalar, ref_scalar);
+}
+
+// Test subtract operation for 1D-8D
+TYPED_TEST(TestMDUnaryOperation, Subtract1Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using layout_type          = typename TestFixture::layout_type;
+  const double init_scalar   = this->m_init_scalar;
+  const double scalar        = this->m_scalar;
+  const double ref_scalar    = init_scalar - scalar;
+
+  KokkosFFT::Impl::Subtract sub_op(scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 1>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 2>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 3>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 4>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 5>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 6>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 7>(
+      sub_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 8>(
+      sub_op, init_scalar, ref_scalar);
+}
+
+// Test multiply operation for 1D-8D
+TYPED_TEST(TestMDUnaryOperation, Multiply1Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using layout_type          = typename TestFixture::layout_type;
+  const double init_scalar   = this->m_init_scalar;
+  const double scalar        = this->m_scalar;
+  const double ref_scalar    = init_scalar * scalar;
+
+  KokkosFFT::Impl::Multiply mul_op(scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 1>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 2>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 3>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 4>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 5>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 6>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 7>(
+      mul_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 8>(
+      mul_op, init_scalar, ref_scalar);
+}
+
+// Test divide operation for 1D-8D
+TYPED_TEST(TestMDUnaryOperation, Divide1Dto8D) {
+  using execution_space_type = typename TestFixture::execution_space_type;
+  using layout_type          = typename TestFixture::layout_type;
+  const double init_scalar   = this->m_init_scalar;
+  const double scalar        = this->m_scalar;
+  const double ref_scalar    = init_scalar / scalar;
+
+  KokkosFFT::Impl::Divide div_op(scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 1>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 2>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 3>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 4>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 5>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 6>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 7>(
+      div_op, init_scalar, ref_scalar);
+  test_md_unary_operation<execution_space_type, layout_type, 8>(
+      div_op, init_scalar, ref_scalar);
 }

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -254,11 +254,11 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
     auto extents     = KokkosFFT::Impl::extract_extents(in);
     ManageableComplexInViewType cin(
         "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
-    Kokkos::deep_copy(cin, in);
+    Kokkos::deep_copy(exec_space, cin, in);
     irfft(exec_space, cin, out, new_norm, axis, n);
   } else {
     InViewType in_conj("in_conj", in.layout());
-    Kokkos::deep_copy(in_conj, in);
+    Kokkos::deep_copy(exec_space, in_conj, in);
     if (in_conj.span() >= std::size_t(std::numeric_limits<int>::max())) {
       KokkosFFT::Impl::md_unary_operation<int64_t>(
           "KokkosFFT::conjugate", exec_space, in_conj,

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -5,6 +5,7 @@
 #ifndef KOKKOSFFT_TRANSFORM_HPP
 #define KOKKOSFFT_TRANSFORM_HPP
 
+#include <limits>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_Traits.hpp"
@@ -256,8 +257,17 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
     Kokkos::deep_copy(cin, in);
     irfft(exec_space, cin, out, new_norm, axis, n);
   } else {
-    InViewType in_conj;
-    KokkosFFT::Impl::conjugate(exec_space, in, in_conj);
+    InViewType in_conj("in_conj", in.layout());
+    Kokkos::deep_copy(in_conj, in);
+    if (in_conj.span() >= std::size_t(std::numeric_limits<int>::max())) {
+      KokkosFFT::Impl::md_unary_operation<int64_t>(
+          "KokkosFFT::conjugate", exec_space, in_conj,
+          KokkosFFT::Impl::Conjugate());
+    } else {
+      KokkosFFT::Impl::md_unary_operation<int>("KokkosFFT::conjugate",
+                                               exec_space, in_conj,
+                                               KokkosFFT::Impl::Conjugate());
+    }
     irfft(exec_space, in_conj, out, new_norm, axis, n);
   }
 }
@@ -298,10 +308,14 @@ void ihfft(const ExecutionSpace& exec_space, const InViewType& in,
   KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(in, axis_type<1>({axis})),
                      "axes are invalid for in/out views");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
-  OutViewType out_conj;
   rfft(exec_space, in, out, new_norm, axis, n);
-  KokkosFFT::Impl::conjugate(exec_space, out, out_conj);
-  Kokkos::deep_copy(exec_space, out, out_conj);
+  if (out.span() >= std::size_t(std::numeric_limits<int>::max())) {
+    KokkosFFT::Impl::md_unary_operation<int64_t>(
+        "KokkosFFT::conjugate", exec_space, out, KokkosFFT::Impl::Conjugate());
+  } else {
+    KokkosFFT::Impl::md_unary_operation<int>("KokkosFFT::conjugate", exec_space,
+                                             out, KokkosFFT::Impl::Conjugate());
+  }
 }
 
 // 2D FFT


### PR DESCRIPTION
This PR aims at implementing a broadcasting operator to work on a `View`.
It applies operator `op` to all the elements of `x`

```C++
x = op(x); 
```

- [x] Add a MD operator wrapper with `MDRange` to do `x = op(x)`
- [x] Use the operator in `normalize_impl`, `hfft` and `ihfft`
- [x] Remove badly implemented `conjugate` helper used in `hfft` and `ihfft`