### PR TITLE
Move compute strides into KokkosFFT_Extents.hpp

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -48,16 +48,16 @@ auto extract_extents(const ViewType& view) {
   return extents;
 }
 
-// \brief Helper to compute strides from extents.
-// The extents are computed from a LayoutRight View.
-// The computed strides can be considered as view strides
-// in the reversed order.
-//
-// Examples:
-// v0 (n0) -> (v0.stride(0)) or (1)
-// v1 (n0, n1) -> (v1.stride(1), v1.stride(0)) or (1, n1)
-// v2 (n0, n1, n2) -> (v2.stride(2), v2.stride(1), v2.stride(0))
-//                 or (1, n2, n2 * n1)
+/// \brief Helper to compute strides from extents.
+/// The extents are computed from a LayoutRight View.
+/// The computed strides can be considered as view strides
+/// in the reversed order.
+///
+/// Examples:
+/// v0 (n0) -> (v0.stride(0)) or (1)
+/// v1 (n0, n1) -> (v1.stride(1), v1.stride(0)) or (1, n1)
+/// v2 (n0, n1, n2) -> (v2.stride(2), v2.stride(1), v2.stride(0))
+///                 or (1, n2, n2 * n1)
 /// \tparam ContainerType The container type, must be either one of std::array
 /// or std::vector
 /// \param[in] extents The extents of the data

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -48,6 +48,43 @@ auto extract_extents(const ViewType& view) {
   return extents;
 }
 
+// \brief Helper to compute strides from extents.
+// The extents are computed from a LayoutRight View.
+// The computed strides can be considered as view strides
+// in the reversed order.
+//
+// Examples:
+// v0 (n0) -> (v0.stride(0)) or (1)
+// v1 (n0, n1) -> (v1.stride(1), v1.stride(0)) or (1, n1)
+// v2 (n0, n1, n2) -> (v2.stride(2), v2.stride(1), v2.stride(0))
+//                 or (1, n2, n2 * n1)
+/// \tparam ContainerType The container type, must be either one of std::array
+/// or std::vector
+/// \param[in] extents The extents of the data
+/// \return strides computed from the input data
+/// \throws runtime_error if any of the extents is less than or equal to 0
+template <typename ContainerType,
+          std::enable_if_t<is_std_vector_v<ContainerType> ||
+                               is_std_array_v<ContainerType>,
+                           std::nullptr_t> = nullptr>
+auto compute_strides(const ContainerType& extents) {
+  using index_type = std::remove_cv_t<
+      std::remove_reference_t<typename ContainerType::value_type>>;
+  static_assert(std::is_integral_v<index_type>,
+                "compute_strides: index_type must be an integral type.");
+  KOKKOSFFT_THROW_IF(std::any_of(extents.begin(), extents.end(),
+                                 [](index_type extent) { return extent <= 0; }),
+                     "extents must be greater than 0");
+  ContainerType strides = extents, reversed_extents = extents;
+  std::reverse(reversed_extents.begin(), reversed_extents.end());
+
+  strides.at(0) = 1;
+  for (std::size_t i = 1; i < reversed_extents.size(); i++) {
+    strides.at(i) = reversed_extents.at(i - 1) * strides.at(i - 1);
+  }
+  return strides;
+}
+
 /// \brief Return a new shape of the input view based on the
 /// specified input shape and axes.
 ///

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -62,7 +62,8 @@ auto extract_extents(const ViewType& view) {
 /// or std::vector
 /// \param[in] extents The extents of the data
 /// \return strides computed from the input data
-/// \throws runtime_error if any of the extents is less than or equal to 0
+/// \throws runtime_error if extents is empty or if any of the extents is less
+/// than or equal to 0
 template <typename ContainerType,
           std::enable_if_t<is_std_vector_v<ContainerType> ||
                                is_std_array_v<ContainerType>,
@@ -72,6 +73,8 @@ auto compute_strides(const ContainerType& extents) {
       std::remove_reference_t<typename ContainerType::value_type>>;
   static_assert(std::is_integral_v<index_type>,
                 "compute_strides: index_type must be an integral type.");
+  KOKKOSFFT_THROW_IF(extents.size() == 0,
+                     "extents must have at least one dimension.");
   KOKKOSFFT_THROW_IF(std::any_of(extents.begin(), extents.end(),
                                  [](index_type extent) { return extent <= 0; }),
                      "extents must be greater than 0");

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -331,42 +331,6 @@ auto convert_base_int_type(const ContainerType& src) {
   }
 }
 
-// \brief Helper to compute strides from extents.
-// The extents are computed from a LayoutRight View.
-// The computed strides can be considered as view strides
-// in the reversed order.
-//
-// Examples:
-// v0 (n0) -> (v0.stride(0)) or (1)
-// v1 (n0, n1) -> (v1.stride(1), v1.stride(0)) or (1, n1)
-// v2 (n0, n1, n2) -> (v2.stride(2), v2.stride(1), v2.stride(0))
-//                 or (1, n2, n2 * n1)
-/// \tparam ContainerType The container type, must be either one of std::array
-/// or std::vector
-/// \param[in] extents The extents of the data
-/// \return strides computed from the input data
-template <typename ContainerType,
-          std::enable_if_t<is_std_vector_v<ContainerType> ||
-                               is_std_array_v<ContainerType>,
-                           std::nullptr_t> = nullptr>
-auto compute_strides(const ContainerType& extents) {
-  using index_type =
-      std::remove_cv_t<std::remove_reference_t<decltype(*extents.begin())>>;
-  static_assert(std::is_integral_v<index_type>,
-                "compute_strides: index_type must be an integral type.");
-  KOKKOSFFT_THROW_IF(
-      total_size(extents) <= 0,
-      "compute_strides: total size of the extents must not be 0");
-  ContainerType strides = extents, reversed_extents = extents;
-  std::reverse(reversed_extents.begin(), reversed_extents.end());
-
-  strides.at(0) = 1;
-  for (std::size_t i = 1; i < reversed_extents.size(); i++) {
-    strides.at(i) = reversed_extents.at(i - 1) * strides.at(i - 1);
-  }
-  return strides;
-}
-
 /// \brief Returns a reversed copy of the input container
 /// \tparam Container The container type, must support begin() and end()
 /// \param[in,out] c The input container

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -597,15 +597,6 @@ void test_is_out_of_range_value_included() {
 }
 
 template <typename ContainerType>
-void test_compute_strides() {
-  ContainerType v0 = {2, 3, 5}, v1 = {1, 3, 0};
-  ContainerType ref_strides0 = {1, 5, 3 * 5};
-
-  EXPECT_EQ(KokkosFFT::Impl::compute_strides(v0), ref_strides0);
-  EXPECT_THROW(KokkosFFT::Impl::compute_strides(v1), std::runtime_error);
-}
-
-template <typename ContainerType>
 void test_reversed() {
   ContainerType v = {2, 3, 5}, v_fixed = {2, 3, 5};
   ContainerType ref_reversed = {5, 3, 2};
@@ -1030,17 +1021,6 @@ TYPED_TEST(ContainerTypes, test_total_size_of_array) {
   using container_type1 = std::array<value_type, 3>;
   using container_type2 = std::array<value_type, 1>;
   test_total_size<container_type0, container_type1, container_type2>();
-}
-
-TYPED_TEST(ContainerTypes, test_compute_strides_of_arrays) {
-  using value_type     = typename TestFixture::value_type;
-  using container_type = std::array<value_type, 3>;
-  test_compute_strides<container_type>();
-}
-
-TYPED_TEST(ContainerTypes, test_compute_strides_of_vectors) {
-  using container_type = typename TestFixture::vector_type;
-  test_compute_strides<container_type>();
 }
 
 TYPED_TEST(ContainerTypes, test_reversed_of_arrays) {

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -67,13 +67,16 @@ void test_extent_after_transform() {
 }
 
 // Tests for compute strides
-template <typename ContainerType>
+template <typename ContainerType, typename EmptyContainterType>
 void test_compute_strides() {
   ContainerType v0 = {2, 3, 5}, v1 = {1, 3, 0};
   ContainerType ref_strides0 = {1, 5, 3 * 5};
 
   EXPECT_EQ(KokkosFFT::Impl::compute_strides(v0), ref_strides0);
   EXPECT_THROW(KokkosFFT::Impl::compute_strides(v1), std::runtime_error);
+
+  EmptyContainterType empty{};
+  EXPECT_THROW(KokkosFFT::Impl::compute_strides(empty), std::runtime_error);
 }
 
 // Tests for padded_extents
@@ -1119,13 +1122,15 @@ TEST(TestGetOutputExtent, C2C) {
 TYPED_TEST(TestStrides, compute_strides_of_arrays) {
   using value_type     = typename TestFixture::value_type;
   using container_type = std::array<value_type, 3>;
-  test_compute_strides<container_type>();
+  using empty_type     = std::array<value_type, 0>;
+  test_compute_strides<container_type, empty_type>();
 }
 
 TYPED_TEST(TestStrides, compute_strides_of_vectors) {
   using value_type     = typename TestFixture::value_type;
   using container_type = std::vector<value_type>;
-  test_compute_strides<container_type>();
+  using empty_type     = std::vector<value_type>;
+  test_compute_strides<container_type, empty_type>();
 }
 
 // Padded extents

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -67,7 +67,7 @@ void test_extent_after_transform() {
 }
 
 // Tests for compute strides
-template <typename ContainerType, typename EmptyContainterType>
+template <typename ContainerType, typename EmptyContainerType>
 void test_compute_strides() {
   ContainerType v0 = {2, 3, 5}, v1 = {1, 3, 0};
   ContainerType ref_strides0 = {1, 5, 3 * 5};
@@ -75,7 +75,7 @@ void test_compute_strides() {
   EXPECT_EQ(KokkosFFT::Impl::compute_strides(v0), ref_strides0);
   EXPECT_THROW(KokkosFFT::Impl::compute_strides(v1), std::runtime_error);
 
-  EmptyContainterType empty{};
+  EmptyContainerType empty{};
   EXPECT_THROW(KokkosFFT::Impl::compute_strides(empty), std::runtime_error);
 }
 

--- a/common/unit_test/Test_Extents.cpp
+++ b/common/unit_test/Test_Extents.cpp
@@ -21,6 +21,11 @@ struct TestExtents : public ::testing::Test {
 };
 
 template <typename T>
+struct TestStrides : public ::testing::Test {
+  using value_type = T;
+};
+
+template <typename T>
 struct TestGetExtents1D : public ::testing::Test {
   using layout_type = T;
 };
@@ -59,6 +64,16 @@ void test_extent_after_transform() {
     EXPECT_EQ(n0h, n0);
     EXPECT_EQ(n1h, n1);
   }
+}
+
+// Tests for compute strides
+template <typename ContainerType>
+void test_compute_strides() {
+  ContainerType v0 = {2, 3, 5}, v1 = {1, 3, 0};
+  ContainerType ref_strides0 = {1, 5, 3 * 5};
+
+  EXPECT_EQ(KokkosFFT::Impl::compute_strides(v0), ref_strides0);
+  EXPECT_THROW(KokkosFFT::Impl::compute_strides(v1), std::runtime_error);
 }
 
 // Tests for padded_extents
@@ -1083,6 +1098,7 @@ void test_extents_2d_view_3d(bool is_static = true) {
 }  // namespace
 
 TYPED_TEST_SUITE(TestExtents, test_int_types);
+TYPED_TEST_SUITE(TestStrides, test_int_types);
 TYPED_TEST_SUITE(TestGetExtents1D, test_types);
 TYPED_TEST_SUITE(TestGetExtents2D, test_types);
 TYPED_TEST_SUITE(TestGetDynExtents1D, test_types);
@@ -1097,6 +1113,19 @@ TEST(TestGetOutputExtent, R2C) {
 TEST(TestGetOutputExtent, C2C) {
   using float_type = Kokkos::complex<double>;
   test_extent_after_transform<float_type>();
+}
+
+// Compute strides
+TYPED_TEST(TestStrides, compute_strides_of_arrays) {
+  using value_type     = typename TestFixture::value_type;
+  using container_type = std::array<value_type, 3>;
+  test_compute_strides<container_type>();
+}
+
+TYPED_TEST(TestStrides, compute_strides_of_vectors) {
+  using value_type     = typename TestFixture::value_type;
+  using container_type = std::vector<value_type>;
+  test_compute_strides<container_type>();
 }
 
 // Padded extents

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -12,6 +12,7 @@
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_Asserts.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_utils.hpp"


### PR DESCRIPTION
This PR moves `compute_strides` into `KokkosFFT_Extents.hpp`

- [x] Moves `compute_strides` into `KokkosFFT_Extents.hpp` and corresponding unit-tests
- [x] Refactor the internal check in `compute_strides` not to rely on `total_size` function
- [x] Update include in `KokkosFFT_ROCM_types.hpp`