### PR TITLE
Fix: arange and add docs

### DIFF
--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -56,7 +56,7 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \param[in] stop The stopping value of the sequence (exclusive)
 /// \param[in] step The step size between consecutive values (default is 1)
 /// \return A std::vector containing the generated sequence values
-/// \throws std::invalid_argument if step is zero or if the combination of
+/// \throws std::runtime_error if step is zero or if the combination of
 /// start, stop, and step would result in an overflow in the number of generated
 /// elements
 template <typename ElementType>
@@ -125,30 +125,27 @@ auto total_size(const ContainerType& values) {
                 "total_size: Container value type must be an integral type");
 
   auto safe_multiply = [](value_type a, value_type b) -> value_type {
-    if constexpr (std::is_integral_v<value_type>) {
-      if constexpr (std::is_signed_v<value_type>) {
-        // Check special cases with std::numeric_limits<value_type>::min()
-        if ((a == std::numeric_limits<value_type>::min() && b < 0) ||
-            (b == std::numeric_limits<value_type>::min() && a < 0)) {
+    if constexpr (std::is_signed_v<value_type>) {
+      // Check special cases with std::numeric_limits<value_type>::min()
+      if ((a == std::numeric_limits<value_type>::min() && b < 0) ||
+          (b == std::numeric_limits<value_type>::min() && a < 0)) {
+        throw std::overflow_error("Integer multiplication overflow");
+      }
+      if (a > 0) {
+        if ((b > 0 && a > std::numeric_limits<value_type>::max() / b) ||
+            (b < 0 && b < std::numeric_limits<value_type>::min() / a)) {
           throw std::overflow_error("Integer multiplication overflow");
         }
-
-        if (a > 0) {
-          if ((b > 0 && a > std::numeric_limits<value_type>::max() / b) ||
-              (b < 0 && b < std::numeric_limits<value_type>::min() / a)) {
-            throw std::overflow_error("Integer multiplication overflow");
-          }
-        } else if (a < 0) {  // a < 0
-          if ((b > 0 && a < std::numeric_limits<value_type>::min() / b) ||
-              (b < 0 && a > std::numeric_limits<value_type>::max() / b)) {
-            throw std::overflow_error("Integer multiplication overflow");
-          }
+      } else if (a < 0) {  // a < 0
+        if ((b > 0 && a < std::numeric_limits<value_type>::min() / b) ||
+            (b < 0 && a > std::numeric_limits<value_type>::max() / b)) {
+          throw std::overflow_error("Integer multiplication overflow");
         }
-      } else {
-        // nvcc warns a pointless comparison of unsigned integer with zero
-        if (b != 0 && a > std::numeric_limits<value_type>::max() / b) {
-          throw std::overflow_error("Unsigned integer multiplication overflow");
-        }
+      }
+    } else {
+      // nvcc warns a pointless comparison of unsigned integer with zero
+      if (b != 0 && a > std::numeric_limits<value_type>::max() / b) {
+        throw std::overflow_error("Unsigned integer multiplication overflow");
       }
     }
     return a * b;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -46,8 +46,8 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \brief Generate values starting from a specified value with a specified step
 /// size excluding the stop value.
 /// Example usage:
-/// \code{.cpp} std::vector<int>
-/// sequence = arange(0, 10, 2);
+/// \code{.cpp}
+/// std::vector<int> sequence = arange(0, 10, 2);
 /// \endcode
 /// This will generate a std::vector containing the values {0, 2, 4, 6, 8}
 ///
@@ -65,16 +65,23 @@ std::vector<ElementType> arange(const ElementType start, const ElementType stop,
   KOKKOSFFT_THROW_IF(step == 0, "step must be non-zero");
 
   std::vector<ElementType> result;
-  // nvcc warns a pointless comparison of unsigned integer with zero, so we
-  // check step <= 0 even though step == 0 is already checked above
-  if ((step > 0 && start >= stop) || (step <= 0 && start <= stop)) {
-    return result;
+  if constexpr (std::is_signed_v<ElementType>) {
+    if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
+      return result;
+    }
+  } else {
+    if (step > 0 && start >= stop) {
+      return result;
+    }
   }
 
   const long double span =
       static_cast<long double>(stop) - static_cast<long double>(start);
   const long double stride = static_cast<long double>(step);
-  const long double n      = std::ceil(span / stride);
+  KOKKOSFFT_THROW_IF(!std::isfinite(span) || !std::isfinite(stride),
+                     "span and step must be finite");
+
+  const long double n = std::ceil(span / stride);
   KOKKOSFFT_THROW_IF(
       n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
       "sequence size overflow");
@@ -110,7 +117,8 @@ constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
 
 /// \brief Compute the total size by multiplying all elements in the container
 /// Example usage:
-/// \code{.cpp} std::vector<int> dims = {2, 3, 4};
+/// \code{.cpp}
+/// std::vector<int> dims = {2, 3, 4};
 /// auto size = total_size(dims); // size will be 24
 /// \endcode
 /// \tparam ContainerType The container type, must support begin() and end()

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -93,8 +93,30 @@ std::vector<ElementType> arange(const ElementType start, const ElementType stop,
 
   const std::size_t count = static_cast<std::size_t>(n);
   result.reserve(count);
-  for (std::size_t i = 0; i < count; ++i) {
-    result.push_back(start + static_cast<ElementType>(i) * step);
+  if constexpr (std::is_integral_v<ElementType>) {
+    ElementType value = start;
+    for (std::size_t i = 0; i < count; ++i) {
+      result.push_back(value);
+      if (i + 1 < count) {
+        if constexpr (std::is_signed_v<ElementType>) {
+          KOKKOSFFT_THROW_IF(
+              (step > 0 &&
+               value > std::numeric_limits<ElementType>::max() - step) ||
+                  (step < 0 &&
+                   value < std::numeric_limits<ElementType>::min() - step),
+              "arange value overflow");
+        } else {
+          KOKKOSFFT_THROW_IF(
+              value > std::numeric_limits<ElementType>::max() - step,
+              "arange value overflow");
+        }
+        value += step;
+      }
+    }
+  } else {
+    for (std::size_t i = 0; i < count; ++i) {
+      result.push_back(start + static_cast<ElementType>(i) * step);
+    }
   }
 
   return result;

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <set>
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <stdexcept>
 #include <limits>
@@ -50,28 +51,38 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \endcode
 /// This will generate a std::vector containing the values {0, 2, 4, 6, 8}
 ///
-/// \tparam ElementType The integral type of the sequence values
+/// \tparam ElementType The arithmetic type of the sequence values
 /// \param[in] start The starting value of the sequence
 /// \param[in] stop The stopping value of the sequence (exclusive)
 /// \param[in] step The step size between consecutive values (default is 1)
-/// \return A std::vector containing the generated sequence of integral values
-/// \throws std::invalid_argument if step is zero
+/// \return A std::vector containing the generated sequence values
+/// \throws std::invalid_argument if step is zero or if the combination of
+/// start, stop, and step would result in an overflow in the number of generated
+/// elements
 template <typename ElementType>
 std::vector<ElementType> arange(const ElementType start, const ElementType stop,
                                 const ElementType step = 1) {
-  if (step == 0) {
-    throw std::invalid_argument("step must be non-zero");
-  }
+  KOKKOSFFT_THROW_IF(step == 0, "step must be non-zero");
 
   std::vector<ElementType> result;
-  if (step > 0) {
-    for (ElementType value = start; value < stop; value += step) {
-      result.push_back(value);
-    }
-  } else {
-    for (ElementType value = start; value > stop; value += step) {
-      result.push_back(value);
-    }
+  // nvcc warns a pointless comparison of unsigned integer with zero, so we
+  // check step <= 0 even though step == 0 is already checked above
+  if ((step > 0 && start >= stop) || (step <= 0 && start <= stop)) {
+    return result;
+  }
+
+  const long double span =
+      static_cast<long double>(stop) - static_cast<long double>(start);
+  const long double stride = static_cast<long double>(step);
+  const long double n      = std::ceil(span / stride);
+  KOKKOSFFT_THROW_IF(
+      n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
+      "sequence size overflow");
+
+  const std::size_t count = static_cast<std::size_t>(n);
+  result.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    result.push_back(start + static_cast<ElementType>(i) * step);
   }
 
   return result;
@@ -108,8 +119,8 @@ constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
 /// \throws std::overflow_error if multiplication overflows
 template <typename ContainerType>
 auto total_size(const ContainerType& values) {
-  using value_type = std::remove_cv_t<
-      std::remove_reference_t<typename ContainerType::value_type>>;
+  using value_type =
+      std::remove_cv_t<std::remove_reference_t<decltype(*values.begin())>>;
   static_assert(std::is_integral_v<value_type>,
                 "total_size: Container value type must be an integral type");
 

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -56,9 +56,10 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \param[in] stop The stopping value of the sequence (exclusive)
 /// \param[in] step The step size between consecutive values (default is 1)
 /// \return A std::vector containing the generated sequence values
-/// \throws std::runtime_error if step is zero or if the combination of
-/// start, stop, and step would result in an overflow in the number of generated
-/// elements
+/// \throws std::runtime_error if step is zero, if span or step is not finite,
+/// if the combination of start, stop, and step would result in an overflow in
+/// the number of generated elements, or if an unsigned step exceeds the
+/// supported range for the internal size checks
 template <typename ElementType>
 std::vector<ElementType> arange(const ElementType start, const ElementType stop,
                                 const ElementType step = 1) {
@@ -67,22 +68,14 @@ std::vector<ElementType> arange(const ElementType start, const ElementType stop,
   KOKKOSFFT_THROW_IF(step == 0, "step must be non-zero");
 
   std::vector<ElementType> result;
-  if constexpr (std::is_integral_v<ElementType>) {
-    if constexpr (std::is_signed_v<ElementType>) {
-      if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
-        return result;
-      }
-    } else {
-      KOKKOSFFT_THROW_IF(
-          step > static_cast<std::size_t>(
-                     std::numeric_limits<std::ptrdiff_t>::max()),
-          "Negative step size passed where std::size_t was expected");
-      if ((step > 0 && start >= stop)) {
-        return result;
-      }
+  // Unsigned integers require special treatment: step is always positive
+  if constexpr (std::is_integral_v<ElementType> &&
+                std::is_unsigned_v<ElementType>) {
+    if (start >= stop) {
+      return result;
     }
   } else {
-    // floating-point case:
+    // For signed integers and floating-point types
     if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
       return result;
     }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -57,8 +57,8 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \param[in] step The step size between consecutive values (default is 1)
 /// \return A std::vector containing the generated sequence values
 /// \throws std::runtime_error if step is zero, if span or step is not finite,
-/// or if the computed number of generated elements would overflow
-/// `std::size_t`
+/// if the computed number of generated elements would overflow `std::size_t`,
+/// or if generating the next integral value would overflow `ElementType`
 template <typename ElementType>
 std::vector<ElementType> arange(const ElementType start, const ElementType stop,
                                 const ElementType step = 1) {
@@ -80,28 +80,18 @@ std::vector<ElementType> arange(const ElementType start, const ElementType stop,
     }
   }
 
-  std::size_t count = 0;
-  if constexpr (std::is_floating_point_v<ElementType>) {
-    const long double span =
-        static_cast<long double>(stop) - static_cast<long double>(start);
-    const long double stride = static_cast<long double>(step);
-    KOKKOSFFT_THROW_IF(!std::isfinite(span) || !std::isfinite(stride),
-                       "span and step must be finite");
+  const long double span =
+      static_cast<long double>(stop) - static_cast<long double>(start);
+  const long double stride = static_cast<long double>(step);
+  KOKKOSFFT_THROW_IF(!std::isfinite(span) || !std::isfinite(stride),
+                     "span and step must be finite");
 
-    const long double n = std::ceil(span / stride);
-    KOKKOSFFT_THROW_IF(
-        n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
-        "sequence size overflow");
+  const long double n = std::ceil(span / stride);
+  KOKKOSFFT_THROW_IF(
+      n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
+      "sequence size overflow");
 
-    count = static_cast<std::size_t>(n);
-  } else {
-    // For integral types, we can compute the count using integer arithmetic
-    if constexpr (std::is_unsigned_v<ElementType>) {
-      count = (stop - start + step - 1) / step;  // Round up for unsigned
-    } else {
-      count = (stop - start + (step > 0 ? step - 1 : step + 1)) / step;
-    }
-  }
+  const std::size_t count = static_cast<std::size_t>(n);
   result.reserve(count);
   for (std::size_t i = 0; i < count; ++i) {
     result.push_back(start + static_cast<ElementType>(i) * step);

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -62,15 +62,28 @@ constexpr std::array<IntType, N> index_sequence() {
 template <typename ElementType>
 std::vector<ElementType> arange(const ElementType start, const ElementType stop,
                                 const ElementType step = 1) {
+  static_assert(std::is_arithmetic_v<ElementType>,
+                "arange: ElementType must be an arithmetic type");
   KOKKOSFFT_THROW_IF(step == 0, "step must be non-zero");
 
   std::vector<ElementType> result;
-  if constexpr (std::is_signed_v<ElementType>) {
-    if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
-      return result;
+  if constexpr (std::is_integral_v<ElementType>) {
+    if constexpr (std::is_signed_v<ElementType>) {
+      if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
+        return result;
+      }
+    } else {
+      KOKKOSFFT_THROW_IF(
+          step > static_cast<std::size_t>(
+                     std::numeric_limits<std::ptrdiff_t>::max()),
+          "Negative step size passed where std::size_t was expected");
+      if ((step > 0 && start >= stop)) {
+        return result;
+      }
     }
   } else {
-    if (step > 0 && start >= stop) {
+    // floating-point case:
+    if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
       return result;
     }
   }

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -57,9 +57,8 @@ constexpr std::array<IntType, N> index_sequence() {
 /// \param[in] step The step size between consecutive values (default is 1)
 /// \return A std::vector containing the generated sequence values
 /// \throws std::runtime_error if step is zero, if span or step is not finite,
-/// if the combination of start, stop, and step would result in an overflow in
-/// the number of generated elements, or if an unsigned step exceeds the
-/// supported range for the internal size checks
+/// or if the computed number of generated elements would overflow
+/// `std::size_t`
 template <typename ElementType>
 std::vector<ElementType> arange(const ElementType start, const ElementType stop,
                                 const ElementType step = 1) {
@@ -81,18 +80,28 @@ std::vector<ElementType> arange(const ElementType start, const ElementType stop,
     }
   }
 
-  const long double span =
-      static_cast<long double>(stop) - static_cast<long double>(start);
-  const long double stride = static_cast<long double>(step);
-  KOKKOSFFT_THROW_IF(!std::isfinite(span) || !std::isfinite(stride),
-                     "span and step must be finite");
+  std::size_t count = 0;
+  if constexpr (std::is_floating_point_v<ElementType>) {
+    const long double span =
+        static_cast<long double>(stop) - static_cast<long double>(start);
+    const long double stride = static_cast<long double>(step);
+    KOKKOSFFT_THROW_IF(!std::isfinite(span) || !std::isfinite(stride),
+                       "span and step must be finite");
 
-  const long double n = std::ceil(span / stride);
-  KOKKOSFFT_THROW_IF(
-      n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
-      "sequence size overflow");
+    const long double n = std::ceil(span / stride);
+    KOKKOSFFT_THROW_IF(
+        n > static_cast<long double>(std::numeric_limits<std::size_t>::max()),
+        "sequence size overflow");
 
-  const std::size_t count = static_cast<std::size_t>(n);
+    count = static_cast<std::size_t>(n);
+  } else {
+    // For integral types, we can compute the count using integer arithmetic
+    if constexpr (std::is_unsigned_v<ElementType>) {
+      count = (stop - start + step - 1) / step;  // Round up for unsigned
+    } else {
+      count = (stop - start + (step > 0 ? step - 1 : step + 1)) / step;
+    }
+  }
   result.reserve(count);
   for (std::size_t i = 0; i < count; ++i) {
     result.push_back(start + static_cast<ElementType>(i) * step);

--- a/common/src/KokkosFFT_utils.hpp
+++ b/common/src/KokkosFFT_utils.hpp
@@ -18,6 +18,19 @@
 
 namespace KokkosFFT {
 namespace Impl {
+/// \brief Generate a compile-time sequence of integral values starting from a
+/// specified value
+/// Example usage:
+/// \code{.cpp}
+/// std::array<int, 5> sequence = index_sequence<int, 5, 1>();
+/// \endcode
+/// This will generate a std::array containing the values {1, 2, 3, 4, 5}
+///
+/// \tparam IntType The integral type of the sequence values
+/// \tparam N The number of values in the sequence
+/// \tparam start The starting value of the sequence
+///
+/// \return A std::array containing the generated sequence of integral values
 template <typename IntType, std::size_t N, IntType start>
 constexpr std::array<IntType, N> index_sequence() {
   static_assert(std::is_integral_v<IntType>,
@@ -29,19 +42,38 @@ constexpr std::array<IntType, N> index_sequence() {
   return sequence;
 }
 
+/// \brief Generate values starting from a specified value with a specified step
+/// size excluding the stop value.
+/// Example usage:
+/// \code{.cpp} std::vector<int>
+/// sequence = arange(0, 10, 2);
+/// \endcode
+/// This will generate a std::vector containing the values {0, 2, 4, 6, 8}
+///
+/// \tparam ElementType The integral type of the sequence values
+/// \param[in] start The starting value of the sequence
+/// \param[in] stop The stopping value of the sequence (exclusive)
+/// \param[in] step The step size between consecutive values (default is 1)
+/// \return A std::vector containing the generated sequence of integral values
+/// \throws std::invalid_argument if step is zero
 template <typename ElementType>
-inline std::vector<ElementType> arange(const ElementType start,
-                                       const ElementType stop,
-                                       const ElementType step = 1) {
-  const size_t length = ceil((stop - start) / step);
-  std::vector<ElementType> result;
-  ElementType delta = (stop - start) / length;
-
-  // thrust::sequence
-  for (std::size_t i = 0; i < length; i++) {
-    ElementType value = start + delta * i;
-    result.push_back(value);
+std::vector<ElementType> arange(const ElementType start, const ElementType stop,
+                                const ElementType step = 1) {
+  if (step == 0) {
+    throw std::invalid_argument("step must be non-zero");
   }
+
+  std::vector<ElementType> result;
+  if (step > 0) {
+    for (ElementType value = start; value < stop; value += step) {
+      result.push_back(value);
+    }
+  } else {
+    for (ElementType value = start; value > stop; value += step) {
+      result.push_back(value);
+    }
+  }
+
   return result;
 }
 
@@ -65,48 +97,54 @@ constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
   return to_array_rvalue(std::move(a), std::make_index_sequence<N>());
 }
 
-template <typename T>
-T safe_multiply(T a, T b) {
-  if constexpr (std::is_integral_v<T>) {
-    if constexpr (std::is_signed_v<T>) {
-      // Check special cases with std::numeric_limits<T>::min()
-      if ((a == std::numeric_limits<T>::min() && b < 0) ||
-          (b == std::numeric_limits<T>::min() && a < 0)) {
-        throw std::overflow_error("Integer multiplication overflow");
-      }
-
-      if (a > 0) {
-        if ((b > 0 && a > std::numeric_limits<T>::max() / b) ||
-            (b < 0 && b < std::numeric_limits<T>::min() / a)) {
-          throw std::overflow_error("Integer multiplication overflow");
-        }
-      } else if (a < 0) {  // a < 0
-        if ((b > 0 && a < std::numeric_limits<T>::min() / b) ||
-            (b < 0 && a > std::numeric_limits<T>::max() / b)) {
-          throw std::overflow_error("Integer multiplication overflow");
-        }
-      }
-    } else {
-      // nvcc warns a pointless comparison of unsigned integer with zero
-      if (b != 0 && a > std::numeric_limits<T>::max() / b) {
-        throw std::overflow_error("Unsigned integer multiplication overflow");
-      }
-    }
-  }
-  return a * b;
-}
-
+/// \brief Compute the total size by multiplying all elements in the container
+/// Example usage:
+/// \code{.cpp} std::vector<int> dims = {2, 3, 4};
+/// auto size = total_size(dims); // size will be 24
+/// \endcode
+/// \tparam ContainerType The container type, must support begin() and end()
+/// \param[in] values The input container of integral values
+/// \return The total size computed by multiplying all elements in the container
+/// \throws std::overflow_error if multiplication overflows
 template <typename ContainerType>
 auto total_size(const ContainerType& values) {
-  using value_type =
-      std::remove_cv_t<std::remove_reference_t<decltype(*values.begin())>>;
-
-  value_type init = 1;
+  using value_type = std::remove_cv_t<
+      std::remove_reference_t<typename ContainerType::value_type>>;
   static_assert(std::is_integral_v<value_type>,
                 "total_size: Container value type must be an integral type");
-  return std::accumulate(
-      values.begin(), values.end(), init,
-      [](value_type a, value_type b) { return safe_multiply(a, b); });
+
+  auto safe_multiply = [](value_type a, value_type b) -> value_type {
+    if constexpr (std::is_integral_v<value_type>) {
+      if constexpr (std::is_signed_v<value_type>) {
+        // Check special cases with std::numeric_limits<value_type>::min()
+        if ((a == std::numeric_limits<value_type>::min() && b < 0) ||
+            (b == std::numeric_limits<value_type>::min() && a < 0)) {
+          throw std::overflow_error("Integer multiplication overflow");
+        }
+
+        if (a > 0) {
+          if ((b > 0 && a > std::numeric_limits<value_type>::max() / b) ||
+              (b < 0 && b < std::numeric_limits<value_type>::min() / a)) {
+            throw std::overflow_error("Integer multiplication overflow");
+          }
+        } else if (a < 0) {  // a < 0
+          if ((b > 0 && a < std::numeric_limits<value_type>::min() / b) ||
+              (b < 0 && a > std::numeric_limits<value_type>::max() / b)) {
+            throw std::overflow_error("Integer multiplication overflow");
+          }
+        }
+      } else {
+        // nvcc warns a pointless comparison of unsigned integer with zero
+        if (b != 0 && a > std::numeric_limits<value_type>::max() / b) {
+          throw std::overflow_error("Unsigned integer multiplication overflow");
+        }
+      }
+    }
+    return a * b;
+  };
+
+  value_type init = 1;
+  return std::accumulate(values.begin(), values.end(), init, safe_multiply);
 }
 
 /// \brief Helper to convert the base integral type of a container to another

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -175,6 +175,11 @@ void test_arange() {
       auto neg_result = KokkosFFT::Impl::arange(start, stop, step);
       std::vector<ValueType> ref_neg_result = {-3, -1, 1, 3};
       EXPECT_EQ(neg_result, ref_neg_result);
+
+      ValueType neg_step   = -2;
+      auto neg_step_result = KokkosFFT::Impl::arange(stop, start, neg_step);
+      std::vector<ValueType> ref_neg_step_result = {4, 2, 0, -2};
+      EXPECT_EQ(neg_step_result, ref_neg_step_result);
     }
   } else {
     // For non-integral type, we test an explicit non-unit step size

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -177,11 +177,34 @@ void test_arange() {
       EXPECT_EQ(neg_result, ref_neg_result);
     }
   } else {
-    // For non-integral type, we test the default step size
+    // For non-integral type, we test an explicit non-unit step size
     ValueType start = -1.0, stop = 1.1, step = 0.5;
     auto result = KokkosFFT::Impl::arange(start, stop, step);
     std::vector<ValueType> ref_result = {-1.0, -0.5, 0.0, 0.5, 1.0};
     EXPECT_EQ(result, ref_result);
+  }
+
+  // Failure test for zero step size
+  EXPECT_THROW(
+      {
+        ValueType zero_step = 0;
+        [[maybe_unused]] auto result_zero_step =
+            KokkosFFT::Impl::arange(seq_start, seq_stop, zero_step);
+      },
+      std::runtime_error);
+
+  // Failure test for overflow in step size
+  if constexpr (std::is_floating_point_v<ValueType>) {
+    const ValueType overflow_start = 0;
+    const ValueType overflow_stop  = std::numeric_limits<ValueType>::max();
+    const ValueType overflow_step  = std::numeric_limits<ValueType>::min();
+
+    EXPECT_THROW(
+        {
+          [[maybe_unused]] auto overflow_result = KokkosFFT::Impl::arange(
+              overflow_start, overflow_stop, overflow_step);
+        },
+        std::runtime_error);
   }
 }
 

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -13,6 +13,9 @@ using test_types = ::testing::Types<Kokkos::LayoutLeft, Kokkos::LayoutRight>;
 using base_int_types   = ::testing::Types<int, std::size_t>;
 using signed_int_types = ::testing::Types<int, std::int32_t, std::int64_t>;
 
+// Int or float types
+using data_types = ::testing::Types<int, std::size_t, float, double>;
+
 // value type combinations that are tested
 using paired_scalar_types = ::testing::Types<
     std::pair<float, float>, std::pair<float, Kokkos::complex<float>>,
@@ -42,6 +45,11 @@ struct PairedScalarTypes : public ::testing::Test {
 
 template <typename T>
 struct TestIndexSequence : public ::testing::Test {
+  using value_type = T;
+};
+
+template <typename T>
+struct TestArange : public ::testing::Test {
   using value_type = T;
 };
 
@@ -145,6 +153,35 @@ void test_index_sequence() {
     EXPECT_EQ(range0, ref_range0);
     EXPECT_EQ(range1, ref_range1);
     EXPECT_EQ(range2, ref_range2);
+  }
+}
+
+template <typename ValueType>
+void test_arange() {
+  ValueType seq_start = 0, seq_stop = 5;
+  auto seq_result = KokkosFFT::Impl::arange(seq_start, seq_stop);
+  std::vector<ValueType> ref_result = {0, 1, 2, 3, 4};
+  EXPECT_EQ(seq_result, ref_result);
+
+  if constexpr (std::is_integral_v<ValueType>) {
+    auto pos_result = KokkosFFT::Impl::arange(static_cast<ValueType>(0),
+                                              static_cast<ValueType>(10),
+                                              static_cast<ValueType>(2));
+    std::vector<ValueType> ref_pos_result = {0, 2, 4, 6, 8};
+    EXPECT_EQ(pos_result, ref_pos_result);
+
+    if constexpr (std::is_signed_v<ValueType>) {
+      ValueType start = -3, stop = 4, step = 2;
+      auto neg_result = KokkosFFT::Impl::arange(start, stop, step);
+      std::vector<ValueType> ref_neg_result = {-3, -1, 1, 3};
+      EXPECT_EQ(neg_result, ref_neg_result);
+    }
+  } else {
+    // For non-integral type, we test the default step size
+    ValueType start = -1.0, stop = 1.1, step = 0.5;
+    auto result = KokkosFFT::Impl::arange(start, stop, step);
+    std::vector<ValueType> ref_result = {-1.0, -0.5, 0.0, 0.5, 1.0};
+    EXPECT_EQ(result, ref_result);
   }
 }
 
@@ -305,6 +342,7 @@ void test_convert_base_int_type() {
 TYPED_TEST_SUITE(ContainerTypes, base_int_types);
 TYPED_TEST_SUITE(PairedScalarTypes, paired_scalar_types);
 TYPED_TEST_SUITE(TestIndexSequence, base_int_types);
+TYPED_TEST_SUITE(TestArange, data_types);
 TYPED_TEST_SUITE(TestConvertBaseTypes, paired_int_types);
 
 TYPED_TEST(ContainerTypes, test_total_size_of_vector) {
@@ -341,6 +379,11 @@ TYPED_TEST(ContainerTypes, array_to_vector) {
 TYPED_TEST(TestIndexSequence, make_sequence_3Dto5D) {
   using value_type = typename TestFixture::value_type;
   test_index_sequence<value_type>();
+}
+
+TYPED_TEST(TestArange, arange) {
+  using value_type = typename TestFixture::value_type;
+  test_arange<value_type>();
 }
 
 TEST(ToArray, lvalue) {

--- a/common/unit_test/Test_Common_Utils.cpp
+++ b/common/unit_test/Test_Common_Utils.cpp
@@ -163,6 +163,10 @@ void test_arange() {
   std::vector<ValueType> ref_result = {0, 1, 2, 3, 4};
   EXPECT_EQ(seq_result, ref_result);
 
+  auto empty_result = KokkosFFT::Impl::arange(seq_stop, seq_start);
+  std::vector<ValueType> ref_empty_result{};
+  EXPECT_EQ(empty_result, ref_empty_result);
+
   if constexpr (std::is_integral_v<ValueType>) {
     auto pos_result = KokkosFFT::Impl::arange(static_cast<ValueType>(0),
                                               static_cast<ValueType>(10),
@@ -180,6 +184,10 @@ void test_arange() {
       auto neg_step_result = KokkosFFT::Impl::arange(stop, start, neg_step);
       std::vector<ValueType> ref_neg_step_result = {4, 2, 0, -2};
       EXPECT_EQ(neg_step_result, ref_neg_step_result);
+
+      auto neg_empty_result = KokkosFFT::Impl::arange(start, stop, neg_step);
+      std::vector<ValueType> ref_neg_empty_result{};
+      EXPECT_EQ(neg_empty_result, ref_neg_empty_result);
     }
   } else {
     // For non-integral type, we test an explicit non-unit step size
@@ -198,7 +206,7 @@ void test_arange() {
       },
       std::runtime_error);
 
-  // Failure test for overflow in step size
+  // Failure test for overflow in the number of elements
   if constexpr (std::is_floating_point_v<ValueType>) {
     const ValueType overflow_start = 0;
     const ValueType overflow_stop  = std::numeric_limits<ValueType>::max();


### PR DESCRIPTION
This PR aims at fixing the behavior of [arange](https://numpy.org/doc/stable/reference/generated/numpy.arange.html) to align with numpy implementation.

- [x] Fix `arange`
- [x] Add an unit-test for `arange` 
- [x] Add docstrings to `index_sequence`, `arange` and `total_size`