### PR TITLE
fix: nvcc pointless-comparison-warning

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -82,7 +82,7 @@ auto compute_strides(const ContainerType& extents) {
   std::reverse(reversed_extents.begin(), reversed_extents.end());
 
   strides.at(0) = 1;
-  for (std::size_t i = 1; i < reversed_extents.size(); i++) {
+  for (std::size_t i = 1; i < extents.size(); i++) {
     strides.at(i) = reversed_extents.at(i - 1) * strides.at(i - 1);
   }
   return strides;


### PR DESCRIPTION
This is needed to suppress the warnings.

```
[ 64%] Building CXX object common/unit_test/CMakeFiles/unit-tests-kokkos-fft-common.dir/Test_Extents.cpp.o
/work/common/src/KokkosFFT_Extents.hpp(85): warning #186-D: pointless comparison of unsigned integer with zero
    for (std::size_t i = 1; i < reversed_extents.size(); i++) {
                              ^
          detected during:
            instantiation of "auto KokkosFFT::Impl::compute_strides(const ContainerType &) [with ContainerType=std::array<int, 0UL>, <unnamed>=nullptr]" at line 79 of /work/common/unit_test/Test_Extents.cpp
            instantiation of "void <unnamed>::test_compute_strides<ContainerType,EmptyContainerType>() [with ContainerType=std::array<int, 3UL>, EmptyContainerType=std::array<int, 0UL>]" at line 1126 of /work/common/unit_test/Test_Extents.cpp
```