### PR TITLE
Add rfftn/irfftn example

### DIFF
--- a/docs/api/real/irfftn.rst
+++ b/docs/api/real/irfftn.rst
@@ -6,4 +6,31 @@ KokkosFFT::irfftn
 -----------------
 
 .. doxygenfunction:: KokkosFFT::irfftn(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)
-   
+
+.. note::
+
+   The input must be a complex-valued view, and the output must be a real-valued view. The input length along the transform axis (``axes[DIM-1]``) is ``n/2 + 1``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+
+Examples
+========
+
+In this example, we use the 3D View with `LayoutRight` to avoid the internal transpose. 
+This allows `irfftn` to perform 3-dimensional inverse FFT on the outermost dimension without transpose.
+
+.. literalinclude:: ../../../examples/docs/real/docs_irfftn.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ 1 2
+ 3 4
+
+ 5 6
+ 7 8
+
+ 9 10
+ 11 12

--- a/docs/api/real/rfftn.rst
+++ b/docs/api/real/rfftn.rst
@@ -6,3 +6,31 @@ KokkosFFT::rfftn
 ----------------
 
 .. doxygenfunction:: KokkosFFT::rfftn(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, axis_type<DIM> axes, KokkosFFT::Normalization, shape_type<DIM> s)
+
+.. note::
+
+   The input must be a real-valued view, and the output must be a complex-valued view. The output length along the transform axis (``axes[DIM-1]``) is ``n/2 + 1``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+
+Examples
+========
+
+In this example, we use the 3D View with `LayoutRight` to avoid the internal transpose. 
+This allows `rfftn` to perform 3-dimensional FFT on the outermost dimension without transpose.
+
+.. literalinclude:: ../../../examples/docs/real/docs_rfftn.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (78,0) (-6,0)
+ (-12,0) (0,0)
+
+ (-24,13.8564) (0,0)
+ (0,0) (0,0)
+
+ (-24,-13.8564) (0,0)
+ (0,0) (0,0)

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -33,3 +33,9 @@ target_link_libraries(docs_rfft2 PUBLIC KokkosFFT::fft)
 
 add_executable(docs_irfft2 real/docs_irfft2.cpp)
 target_link_libraries(docs_irfft2 PUBLIC KokkosFFT::fft)
+
+add_executable(docs_rfftn real/docs_rfftn.cpp)
+target_link_libraries(docs_rfftn PUBLIC KokkosFFT::fft)
+
+add_executable(docs_irfftn real/docs_irfftn.cpp)
+target_link_libraries(docs_irfftn PUBLIC KokkosFFT::fft)

--- a/examples/docs/real/docs_irfftn.cpp
+++ b/examples/docs/real/docs_irfftn.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
 
   ComplexView3D x_hat("x_hat", n0, n1, n2 / 2 + 1);
   View3D x("x", n0, n1, n2);
-  auto h_x_hat  = Kokkos::create_mirror_view(x_hat);
+  auto h_x_hat     = Kokkos::create_mirror_view(x_hat);
   h_x_hat(0, 0, 0) = Kokkos::complex<double>(78, 0);
   h_x_hat(0, 0, 1) = Kokkos::complex<double>(-6, 0);
   h_x_hat(0, 1, 0) = Kokkos::complex<double>(-12, 0);

--- a/examples/docs/real/docs_irfftn.cpp
+++ b/examples/docs/real/docs_irfftn.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of irfftn usage in documentation
+/// x_hat = [[[78, -6j],
+///           [-12, 0]],
+///          [[-24+13.8564j, 0],
+///           [0, 0]],
+///          [[-24-13.8564j, 0],
+///           [0, 0]]]
+/// x = [[[1, 2],
+///       [3, 4]],
+///      [[5, 6],
+///       [7, 8]],
+///      [[9, 10],
+///       [11, 12]]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View3D = Kokkos::View<double***, Kokkos::LayoutRight, ExecutionSpace>;
+  using ComplexView3D = Kokkos::View<Kokkos::complex<double>***,
+                                     Kokkos::LayoutRight, ExecutionSpace>;
+
+  const int n0 = 3, n1 = 2, n2 = 2;
+
+  ComplexView3D x_hat("x_hat", n0, n1, n2 / 2 + 1);
+  View3D x("x", n0, n1, n2);
+  auto h_x_hat  = Kokkos::create_mirror_view(x_hat);
+  h_x_hat(0, 0, 0) = Kokkos::complex<double>(78, 0);
+  h_x_hat(0, 0, 1) = Kokkos::complex<double>(-6, 0);
+  h_x_hat(0, 1, 0) = Kokkos::complex<double>(-12, 0);
+  h_x_hat(1, 0, 0) = Kokkos::complex<double>(-24, 13.8564);
+  h_x_hat(2, 0, 0) = Kokkos::complex<double>(-24, -13.8564);
+  Kokkos::deep_copy(x_hat, h_x_hat);
+
+  ExecutionSpace exec;
+  KokkosFFT::irfftn(exec, x_hat, x);
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2; ++k) {
+        std::cout << " " << h_x(i, j, k);
+      }
+      std::cout << std::endl;
+    }
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/examples/docs/real/docs_irfftn.cpp
+++ b/examples/docs/real/docs_irfftn.cpp
@@ -8,7 +8,7 @@
 #include <KokkosFFT.hpp>
 
 /// \brief Example of irfftn usage in documentation
-/// x_hat = [[[78, -6j],
+/// x_hat = [[[78, -6],
 ///           [-12, 0]],
 ///          [[-24+13.8564j, 0],
 ///           [0, 0]],

--- a/examples/docs/real/docs_rfftn.cpp
+++ b/examples/docs/real/docs_rfftn.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of rfftn usage in documentation
+/// x = [[[1, 2],
+///       [3, 4]],
+///      [[5, 6],
+///       [7, 8]],
+///      [[9, 10],
+///       [11, 12]]]
+/// x_hat = [[[78, -6],
+///           [-12, 0]],
+///          [[-24+13.8564j, 0],
+///           [0, 0]],
+///          [[-24-13.8564j, 0],
+///           [0, 0]]]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View3D = Kokkos::View<double***, Kokkos::LayoutRight, ExecutionSpace>;
+  using ComplexView3D = Kokkos::View<Kokkos::complex<double>***,
+                                     Kokkos::LayoutRight, ExecutionSpace>;
+
+  const int n0 = 3, n1 = 2, n2 = 2;
+
+  View3D x("x", n0, n1, n2);
+  ComplexView3D x_hat("x_hat", n0, n1, n2 / 2 + 1);
+  auto h_x = Kokkos::create_mirror_view(x);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2; ++k) {
+        h_x(i, j, k) = i * n1 * n2 + j * n2 + k + 1;
+      }
+    }
+  }
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::rfftn(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < n0; ++i) {
+    for (int j = 0; j < n1; ++j) {
+      for (int k = 0; k < n2 / 2 + 1; ++k) {
+        std::cout << " " << h_x_hat(i, j, k);
+      }
+      std::cout << std::endl;
+    }
+    std::cout << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_rfftn.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_irfftn.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.

