### PR TITLE
Remove check in get_map_axes and remove axis API

### DIFF
--- a/common/src/KokkosFFT_Mapping.hpp
+++ b/common/src/KokkosFFT_Mapping.hpp
@@ -96,7 +96,6 @@ auto get_map_axes(const std::array<IntType, FFT_DIM>& axes) {
 /// \param[in] view The input view (used for type deduction)
 /// \param[in] axes Axes over which FFT is performed
 /// \return The mapping axes and inverse mapping axes as a tuple
-/// \throws if axes are not valid for the view
 template <typename ViewType, std::size_t FFT_DIM>
 auto get_map_axes(const ViewType& /*view*/, const axis_type<FFT_DIM>& axes) {
   using LayoutType = typename ViewType::array_layout;

--- a/common/src/KokkosFFT_Mapping.hpp
+++ b/common/src/KokkosFFT_Mapping.hpp
@@ -93,29 +93,14 @@ auto get_map_axes(const std::array<IntType, FFT_DIM>& axes) {
 /// \tparam ViewType The type of the input view
 /// \tparam FFT_DIM The dimensionality of the FFT axes
 ///
+/// \param[in] view The input view (used for type deduction)
 /// \param[in] axes Axes over which FFT is performed
 /// \return The mapping axes and inverse mapping axes as a tuple
 /// \throws if axes are not valid for the view
 template <typename ViewType, std::size_t FFT_DIM>
-auto get_map_axes(const ViewType& view, const axis_type<FFT_DIM>& axes) {
-  KOKKOSFFT_THROW_IF(!KokkosFFT::Impl::are_valid_axes(view, axes),
-                     "get_map_axes: input axes are not valid for the view");
+auto get_map_axes(const ViewType& /*view*/, const axis_type<FFT_DIM>& axes) {
   using LayoutType = typename ViewType::array_layout;
   return get_map_axes<LayoutType, ViewType::rank()>(axes);
-}
-
-/// \brief Mapping axes for transpose. With this mapping,
-/// the input view is transposed into the contiguous order which is expected by
-/// the FFT plan.
-///
-/// \tparam ViewType The type of the input view
-///
-/// \param[in] axis Axis over which FFT is performed
-/// \return The mapping axes and inverse mapping axes as a tuple
-/// \throws if axes are not valid for the view
-template <typename ViewType>
-auto get_map_axes(const ViewType& view, int axis) {
-  return get_map_axes(view, axis_type<1>({axis}));
 }
 
 }  // namespace Impl

--- a/common/src/KokkosFFT_Mapping.hpp
+++ b/common/src/KokkosFFT_Mapping.hpp
@@ -27,7 +27,8 @@ namespace Impl {
 ///
 /// \param[in] axes Axes over which FFT is performed
 /// \return The mapping axes and inverse mapping axes as a tuple
-/// \throws if axes are not valid for the view
+/// \throws std::runtime_error if any axis is out of range
+/// \pre axes must not contain duplicates after negative-axis conversion
 template <typename Layout, std::size_t DIM, typename IntType,
           std::size_t FFT_DIM>
 auto get_map_axes(const std::array<IntType, FFT_DIM>& axes) {

--- a/common/unit_test/Test_Mapping.cpp
+++ b/common/unit_test/Test_Mapping.cpp
@@ -27,16 +27,12 @@ void test_map_axes1d() {
   using RealView1Dtype = Kokkos::View<double*, LayoutType, execution_space>;
   RealView1Dtype x("x", len);
 
-  auto [map_axis, map_inv_axis] = KokkosFFT::Impl::get_map_axes(x, /*axis=*/0);
   auto [map_axes, map_inv_axes] =
       KokkosFFT::Impl::get_map_axes(x, /*axes=*/axes_type<1>({0}));
 
-  axes_type<1> ref_map_axis = {0};
-  axes_type<1> ref_map_axes = {0};
+  axes_type<1> ref_map_axes{0};
 
-  EXPECT_TRUE(map_axis == ref_map_axis);
   EXPECT_TRUE(map_axes == ref_map_axes);
-  EXPECT_TRUE(map_inv_axis == ref_map_axis);
   EXPECT_TRUE(map_inv_axes == ref_map_axes);
 }
 
@@ -46,12 +42,6 @@ void test_map_axes2d() {
   using RealView2Dtype = Kokkos::View<double**, LayoutType, execution_space>;
   RealView2Dtype x("x", n0, n1);
 
-  auto [map_axis_0, map_inv_axis_0] =
-      KokkosFFT::Impl::get_map_axes(x, /*axis=*/0);
-  auto [map_axis_1, map_inv_axis_1] =
-      KokkosFFT::Impl::get_map_axes(x, /*axis=*/1);
-  auto [map_axis_minus1, map_inv_axis_minus1] =
-      KokkosFFT::Impl::get_map_axes(x, /*axis=*/-1);
   auto [map_axes_0, map_inv_axes_0] =
       KokkosFFT::Impl::get_map_axes(x, /*axes=*/axes_type<1>({0}));
   auto [map_axes_1, map_inv_axes_1] =
@@ -67,9 +57,6 @@ void test_map_axes2d() {
   auto [map_axes_1_0, map_inv_axes_1_0] =
       KokkosFFT::Impl::get_map_axes(x, /*axes=*/axes_type<2>({1, 0}));
 
-  axes_type<2> ref_map_axis_0, ref_map_inv_axis_0;
-  axes_type<2> ref_map_axis_1, ref_map_inv_axis_1;
-  axes_type<2> ref_map_axis_minus1, ref_map_inv_axis_minus1;
   axes_type<2> ref_map_axes_0, ref_map_inv_axes_0;
   axes_type<2> ref_map_axes_1, ref_map_inv_axes_1;
   axes_type<2> ref_map_axes_minus1, ref_map_inv_axes_minus1;
@@ -81,9 +68,6 @@ void test_map_axes2d() {
 
   if (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
     // Layout Left
-    ref_map_axis_0 = {0, 1}, ref_map_inv_axis_0 = {0, 1};
-    ref_map_axis_1 = {1, 0}, ref_map_inv_axis_1 = {1, 0};
-    ref_map_axis_minus1 = {1, 0}, ref_map_inv_axis_minus1 = {1, 0};
     ref_map_axes_0 = {0, 1}, ref_map_inv_axes_0 = {0, 1};
     ref_map_axes_1 = {1, 0}, ref_map_inv_axes_1 = {1, 0};
     ref_map_axes_minus1 = {1, 0}, ref_map_inv_axes_minus1 = {1, 0};
@@ -94,9 +78,6 @@ void test_map_axes2d() {
     ref_map_axes_1_0 = {0, 1}, ref_map_inv_axes_1_0 = {0, 1};
   } else {
     // Layout Right
-    ref_map_axis_0 = {1, 0}, ref_map_inv_axis_0 = {1, 0};
-    ref_map_axis_1 = {0, 1}, ref_map_inv_axis_1 = {0, 1};
-    ref_map_axis_minus1 = {0, 1}, ref_map_inv_axis_minus1 = {0, 1};
     ref_map_axes_0 = {1, 0}, ref_map_inv_axes_0 = {1, 0};
     ref_map_axes_1 = {0, 1}, ref_map_inv_axes_1 = {0, 1};
     ref_map_axes_minus1 = {0, 1}, ref_map_inv_axes_minus1 = {0, 1};
@@ -108,9 +89,6 @@ void test_map_axes2d() {
   }
 
   // Forward mapping
-  EXPECT_TRUE(map_axis_0 == ref_map_axis_0);
-  EXPECT_TRUE(map_axis_1 == ref_map_axis_1);
-  EXPECT_TRUE(map_axis_minus1 == ref_map_axis_minus1);
   EXPECT_TRUE(map_axes_0 == ref_map_axes_0);
   EXPECT_TRUE(map_axes_1 == ref_map_axes_1);
   EXPECT_TRUE(map_axes_minus1 == ref_map_axes_minus1);
@@ -120,9 +98,6 @@ void test_map_axes2d() {
   EXPECT_TRUE(map_axes_1_0 == ref_map_axes_1_0);
 
   // Inverse mapping
-  EXPECT_TRUE(map_inv_axis_0 == ref_map_inv_axis_0);
-  EXPECT_TRUE(map_inv_axis_1 == ref_map_inv_axis_1);
-  EXPECT_TRUE(map_inv_axis_minus1 == ref_map_inv_axis_minus1);
   EXPECT_TRUE(map_inv_axes_0 == ref_map_inv_axes_0);
   EXPECT_TRUE(map_inv_axes_1 == ref_map_inv_axes_1);
   EXPECT_TRUE(map_inv_axes_minus1 == ref_map_inv_axes_minus1);
@@ -138,9 +113,6 @@ void test_map_axes3d() {
   using RealView3Dtype = Kokkos::View<double***, LayoutType, execution_space>;
   RealView3Dtype x("x", n0, n1, n2);
 
-  auto [map_axis_0, map_inv_axis_0] = KokkosFFT::Impl::get_map_axes(x, 0);
-  auto [map_axis_1, map_inv_axis_1] = KokkosFFT::Impl::get_map_axes(x, 1);
-  auto [map_axis_2, map_inv_axis_2] = KokkosFFT::Impl::get_map_axes(x, 2);
   auto [map_axes_0, map_inv_axes_0] =
       KokkosFFT::Impl::get_map_axes(x, axes_type<1>({0}));
   auto [map_axes_1, map_inv_axes_1] =
@@ -175,10 +147,6 @@ void test_map_axes3d() {
   auto [map_axes_2_1_0, map_inv_axes_2_1_0] =
       KokkosFFT::Impl::get_map_axes(x, axes_type<3>({2, 1, 0}));
 
-  axes_type<3> ref_map_axis_0, ref_map_inv_axis_0;
-  axes_type<3> ref_map_axis_1, ref_map_inv_axis_1;
-  axes_type<3> ref_map_axis_2, ref_map_inv_axis_2;
-
   axes_type<3> ref_map_axes_0, ref_map_inv_axes_0;
   axes_type<3> ref_map_axes_1, ref_map_inv_axes_1;
   axes_type<3> ref_map_axes_2, ref_map_inv_axes_2;
@@ -199,10 +167,6 @@ void test_map_axes3d() {
 
   if (std::is_same_v<LayoutType, Kokkos::LayoutLeft>) {
     // Layout Left
-    ref_map_axis_0 = {0, 1, 2}, ref_map_inv_axis_0 = {0, 1, 2};
-    ref_map_axis_1 = {1, 0, 2}, ref_map_inv_axis_1 = {1, 0, 2};
-    ref_map_axis_2 = {2, 0, 1}, ref_map_inv_axis_2 = {1, 2, 0};
-
     ref_map_axes_0 = {0, 1, 2}, ref_map_inv_axes_0 = {0, 1, 2};
     ref_map_axes_1 = {1, 0, 2}, ref_map_inv_axes_1 = {1, 0, 2};
     ref_map_axes_2 = {2, 0, 1}, ref_map_inv_axes_2 = {1, 2, 0};
@@ -222,10 +186,6 @@ void test_map_axes3d() {
     ref_map_axes_2_1_0 = {0, 1, 2}, ref_map_inv_axes_2_1_0 = {0, 1, 2};
   } else {
     // Layout Right
-    ref_map_axis_0 = {1, 2, 0}, ref_map_inv_axis_0 = {2, 0, 1};
-    ref_map_axis_1 = {0, 2, 1}, ref_map_inv_axis_1 = {0, 2, 1};
-    ref_map_axis_2 = {0, 1, 2}, ref_map_inv_axis_2 = {0, 1, 2};
-
     ref_map_axes_0 = {1, 2, 0}, ref_map_inv_axes_0 = {2, 0, 1};
     ref_map_axes_1 = {0, 2, 1}, ref_map_inv_axes_1 = {0, 2, 1};
     ref_map_axes_2 = {0, 1, 2}, ref_map_inv_axes_2 = {0, 1, 2};
@@ -246,9 +206,6 @@ void test_map_axes3d() {
   }
 
   // Forward mapping
-  EXPECT_TRUE(map_axis_0 == ref_map_axis_0);
-  EXPECT_TRUE(map_axis_1 == ref_map_axis_1);
-  EXPECT_TRUE(map_axis_2 == ref_map_axis_2);
   EXPECT_TRUE(map_axes_0 == ref_map_axes_0);
   EXPECT_TRUE(map_axes_1 == ref_map_axes_1);
   EXPECT_TRUE(map_axes_2 == ref_map_axes_2);
@@ -268,9 +225,6 @@ void test_map_axes3d() {
   EXPECT_TRUE(map_axes_2_1_0 == ref_map_axes_2_1_0);
 
   // Inverse mapping
-  EXPECT_TRUE(map_inv_axis_0 == ref_map_inv_axis_0);
-  EXPECT_TRUE(map_inv_axis_1 == ref_map_inv_axis_1);
-  EXPECT_TRUE(map_inv_axis_2 == ref_map_inv_axis_2);
   EXPECT_TRUE(map_inv_axes_0 == ref_map_inv_axes_0);
   EXPECT_TRUE(map_inv_axes_1 == ref_map_inv_axes_1);
   EXPECT_TRUE(map_inv_axes_2 == ref_map_inv_axes_2);

--- a/common/unit_test/Test_Transpose.cpp
+++ b/common/unit_test/Test_Transpose.cpp
@@ -217,10 +217,10 @@ void test_transpose_1d(bool bounds_check) {
   exec.fence();
 
   for (std::size_t axis0 = 0; axis0 < DIM; axis0++) {
-    auto [map, map_inv] =
-        KokkosFFT::Impl::get_map_axes(x, static_cast<int>(axis0));
-    auto out_extents = get_out_extents(in_extents, map, bounds_check);
-    auto out_layout  = KokkosFFT::Impl::create_layout<LayoutType2>(out_extents);
+    KokkosFFT::axis_type<1> axes{static_cast<int>(axis0)};
+    auto [map, map_inv] = KokkosFFT::Impl::get_map_axes(x, axes);
+    auto out_extents    = get_out_extents(in_extents, map, bounds_check);
+    auto out_layout = KokkosFFT::Impl::create_layout<LayoutType2>(out_extents);
     ViewLayout2type xt("xt", out_layout), xt_ref("xt_ref", out_layout);
     make_transposed(x, xt_ref, map);
 


### PR DESCRIPTION
Preparation for a bigger cleanup PR #453 

- [x] Remove `get_map_axes(const ViewType& view, int axis)` overload, which is unused
- [x] Remove unit-tests for this overload 
- [x] Remove `are_valid_axes` check in `get_map_axes` which should be made before calling this API