### PR TITLE
Relax cufft exec to directly take cuFFT handle

### DIFF
--- a/fft/src/KokkosFFT_Cuda_transform.hpp
+++ b/fft/src/KokkosFFT_Cuda_transform.hpp
@@ -19,7 +19,11 @@ inline void exec_plan(const PlanType& scoped_plan, cufftReal* idata,
                       cufftComplex* odata, int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecR2C]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecR2C(scoped_plan.plan(), idata, odata));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecR2C(scoped_plan, idata, odata));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecR2C(scoped_plan.plan(), idata, odata));
+  }
 }
 
 template <typename PlanType>
@@ -27,7 +31,11 @@ inline void exec_plan(const PlanType& scoped_plan, cufftDoubleReal* idata,
                       cufftDoubleComplex* odata, int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecD2Z]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecD2Z(scoped_plan.plan(), idata, odata));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecD2Z(scoped_plan, idata, odata));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecD2Z(scoped_plan.plan(), idata, odata));
+  }
 }
 
 template <typename PlanType>
@@ -35,7 +43,11 @@ inline void exec_plan(const PlanType& scoped_plan, cufftComplex* idata,
                       cufftReal* odata, int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecC2R]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecC2R(scoped_plan.plan(), idata, odata));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecC2R(scoped_plan, idata, odata));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecC2R(scoped_plan.plan(), idata, odata));
+  }
 }
 
 template <typename PlanType>
@@ -43,7 +55,11 @@ inline void exec_plan(const PlanType& scoped_plan, cufftDoubleComplex* idata,
                       cufftDoubleReal* odata, int /*direction*/) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecZ2D]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecZ2D(scoped_plan.plan(), idata, odata));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecZ2D(scoped_plan, idata, odata));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(cufftExecZ2D(scoped_plan.plan(), idata, odata));
+  }
 }
 
 template <typename PlanType>
@@ -51,8 +67,13 @@ inline void exec_plan(const PlanType& scoped_plan, cufftComplex* idata,
                       cufftComplex* odata, int direction) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecC2C]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(
-      cufftExecC2C(scoped_plan.plan(), idata, odata, direction));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(
+        cufftExecC2C(scoped_plan, idata, odata, direction));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(
+        cufftExecC2C(scoped_plan.plan(), idata, odata, direction));
+  }
 }
 
 template <typename PlanType>
@@ -60,8 +81,13 @@ inline void exec_plan(const PlanType& scoped_plan, cufftDoubleComplex* idata,
                       cufftDoubleComplex* odata, int direction) {
   Kokkos::Profiling::ScopedRegion region(
       "KokkosFFT::exec_plan[TPL_cufftExecZ2Z]");
-  KOKKOSFFT_CHECK_CUFFT_CALL(
-      cufftExecZ2Z(scoped_plan.plan(), idata, odata, direction));
+  if constexpr (std::is_same_v<PlanType, cufftHandle>) {
+    KOKKOSFFT_CHECK_CUFFT_CALL(
+        cufftExecZ2Z(scoped_plan, idata, odata, direction));
+  } else {
+    KOKKOSFFT_CHECK_CUFFT_CALL(
+        cufftExecZ2Z(scoped_plan.plan(), idata, odata, direction));
+  }
 }
 }  // namespace Impl
 }  // namespace KokkosFFT


### PR DESCRIPTION
To support cuFFTMp + nvshmem, we would like to call `KokkosFFT::Impl::exec_plan` directly with cuFFT handle. 
If direction is `forward`, it returns internal forward plan.

```C++
  cufftHandle plan(
      [[maybe_unused]] KokkosFFT::Direction direction) const noexcept {
    if constexpr (KokkosFFT::Impl::is_real_v<T1>) {
      return direction == KokkosFFT::Direction::forward ? m_plan_f : m_plan_b;
    } else {
      return m_plan_f;
    }
  }
```

```C++
  auto in_buffer = scoped_plan.template buffer_data<InRightViewType>(in_extents);
  auto out_buffer = scoped_plan.template buffer_data<OutRightViewType>(out_extents);

  KokkosFFT::Impl::transpose(exec_space, in, in_buffer, in_map, true);
  {
    auto* idata = reinterpret_cast<
        typename KokkosFFT::Impl::fft_data_type<ExecutionSpace, in_value_type>::type*>(
        in_buffer.data());
    auto* odata = reinterpret_cast<
        typename KokkosFFT::Impl::fft_data_type<ExecutionSpace, out_value_type>::type*>(
        out_buffer.data());
    const auto dir = KokkosFFT::Impl::direction_type<ExecutionSpace>(direction);
    KokkosFFT::Impl::exec_plan(scoped_plan.plan(direction), idata, odata, dir);
  }
  KokkosFFT::Impl::transpose(exec_space, out_buffer, out, out_map, true);
```