### PR TITLE
Rename KokkosFFT_common_types.hpp

### DIFF
--- a/common/src/KokkosFFT_Common_Types.hpp
+++ b/common/src/KokkosFFT_Common_Types.hpp
@@ -5,6 +5,8 @@
 #ifndef KOKKOSFFT_COMMON_TYPES_HPP
 #define KOKKOSFFT_COMMON_TYPES_HPP
 
+#include <array>
+
 namespace KokkosFFT {
 //! Type to specify transform axis
 template <std::size_t DIM>

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -16,7 +16,6 @@
 #include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
-
 namespace KokkosFFT {
 namespace Impl {
 /// \brief Compute the extent after FFT

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -9,11 +9,13 @@
 #include <tuple>
 #include <algorithm>
 #include <numeric>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_Traits.hpp"
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Mapping.hpp"
+#include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_utils.hpp"
+
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -6,10 +6,10 @@
 #define KOKKOSFFT_HELPERS_HPP
 
 #include <Kokkos_Core.hpp>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_Mapping.hpp
+++ b/common/src/KokkosFFT_Mapping.hpp
@@ -8,8 +8,9 @@
 #include <vector>
 #include <tuple>
 #include <numeric>
-#include "KokkosFFT_common_types.hpp"
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_Normalization.hpp
+++ b/common/src/KokkosFFT_Normalization.hpp
@@ -10,9 +10,10 @@
 #include <numeric>
 #include <tuple>
 #include <limits>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_Traits.hpp"
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_MDOperations.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_UnaryOps.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_Padding.hpp
+++ b/common/src/KokkosFFT_Padding.hpp
@@ -10,8 +10,8 @@
 #include <utility>
 #include <tuple>
 #include <Kokkos_Core.hpp>
-#include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Traits.hpp"
 
 namespace KokkosFFT {

--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -11,11 +11,11 @@
 #include <utility>
 #include <type_traits>
 #include <Kokkos_Core.hpp>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_utils.hpp"
-#include "KokkosFFT_Padding.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
+#include "KokkosFFT_Padding.hpp"
+#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -5,16 +5,16 @@
 #ifndef KOKKOSFFT_UTILS_HPP
 #define KOKKOSFFT_UTILS_HPP
 
-#include <Kokkos_Core.hpp>
 #include <vector>
 #include <set>
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>
 #include <limits>
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_common_types.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -4,8 +4,9 @@
 
 #include <utility>
 #include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-#include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Mapping.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Transpose.hpp"

--- a/fft/src/KokkosFFT_Cuda_types.hpp
+++ b/fft/src/KokkosFFT_Cuda_types.hpp
@@ -8,9 +8,9 @@
 #include <cufft.h>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_common_types.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Cuda_asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -8,7 +8,7 @@
 #include <fftw3.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_utils.hpp"
 
 // Check the size of complex type

--- a/fft/src/KokkosFFT_HIP_types.hpp
+++ b/fft/src/KokkosFFT_HIP_types.hpp
@@ -8,7 +8,7 @@
 #include <hipfft/hipfft.h>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_common_types.hpp"
+#include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_HIP_asserts.hpp"
 

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -11,9 +11,9 @@
 #include <rocfft/rocfft.h>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_ROCM_asserts.hpp"
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -13,9 +13,10 @@
 #else
 #include <oneapi/mkl/dfti.hpp>
 #endif
-#include "KokkosFFT_common_types.hpp"
-#include "KokkosFFT_Traits.hpp"
+#include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)


### PR DESCRIPTION
- [x] Rename `KokkosFFT_common_types.hpp` into `KokkosFFT_Common_Types.hpp`
- [x] Include missing headers 