### PR TITLE
Move extract_extents into KokkosFFT_Extents.hpp

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -31,6 +31,23 @@ inline auto extent_after_transform(std::size_t extent, bool is_R2C) {
   return is_R2C ? (extent / 2 + 1) : extent;
 }
 
+/// \brief Return the extents of the input view
+/// \tparam ViewType The type of the input view
+///
+/// \param[in] view The input view
+/// \return The extents of the input view
+template <typename ViewType>
+auto extract_extents(const ViewType& view) {
+  static_assert(Kokkos::is_view_v<ViewType>,
+                "extract_extents: ViewType is not a Kokkos::View.");
+  constexpr std::size_t rank = ViewType::rank();
+  std::array<std::size_t, rank> extents{};
+  for (std::size_t i = 0; i < rank; i++) {
+    extents.at(i) = view.extent(i);
+  }
+  return extents;
+}
+
 /// \brief Return a new shape of the input view based on the
 /// specified input shape and axes.
 ///
@@ -54,18 +71,15 @@ auto get_modified_shape(const InViewType in, const OutViewType /* out */,
 
   shape_type<DIM> zeros{};  // default shape means no crop or pad
   if (shape == zeros) {
-    return KokkosFFT::Impl::extract_extents(in);
+    return extract_extents(in);
   }
 
   // Convert the input axes to be in the range of [0, rank-1]
   constexpr std::size_t rank = InViewType::rank();
   auto non_negative_axes     = convert_negative_axes(axes, rank);
 
-  using full_shape_type = shape_type<rank>;
-  full_shape_type modified_shape;
-  for (std::size_t i = 0; i < rank; i++) {
-    modified_shape.at(i) = in.extent(i);
-  }
+  using full_shape_type          = shape_type<rank>;
+  full_shape_type modified_shape = extract_extents(in);
 
   // Update shapes based on newly given shape
   for (std::size_t i = 0; i < DIM; i++) {

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -7,6 +7,7 @@
 
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_Traits.hpp"

--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -12,7 +12,6 @@
 #include <type_traits>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Common_Types.hpp"
-#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_Padding.hpp"

--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_Padding.hpp"

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -184,18 +184,6 @@ inline std::vector<ElementType> arange(const ElementType start,
   return result;
 }
 
-template <typename ViewType>
-auto extract_extents(const ViewType& view) {
-  static_assert(Kokkos::is_view_v<ViewType>,
-                "extract_extents: ViewType is not a Kokkos::View.");
-  constexpr std::size_t rank = ViewType::rank();
-  std::array<std::size_t, rank> extents;
-  for (std::size_t i = 0; i < rank; i++) {
-    extents.at(i) = view.extent(i);
-  }
-  return extents;
-}
-
 template <typename T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_lvalue(
     std::array<T, N>& a, std::index_sequence<Is...>) {

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -1066,46 +1066,6 @@ TYPED_TEST(ContainerTypes, array_to_vector) {
   }
 }
 
-TEST(ExtractExtents, 1Dto8D) {
-  using View1Dtype = Kokkos::View<double*, execution_space>;
-  using View2Dtype = Kokkos::View<double**, execution_space>;
-  using View3Dtype = Kokkos::View<double***, execution_space>;
-  using View4Dtype = Kokkos::View<double****, execution_space>;
-  using View5Dtype = Kokkos::View<double*****, execution_space>;
-  using View6Dtype = Kokkos::View<double******, execution_space>;
-  using View7Dtype = Kokkos::View<double*******, execution_space>;
-  using View8Dtype = Kokkos::View<double********, execution_space>;
-
-  std::size_t n1 = 1, n2 = 1, n3 = 2, n4 = 3, n5 = 5, n6 = 8, n7 = 13, n8 = 21;
-
-  std::array<std::size_t, 1> ref_extents1D = {n1};
-  std::array<std::size_t, 2> ref_extents2D = {n1, n2};
-  std::array<std::size_t, 3> ref_extents3D = {n1, n2, n3};
-  std::array<std::size_t, 4> ref_extents4D = {n1, n2, n3, n4};
-  std::array<std::size_t, 5> ref_extents5D = {n1, n2, n3, n4, n5};
-  std::array<std::size_t, 6> ref_extents6D = {n1, n2, n3, n4, n5, n6};
-  std::array<std::size_t, 7> ref_extents7D = {n1, n2, n3, n4, n5, n6, n7};
-  std::array<std::size_t, 8> ref_extents8D = {n1, n2, n3, n4, n5, n6, n7, n8};
-
-  View1Dtype view1D("view1D", n1);
-  View2Dtype view2D("view2D", n1, n2);
-  View3Dtype view3D("view3D", n1, n2, n3);
-  View4Dtype view4D("view4D", n1, n2, n3, n4);
-  View5Dtype view5D("view5D", n1, n2, n3, n4, n5);
-  View6Dtype view6D("view6D", n1, n2, n3, n4, n5, n6);
-  View7Dtype view7D("view7D", n1, n2, n3, n4, n5, n6, n7);
-  View8Dtype view8D("view8D", n1, n2, n3, n4, n5, n6, n7, n8);
-
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view1D), ref_extents1D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view2D), ref_extents2D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view3D), ref_extents3D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view4D), ref_extents4D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view5D), ref_extents5D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view6D), ref_extents6D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view7D), ref_extents7D);
-  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view8D), ref_extents8D);
-}
-
 TYPED_TEST(TestIndexSequence, make_sequence_3Dto5D) {
   using value_type = typename TestFixture::value_type;
   test_index_sequence<value_type>();

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -202,6 +202,46 @@ void test_padded_extents() {
   }
 }
 
+void test_extract_extents() {
+  using View1Dtype = Kokkos::View<double*, execution_space>;
+  using View2Dtype = Kokkos::View<double**, execution_space>;
+  using View3Dtype = Kokkos::View<double***, execution_space>;
+  using View4Dtype = Kokkos::View<double****, execution_space>;
+  using View5Dtype = Kokkos::View<double*****, execution_space>;
+  using View6Dtype = Kokkos::View<double******, execution_space>;
+  using View7Dtype = Kokkos::View<double*******, execution_space>;
+  using View8Dtype = Kokkos::View<double********, execution_space>;
+
+  std::size_t n1 = 1, n2 = 1, n3 = 2, n4 = 3, n5 = 5, n6 = 8, n7 = 13, n8 = 21;
+
+  std::array<std::size_t, 1> ref_extents1D = {n1};
+  std::array<std::size_t, 2> ref_extents2D = {n1, n2};
+  std::array<std::size_t, 3> ref_extents3D = {n1, n2, n3};
+  std::array<std::size_t, 4> ref_extents4D = {n1, n2, n3, n4};
+  std::array<std::size_t, 5> ref_extents5D = {n1, n2, n3, n4, n5};
+  std::array<std::size_t, 6> ref_extents6D = {n1, n2, n3, n4, n5, n6};
+  std::array<std::size_t, 7> ref_extents7D = {n1, n2, n3, n4, n5, n6, n7};
+  std::array<std::size_t, 8> ref_extents8D = {n1, n2, n3, n4, n5, n6, n7, n8};
+
+  View1Dtype view1D("view1D", n1);
+  View2Dtype view2D("view2D", n1, n2);
+  View3Dtype view3D("view3D", n1, n2, n3);
+  View4Dtype view4D("view4D", n1, n2, n3, n4);
+  View5Dtype view5D("view5D", n1, n2, n3, n4, n5);
+  View6Dtype view6D("view6D", n1, n2, n3, n4, n5, n6);
+  View7Dtype view7D("view7D", n1, n2, n3, n4, n5, n6, n7);
+  View8Dtype view8D("view8D", n1, n2, n3, n4, n5, n6, n7, n8);
+
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view1D), ref_extents1D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view2D), ref_extents2D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view3D), ref_extents3D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view4D), ref_extents4D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view5D), ref_extents5D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view6D), ref_extents6D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view7D), ref_extents7D);
+  EXPECT_EQ(KokkosFFT::Impl::extract_extents(view8D), ref_extents8D);
+}
+
 // Tests for mapped extents
 template <typename ContainerType, typename iType>
 void test_compute_mapped_extents(iType n) {
@@ -1071,6 +1111,9 @@ TYPED_TEST(TestExtents, C2C) {
   using int_type   = typename TestFixture::value_type;
   test_padded_extents<float_type, int_type>();
 }
+
+// Extract extents
+TEST(TestExtractExtents, extract_extents) { test_extract_extents(); }
 
 // Mapped extents
 TYPED_TEST(TestExtents, mapped_extents_of_vector) {

--- a/fft/src/KokkosFFT_DynPlans.hpp
+++ b/fft/src/KokkosFFT_DynPlans.hpp
@@ -14,8 +14,9 @@
 #include <algorithm>
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_default_types.hpp"
-#include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_CUFFT)

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -8,11 +8,13 @@
 #include <limits>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
-#include "KokkosFFT_Traits.hpp"
+
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
-#include "KokkosFFT_utils.hpp"
 #include "KokkosFFT_Plans.hpp"
+#include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 


### PR DESCRIPTION
Move `extract_extents` from KokkosFFT_utils.hpp into KokkosFFT_Extents.hpp.

- [x] Corresponding tests are moved
- [x] Use `extract_extents` in `get_modified_shape`