### PR TITLE
Rename utils to convert-types

### DIFF
--- a/common/src/KokkosFFT_Convert_Types.hpp
+++ b/common/src/KokkosFFT_Convert_Types.hpp
@@ -20,24 +20,25 @@
 
 namespace KokkosFFT {
 namespace Impl {
-/// \brief Convert a lvalue std::array to Kokkos::Array
-/// \tparam To The target integral type
+/// \brief Convert a lvalue std::array (including const arrays) to Kokkos::Array
+/// \tparam T The element type of the array
 /// \tparam N The number of elements in the array
-///
 /// \tparam Is A parameter pack of indices for the array elements
+///
 /// \param[in] a The input array to be converted
 /// \return A new Kokkos::Array with the same number of elements as the input
 /// array
 template <typename T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_lvalue(
-    std::array<T, N>& a, std::index_sequence<Is...>) {
+    const std::array<T, N>& a, std::index_sequence<Is...>) {
   return {{a[Is]...}};
 }
 
 /// \brief Convert a std::array to Kokkos::Array by moving elements from an
-/// rvalue std::array \tparam To The target integral type \tparam N The number
-/// of elements in the array \tparam Is A parameter pack of indices for the
-/// array elements
+/// rvalue std::array
+/// \tparam T The element type of the array
+/// \tparam N The number of elements in the array
+/// \tparam Is A parameter pack of indices for the array elements
 ///
 /// \param[in, out] a The input array to be converted, which will be moved from
 /// \return A new Kokkos::Array with the same number of elements as the input
@@ -48,20 +49,22 @@ constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_rvalue(
   return {{std::move(a[Is])...}};
 }
 
-/// \brief Convert a std::array to Kokkos::Array
-/// \tparam T The type of the elements in the array
+/// \brief Convert a const std::array to a const Kokkos::Array
+/// \tparam T The element type of the array
 /// \tparam N The number of elements in the array
 ///
-/// \param[in] a The input lvalue std::array
+/// \param[in] a The input const lvalue std::array
 /// \return A Kokkos::Array containing the elements of the input array
 template <typename T, std::size_t N>
-constexpr Kokkos::Array<T, N> to_array(std::array<T, N>& a) {
+constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array(
+    const std::array<T, N>& a) {
   return to_array_lvalue(a, std::make_index_sequence<N>());
 }
 
 /// \brief Convert a std::array to Kokkos::Array by moving elements from an
-/// rvalue std::array \tparam T The type of the elements in the array \tparam N
-/// The number of elements in the array
+/// rvalue std::array
+/// \tparam T The element type of the array
+/// \tparam N The number of elements in the array
 ///
 /// \param[in, out] a The input rvalue std::array
 /// \return A Kokkos::Array containing the elements of the input array

--- a/common/src/KokkosFFT_Convert_Types.hpp
+++ b/common/src/KokkosFFT_Convert_Types.hpp
@@ -49,7 +49,7 @@ constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_rvalue(
   return {{std::move(a[Is])...}};
 }
 
-/// \brief Convert a const std::array to a const Kokkos::Array
+/// \brief Convert a std::array to a Kokkos::Array
 /// \tparam T The element type of the array
 /// \tparam N The number of elements in the array
 ///
@@ -69,7 +69,7 @@ constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array(
 /// \param[in, out] a The input rvalue std::array
 /// \return A Kokkos::Array containing the elements of the input array
 template <typename T, std::size_t N>
-constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
+constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array(std::array<T, N>&& a) {
   return to_array_rvalue(std::move(a), std::make_index_sequence<N>());
 }
 

--- a/common/src/KokkosFFT_Convert_Types.hpp
+++ b/common/src/KokkosFFT_Convert_Types.hpp
@@ -2,16 +2,17 @@
 //
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-#ifndef KOKKOSFFT_UTILS_HPP
-#define KOKKOSFFT_UTILS_HPP
+#ifndef KOKKOSFFT_CONVERT_TYPES_HPP
+#define KOKKOSFFT_CONVERT_TYPES_HPP
 
-#include <vector>
-#include <set>
 #include <algorithm>
-#include <cmath>
-#include <numeric>
-#include <stdexcept>
-#include <limits>
+#include <array>
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Common_Types.hpp"
@@ -19,21 +20,51 @@
 
 namespace KokkosFFT {
 namespace Impl {
+/// \brief Convert a lvalue std::array to Kokkos::Array
+/// \tparam To The target integral type
+/// \tparam N The number of elements in the array
+///
+/// \tparam Is A parameter pack of indices for the array elements
+/// \param[in] a The input array to be converted
+/// \return A new Kokkos::Array with the same number of elements as the input
+/// array
 template <typename T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_lvalue(
     std::array<T, N>& a, std::index_sequence<Is...>) {
   return {{a[Is]...}};
 }
+
+/// \brief Convert a std::array to Kokkos::Array by moving elements from an
+/// rvalue std::array \tparam To The target integral type \tparam N The number
+/// of elements in the array \tparam Is A parameter pack of indices for the
+/// array elements
+///
+/// \param[in, out] a The input array to be converted, which will be moved from
+/// \return A new Kokkos::Array with the same number of elements as the input
+/// array
 template <typename T, std::size_t N, std::size_t... Is>
 constexpr Kokkos::Array<std::remove_cv_t<T>, N> to_array_rvalue(
     std::array<T, N>&& a, std::index_sequence<Is...>) {
   return {{std::move(a[Is])...}};
 }
 
+/// \brief Convert a std::array to Kokkos::Array
+/// \tparam T The type of the elements in the array
+/// \tparam N The number of elements in the array
+///
+/// \param[in] a The input lvalue std::array
+/// \return A Kokkos::Array containing the elements of the input array
 template <typename T, std::size_t N>
 constexpr Kokkos::Array<T, N> to_array(std::array<T, N>& a) {
   return to_array_lvalue(a, std::make_index_sequence<N>());
 }
+
+/// \brief Convert a std::array to Kokkos::Array by moving elements from an
+/// rvalue std::array \tparam T The type of the elements in the array \tparam N
+/// The number of elements in the array
+///
+/// \param[in, out] a The input rvalue std::array
+/// \return A Kokkos::Array containing the elements of the input array
 template <typename T, std::size_t N>
 constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
   return to_array_rvalue(std::move(a), std::make_index_sequence<N>());
@@ -41,6 +72,7 @@ constexpr Kokkos::Array<T, N> to_array(std::array<T, N>&& a) {
 
 /// \brief Convert a std::array to std::vector
 /// \tparam ArrayType The type of the std::array
+///
 /// \param[in, out] arr The input std::array
 /// \return A std::vector containing the elements of the input array
 template <typename ArrayType>

--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -14,9 +14,9 @@
 #include "KokkosFFT_CheckConditions.hpp"
 #include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Mapping.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_Helpers.hpp
+++ b/common/src/KokkosFFT_Helpers.hpp
@@ -12,11 +12,11 @@
 #include "KokkosFFT_CheckConditions.hpp"
 #include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/src/KokkosFFT_Transpose.hpp
+++ b/common/src/KokkosFFT_Transpose.hpp
@@ -11,11 +11,12 @@
 #include <utility>
 #include <type_traits>
 #include <Kokkos_Core.hpp>
+
 #include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_MDOperations.hpp"
 #include "KokkosFFT_Padding.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -6,8 +6,8 @@ add_executable(
   unit-tests-kokkos-fft-common
   Test_Main.cpp
   Test_CheckConditions.cpp
-  Test_Common_Utils.cpp
   Test_Container_Helpers.cpp
+  Test_Convert_Types.cpp
   Test_Traits.cpp
   Test_Layout.cpp
   Test_Normalization.cpp

--- a/common/unit_test/Test_Convert_Types.cpp
+++ b/common/unit_test/Test_Convert_Types.cpp
@@ -59,9 +59,18 @@ TYPED_TEST(ContainerTypes, array_to_vector) {
 
 TEST(ToArray, lvalue) {
   std::array arr{1, 2, 3};
-  ASSERT_EQ(KokkosFFT::Impl::to_array(arr), (Kokkos::Array{1, 2, 3}));
+  auto kokkos_arr = KokkosFFT::Impl::to_array(arr);
+  testing::StaticAssertTypeEq<decltype(kokkos_arr), Kokkos::Array<int, 3>>();
+  ASSERT_EQ(kokkos_arr, (Kokkos::Array{1, 2, 3}));
+
+  const std::array carr{1, 2, 3};
+  auto kokkos_carr = KokkosFFT::Impl::to_array(carr);
+  testing::StaticAssertTypeEq<decltype(kokkos_carr), Kokkos::Array<int, 3>>();
+  ASSERT_EQ(kokkos_carr, (Kokkos::Array{1, 2, 3}));
 }
 
 TEST(ToArray, rvalue) {
-  ASSERT_EQ(KokkosFFT::Impl::to_array(std::array{1, 2}), (Kokkos::Array{1, 2}));
+  auto kokkos_arr = KokkosFFT::Impl::to_array(std::array{1, 2, 3});
+  testing::StaticAssertTypeEq<decltype(kokkos_arr), Kokkos::Array<int, 3>>();
+  ASSERT_EQ(kokkos_arr, (Kokkos::Array{1, 2, 3}));
 }

--- a/common/unit_test/Test_Convert_Types.cpp
+++ b/common/unit_test/Test_Convert_Types.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 
 namespace {
 // Int like types

--- a/common/unit_test/Test_Normalization.cpp
+++ b/common/unit_test/Test_Normalization.cpp
@@ -5,10 +5,11 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
-#include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
+
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_Normalization.hpp"
+#include "KokkosFFT_Traits.hpp"
 #include "Test_Utils.hpp"
 
 namespace {

--- a/fft/src/KokkosFFT.hpp
+++ b/fft/src/KokkosFFT.hpp
@@ -5,11 +5,11 @@
 #ifndef KOKKOSFFT_HPP
 #define KOKKOSFFT_HPP
 
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_default_types.hpp"
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_DynPlans.hpp"
 #include "KokkosFFT_Helpers.hpp"
 #include "KokkosFFT_Plans.hpp"
-#include "KokkosFFT_DynPlans.hpp"
 #include "KokkosFFT_Transform.hpp"
 
 #endif

--- a/fft/src/KokkosFFT_Cuda_plans.hpp
+++ b/fft/src/KokkosFFT_Cuda_plans.hpp
@@ -10,10 +10,10 @@
 
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Cuda_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/fft/src/KokkosFFT_DynPlans.hpp
+++ b/fft/src/KokkosFFT_DynPlans.hpp
@@ -12,13 +12,15 @@
 #define KOKKOSFFT_DYNPLANS_HPP
 
 #include <algorithm>
+
 #include <Kokkos_Core.hpp>
+
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_CheckConditions.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Normalization.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_CUFFT)
 #include "KokkosFFT_Cuda_plans.hpp"

--- a/fft/src/KokkosFFT_FFTW_Types.hpp
+++ b/fft/src/KokkosFFT_FFTW_Types.hpp
@@ -9,7 +9,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_Common_Types.hpp"
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 
 // Check the size of complex type
 static_assert(sizeof(fftwf_complex) == sizeof(Kokkos::complex<float>));

--- a/fft/src/KokkosFFT_Host_plans.hpp
+++ b/fft/src/KokkosFFT_Host_plans.hpp
@@ -11,10 +11,10 @@
 
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/fft/src/KokkosFFT_Plans.hpp
+++ b/fft/src/KokkosFFT_Plans.hpp
@@ -20,6 +20,7 @@
 #include "KokkosFFT_CheckConditions.hpp"
 #include "KokkosFFT_Common_Types.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_default_types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
@@ -27,7 +28,6 @@
 #include "KokkosFFT_Padding.hpp"
 #include "KokkosFFT_Traits.hpp"
 #include "KokkosFFT_Transpose.hpp"
-#include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_CUFFT)
 #include "KokkosFFT_Cuda_plans.hpp"

--- a/fft/src/KokkosFFT_ROCM_plans.hpp
+++ b/fft/src/KokkosFFT_ROCM_plans.hpp
@@ -11,10 +11,10 @@
 
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_ROCM_types.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/fft/src/KokkosFFT_ROCM_types.hpp
+++ b/fft/src/KokkosFFT_ROCM_types.hpp
@@ -8,15 +8,17 @@
 #include <numeric>
 #include <algorithm>
 #include <complex>
+
 #include <rocfft/rocfft.h>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 #include "KokkosFFT_Asserts.hpp"
-#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Common_Types.hpp"
-#include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
+#include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_ROCM_asserts.hpp"
+#include "KokkosFFT_Traits.hpp"
+
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"
 #endif

--- a/fft/src/KokkosFFT_SYCL_plans.hpp
+++ b/fft/src/KokkosFFT_SYCL_plans.hpp
@@ -16,10 +16,10 @@
 
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_SYCL_types.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 namespace Impl {

--- a/fft/src/KokkosFFT_SYCL_types.hpp
+++ b/fft/src/KokkosFFT_SYCL_types.hpp
@@ -16,8 +16,8 @@
 #include <Kokkos_Core.hpp>
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Common_Types.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 #if defined(KOKKOSFFT_ENABLE_TPL_FFTW)
 #include "KokkosFFT_FFTW_Types.hpp"

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -12,11 +12,11 @@
 #include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_CheckConditions.hpp"
 #include "KokkosFFT_Container_Helpers.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Extents.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_Plans.hpp"
 #include "KokkosFFT_Traits.hpp"
-#include "KokkosFFT_utils.hpp"
 
 namespace KokkosFFT {
 

--- a/fft/unit_test/Test_DynPlans.cpp
+++ b/fft/unit_test/Test_DynPlans.cpp
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 #include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-#include "KokkosFFT_utils.hpp"
+#include "KokkosFFT_Convert_Types.hpp"
+#include "KokkosFFT_DynPlans.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_Plans.hpp"
-#include "KokkosFFT_DynPlans.hpp"
 #include "KokkosFFT_Transform.hpp"
 #include "Test_Utils.hpp"
 


### PR DESCRIPTION
This PR aims at renaming `KokkosFFT_utils.hpp` to `KokkosFFT_Convert_Types.hpp`.

- [x] Rename `KokkosFFT_utils.hpp` to `KokkosFFT_Convert_Types.hpp`
- [x] Add docstrings to `to_array`
- [x] Allow to pass const array to lvalue `to_array` function
