### PR TITLE
Add rfft2/irfft2 example

### DIFF
--- a/docs/api/real/irfft2.rst
+++ b/docs/api/real/irfft2.rst
@@ -5,3 +5,24 @@
 KokkosFFT::irfft2
 -----------------
 .. doxygenfunction:: KokkosFFT::irfft2(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)
+
+
+.. note::
+
+   The input must be a complex-valued view, and the output must be a real-valued view. The input length along the transform axis (``axes[1]``) is ``n/2 + 1``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/real/docs_irfft2.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ 1 2 3 4
+ 5 6 7 8
+ 9 10 11 12

--- a/docs/api/real/irfft2.rst
+++ b/docs/api/real/irfft2.rst
@@ -14,6 +14,9 @@ KokkosFFT::irfft2
 Examples
 ========
 
+In this example, we use the 2D View with `LayoutRight` to avoid the internal transpose. 
+This allows `irfft2` to perform 2D FFT on the outermost dimension without transpose.
+
 .. literalinclude:: ../../../examples/docs/real/docs_irfft2.cpp
   :language: c++
   :linenos:

--- a/docs/api/real/rfft2.rst
+++ b/docs/api/real/rfft2.rst
@@ -14,6 +14,9 @@ KokkosFFT::rfft2
 Examples
 ========
 
+In this example, we use the 2D View with `LayoutRight` to avoid the internal transpose. 
+This allows `rfft2` to perform 2D FFT on the outermost dimension without transpose.
+
 .. literalinclude:: ../../../examples/docs/real/docs_rfft2.cpp
   :language: c++
   :linenos:

--- a/docs/api/real/rfft2.rst
+++ b/docs/api/real/rfft2.rst
@@ -6,3 +6,23 @@ KokkosFFT::rfft2
 ----------------
 
 .. doxygenfunction:: KokkosFFT::rfft2(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, axis_type<2> axes, shape_type<2> s)
+
+.. note::
+
+   The input must be a real-valued view, and the output must be a complex-valued view. The output length along the transform axis (``axes[1]``) is ``n/2 + 1``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/real/docs_rfft2.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (78,0) (-6,6) (-6,0)
+ (-24,13.8564) (0,0) (0,0)
+ (-24,-13.8564) (0,0) (0,0)

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -109,7 +109,7 @@ Real FFTs
      - `numpy.fft.irfft <https://numpy.org/doc/stable/reference/generated/numpy.fft.irfft.html>`_ 
    * - Two dimensional FFT for real input
      - :doc:`api/real/rfft2`
-     - `numpy.fft.rfft2 <https://numpy.org/doc/stable/reference/generated/numpy.fft.fft2.html>`_ 
+     - `numpy.fft.rfft2 <https://numpy.org/doc/stable/reference/generated/numpy.fft.rfft2.html>`_ 
    * - Inverse of :doc:`rfft2<api/real/rfft2>`
      - :doc:`api/real/irfft2`
      - `numpy.fft.irfft2 <https://numpy.org/doc/stable/reference/generated/numpy.fft.irfft2.html>`_ 

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -27,3 +27,9 @@ target_link_libraries(docs_rfft PUBLIC KokkosFFT::fft)
 
 add_executable(docs_irfft real/docs_irfft.cpp)
 target_link_libraries(docs_irfft PUBLIC KokkosFFT::fft)
+
+add_executable(docs_rfft2 real/docs_rfft2.cpp)
+target_link_libraries(docs_rfft2 PUBLIC KokkosFFT::fft)
+
+add_executable(docs_irfft2 real/docs_irfft2.cpp)
+target_link_libraries(docs_irfft2 PUBLIC KokkosFFT::fft)

--- a/examples/docs/real/docs_irfft2.cpp
+++ b/examples/docs/real/docs_irfft2.cpp
@@ -18,13 +18,13 @@ int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using View2D         = Kokkos::View<double**, ExecutionSpace>;
-  using ComplexView2D  = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
 
   const int n0 = 3, n1 = 4;
 
   ComplexView2D x_hat("x_hat", n0, n1 / 2 + 1);
   View2D x("x", n0, n1);
-  auto h_x_hat = Kokkos::create_mirror_view(x_hat);
+  auto h_x_hat  = Kokkos::create_mirror_view(x_hat);
   h_x_hat(0, 0) = Kokkos::complex<double>(78, 0);
   h_x_hat(0, 1) = Kokkos::complex<double>(-6, 6);
   h_x_hat(0, 2) = Kokkos::complex<double>(-6, 0);

--- a/examples/docs/real/docs_irfft2.cpp
+++ b/examples/docs/real/docs_irfft2.cpp
@@ -17,8 +17,9 @@
 int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-  using View2D         = Kokkos::View<double**, ExecutionSpace>;
-  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+  using View2D = Kokkos::View<double**, Kokkos::LayoutRight, ExecutionSpace>;
+  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**,
+                                     Kokkos::LayoutRight, ExecutionSpace>;
 
   const int n0 = 3, n1 = 4;
 

--- a/examples/docs/real/docs_irfft2.cpp
+++ b/examples/docs/real/docs_irfft2.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of irfft2 usage in documentation
+/// x_hat = [[78, -6+6j, -6],
+///          [-24+13.8564j, 0, 0],
+///          [-24-13.8564j, 0, 0]]
+/// x = [[1, 2, 3, 4],
+///      [5, 6, 7, 8],
+///      [9, 10, 11, 12]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View2D         = Kokkos::View<double**, ExecutionSpace>;
+  using ComplexView2D  = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+
+  const int n0 = 3, n1 = 4;
+
+  ComplexView2D x_hat("x_hat", n0, n1 / 2 + 1);
+  View2D x("x", n0, n1);
+  auto h_x_hat = Kokkos::create_mirror_view(x_hat);
+  h_x_hat(0, 0) = Kokkos::complex<double>(78, 0);
+  h_x_hat(0, 1) = Kokkos::complex<double>(-6, 6);
+  h_x_hat(0, 2) = Kokkos::complex<double>(-6, 0);
+  h_x_hat(1, 0) = Kokkos::complex<double>(-24, 13.8564);
+  h_x_hat(2, 0) = Kokkos::complex<double>(-24, -13.8564);
+  Kokkos::deep_copy(x_hat, h_x_hat);
+
+  ExecutionSpace exec;
+  KokkosFFT::irfft2(exec, x_hat, x);
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      std::cout << " " << h_x(i, j);
+    }
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/examples/docs/real/docs_rfft2.cpp
+++ b/examples/docs/real/docs_rfft2.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using View2D         = Kokkos::View<double**, ExecutionSpace>;
-  using ComplexView2D  = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
 
   const int n0 = 3, n1 = 4;
 

--- a/examples/docs/real/docs_rfft2.cpp
+++ b/examples/docs/real/docs_rfft2.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of rfft2 usage in documentation
+/// x = [[1, 2, 3, 4],
+///      [5, 6, 7, 8],
+///      [9, 10, 11, 12]]
+/// x_hat = [[78, -6+6j, -6],
+///          [-24+13.8564j, 0, 0],
+///          [-24-13.8564j, 0, 0]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View2D         = Kokkos::View<double**, ExecutionSpace>;
+  using ComplexView2D  = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+
+  const int n0 = 3, n1 = 4;
+
+  View2D x("x", n0, n1);
+  ComplexView2D x_hat("x_hat", n0, n1 / 2 + 1);
+  auto h_x = Kokkos::create_mirror_view(x);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      h_x(i, j) = i * n1 + j + 1;
+    }
+  }
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::rfft2(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1 / 2 + 1; ++j) {
+      std::cout << " " << h_x_hat(i, j);
+    }
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/examples/docs/real/docs_rfft2.cpp
+++ b/examples/docs/real/docs_rfft2.cpp
@@ -17,8 +17,9 @@
 int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-  using View2D         = Kokkos::View<double**, ExecutionSpace>;
-  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**, ExecutionSpace>;
+  using View2D = Kokkos::View<double**, Kokkos::LayoutRight, ExecutionSpace>;
+  using ComplexView2D = Kokkos::View<Kokkos::complex<double>**,
+                                     Kokkos::LayoutRight, ExecutionSpace>;
 
   const int n0 = 3, n1 = 4;
 


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_rfft2.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_irfft2.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.
- [x] Fix numpy docs link to `rfft2`
