### PR TITLE
Add nightly CI on ruche

### DIFF
--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -5,6 +5,7 @@
 name: Nightly CEA builds
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "15 0 * * 1-5" # every weekday at midnight UTC
 

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -6,7 +6,7 @@ name: Nightly CEA builds
 
 on:
   schedule:
-    - cron: "0 0 * * 1-5" # every weekday at midnight UTC
+    - cron: "15 0 * * 1-5" # every weekday at midnight UTC
 
 permissions: read-all
 
@@ -43,13 +43,13 @@ jobs:
           run \
             -m "${{ matrix.backend.modules }}" \
             -e local \
-            cmake -S kokkos -B kokkos_build \
+            bash -lc 'cmake -S kokkos -B kokkos_build \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
               -DCMAKE_INSTALL_PREFIX=kokkos_install \
               ${{ matrix.backend.kokkos_configure }} && \
             cmake --build kokkos_build --parallel && \
-            cmake --install kokkos_build
+            cmake --install kokkos_build'
 
       - name: Initialize the build tree
         # note: BUILDNAME sets the name of the build on the Dashboard

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 name: Nightly CEA builds
 
 on:

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -40,13 +40,16 @@ jobs:
       - name: Install Kokkos
         run: |
           git clone https://github.com/kokkos/kokkos.git && \
-          cmake -S kokkos -B kokkos_build \
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e local \
+            cmake -S kokkos -B kokkos_build \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
               -DCMAKE_INSTALL_PREFIX=kokkos_install \
               ${{ matrix.backend.kokkos_configure }} && \
-          cmake --build kokkos_build --parallel && \
-          cmake --install kokkos_build
+            cmake --build kokkos_build --parallel && \
+            cmake --install kokkos_build
 
       - name: Initialize the build tree
         # note: BUILDNAME sets the name of the build on the Dashboard

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -26,7 +26,7 @@ jobs:
         backend:
           - name: CUDA-A100-GCC/13.4.0-CUDA/12.8.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
             kokkos_configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
-            kokkosFFT_configure: -DKokkosFFT_ENABLE_EXAMPLES=ON -DKokkosFFT_ENABLE_BENCHMARKS=ON -DKokkosFFT_ENABLE_TESTS=ON
+            kokkosFFT_configure: -DKokkosFFT_ENABLE_EXAMPLES=ON -DKokkosFFT_ENABLE_BENCHMARK=ON -DKokkosFFT_ENABLE_TESTS=ON
             test: -e gpu -g a100
             modules: gcc/13.4.0/gcc-15.1.0 cuda/12.8.1/none-none cmake/3.31.9/gcc-15.1.0 python/3.14.0/gcc-15.1.0
 

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -63,7 +63,7 @@ jobs:
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
               -DKokkos_DIR=kokkos_install/lib/cmake/Kokkos/ \
-              ${{ matrix.backend.kokkosFFT_configure }} 
+              ${{ matrix.backend.kokkosFFT_configure }}
 
       - name: Start, update and configure
         id: start_update_configure
@@ -113,7 +113,7 @@ jobs:
               --test-dir build \
               -D NightlySubmit
 
-      # note: this marks the job as failed if any of the mentionned steps (that
+      # note: this marks the job as failed if any of the mentioned steps (that
       # have `continue-on-error`) has failed
       - name: Failure outcome
         if: |-

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Kokkos
         run: |
-          git clone https://github.com/kokkos/kokkos.git && \
+          git clone --depth 1 https://github.com/kokkos/kokkos.git && \
           run \
             -m "${{ matrix.backend.modules }}" \
             -e local \

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -8,7 +8,8 @@ on:
   schedule:
     - cron: "15 0 * * 1-5" # every weekday at midnight UTC
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build_and_test:

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -1,0 +1,121 @@
+name: Nightly CEA builds
+
+on:
+  schedule:
+    - cron: "0 0 * * 1-5" # every weekday at midnight UTC
+
+permissions: read-all
+
+jobs:
+  build_and_test:
+    # only run on original repo
+    if: github.repository == 'kokkos/kokkos-fft'
+
+    strategy:
+      # allow all matrix jobs to perform even if errors occur
+      fail-fast: false
+      matrix:
+        build_type:
+          - Release
+        cxx_standard:
+          - 20
+        backend:
+          - name: CUDA-A100-GCC/13.4.0-CUDA/12.8.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
+            kokkos_configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
+            kokkosFFT_configure: -DKokkosFFT_ENABLE_EXAMPLES=ON -DKokkosFFT_ENABLE_BENCHMARKS=ON -DKokkosFFT_ENABLE_TESTS=ON
+            test: -e gpu -g a100
+            modules: gcc/13.4.0/gcc-15.1.0 cuda/12.8.1/none-none cmake/3.31.9/gcc-15.1.0 python/3.14.0/gcc-15.1.0
+
+    runs-on: [self-hosted, cuda]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Kokkos
+        run: |
+          git clone https://github.com/kokkos/kokkos.git && \
+          cmake -S kokkos -B kokkos_build \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+              -DCMAKE_INSTALL_PREFIX=kokkos_install \
+              ${{ matrix.backend.kokkos_configure }} && \
+          cmake --build kokkos_build --parallel && \
+          cmake --install kokkos_build
+
+      - name: Initialize the build tree
+        # note: BUILDNAME sets the name of the build on the Dashboard
+        # note: SITE sets the name of the site on the Dashboard
+        # note: run is a Ruche command
+        run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e local \
+            cmake \
+              -B build \
+              -DBUILDNAME=${{ matrix.backend.name }}-C++${{ matrix.cxx_standard }}-${{ matrix.build_type }} \
+              -DSITE=cea-ruche \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+              -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
+              -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
+              -DKokkos_DIR=kokkos_install/lib/cmake/Kokkos/ \
+              ${{ matrix.backend.kokkosFFT_configure }} 
+
+      - name: Start, update and configure
+        id: start_update_configure
+        continue-on-error: true
+        run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e local \
+            ctest \
+              -V \
+              --test-dir build \
+              -D NightlyStart \
+              -D NightlyUpdate \
+              -D NightlyConfigure
+
+      - name: Build
+        id: build
+        continue-on-error: true
+        run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e cpu \
+            CMAKE_BUILD_PARALLEL_LEVEL=40 \
+            ctest \
+              -V \
+              --test-dir build \
+              -D NightlyBuild
+
+      - name: Test
+        id: test
+        continue-on-error: true
+        run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            ${{ matrix.backend.test }} \
+            ctest \
+              --output-on-failure \
+              --test-dir build \
+              -D NightlyTest
+
+      - name: Submit
+        run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e local \
+            ctest \
+              --test-dir build \
+              -D NightlySubmit
+
+      # note: this marks the job as failed if any of the mentionned steps (that
+      # have `continue-on-error`) has failed
+      - name: Failure outcome
+        if: |-
+          ${{
+            steps.start_update_configure.outcome == 'failure' ||
+            steps.build.outcome == 'failure' ||
+            steps.test.outcome == 'failure'
+          }}
+        run: exit 1

--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
 
       - name: Install Kokkos
         run: |

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -4,5 +4,5 @@
 
 set(CTEST_PROJECT_NAME "Kokkos-FFT")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
-set(CTEST_SUBMIT_URL https://my.cdash.org/index.php?project=Kokkos-FFT)
+set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=Kokkos-FFT)
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
-set(CTEST_PROJECT_NAME Kokkos FFT)
-set(CTEST_NIGHTLY_START_TIME 01:00:00 UTC)
+set(CTEST_PROJECT_NAME "Kokkos-FFT")
+set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 set(CTEST_SUBMIT_URL https://my.cdash.org/index.php?project=Kokkos-FFT)
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 set(CTEST_PROJECT_NAME "Kokkos-FFT")
-set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 UTC")
 set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=Kokkos-FFT)
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_PROJECT_NAME Kokkos FFT)
+set(CTEST_NIGHTLY_START_TIME 01:00:00 UTC)
+set(CTEST_SUBMIT_URL https://my.cdash.org/index.php?project=Kokkos-FFT)
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
 set(CTEST_PROJECT_NAME Kokkos FFT)
 set(CTEST_NIGHTLY_START_TIME 01:00:00 UTC)
 set(CTEST_SUBMIT_URL https://my.cdash.org/index.php?project=Kokkos-FFT)


### PR DESCRIPTION
This PR aims at adding a nightly test on ruche which is reported on [CDASH](https://my.cdash.org/index.php?project=Kokkos-FFT)

- [x] Add a general configuration file: CTestConfig.cmake
- [x] Add a nightly CI as a workflow 