### PR TITLE
Add a const input API for hfft

### DIFF
--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -216,13 +216,17 @@ void irfft(const ExecutionSpace& exec_space, const InViewType& in,
 /// \tparam InViewType: Input View type for the fft
 /// \tparam OutViewType: Output View type for the fft
 ///
-/// \param exec_space [in] Kokkos execution space
-/// \param in [in] Input data (real or complex)
-/// \param out [out] Output data (real)
-/// \param norm [in] How the normalization is applied (default, backward)
-/// \param axis [in] Axis over which FFT is performed (default, -1)
-/// \param n [in] Length of the transformed axis of the output (default,
+/// \param[in] exec_space Kokkos execution space
+/// \param[in,out] in Input data (real or complex)
+/// \param[out] out Output data (real)
+/// \param[in] norm How the normalization is applied (default, backward)
+/// \param[in] axis Axis over which FFT is performed (default, -1)
+/// \param[in] n Length of the transformed axis of the output (default,
 /// nullopt)
+/// \details The input data is modified in-place to save memory (if the input is
+/// non-const complex). If the input is real or const complex, we create a
+/// temporary complex view to perform the computation, and the input data is not
+/// modified.
 template <typename ExecutionSpace, typename InViewType, typename OutViewType>
 void hfft(const ExecutionSpace& exec_space, const InViewType& in,
           const OutViewType& out,
@@ -248,7 +252,9 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
 
   if constexpr (KokkosFFT::Impl::is_real_v<in_value_type> ||
                 std::is_const_v<typename InViewType::value_type>) {
-    // Convert to complex type if input is real
+    // For real input or const complex input, we create a temporary complex view
+    // to perform the computation, and the input data is not modified. Convert
+    // to complex type if input is real
     using ComplexType =
         std::conditional_t<KokkosFFT::Impl::is_real_v<in_value_type>,
                            Kokkos::complex<in_value_type>, in_value_type>;
@@ -266,7 +272,7 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
     Kokkos::deep_copy(exec_space, cin, in);
     if constexpr (!KokkosFFT::Impl::is_real_v<in_value_type>) {
       if (cin.span() >= std::size_t(std::numeric_limits<int>::max())) {
-        KokkosFFT::Impl::md_unary_operation<int64_t>(
+        KokkosFFT::Impl::md_unary_operation<std::int64_t>(
             "KokkosFFT::conjugate", exec_space, cin,
             KokkosFFT::Impl::Conjugate());
       } else {
@@ -280,7 +286,7 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
     // For non-const complex input, we can perform the conjugation in-place and
     // save memory
     if (in.span() >= std::size_t(std::numeric_limits<int>::max())) {
-      KokkosFFT::Impl::md_unary_operation<int64_t>(
+      KokkosFFT::Impl::md_unary_operation<std::int64_t>(
           "KokkosFFT::conjugate", exec_space, in, KokkosFFT::Impl::Conjugate());
     } else {
       KokkosFFT::Impl::md_unary_operation<int>(

--- a/fft/src/KokkosFFT_Transform.hpp
+++ b/fft/src/KokkosFFT_Transform.hpp
@@ -246,9 +246,13 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
                      "axes are invalid for in/out views");
   auto new_norm = KokkosFFT::Impl::swap_direction(norm);
 
-  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type>) {
-    // Convert to complex type
-    using ComplexType = Kokkos::complex<in_value_type>;
+  if constexpr (KokkosFFT::Impl::is_real_v<in_value_type> ||
+                std::is_const_v<typename InViewType::value_type>) {
+    // Convert to complex type if input is real
+    using ComplexType =
+        std::conditional_t<KokkosFFT::Impl::is_real_v<in_value_type>,
+                           Kokkos::complex<in_value_type>, in_value_type>;
+
     using ComplexInViewType =
         typename KokkosFFT::Impl::ConvertedViewType<InViewType,
                                                     ComplexType>::type;
@@ -258,21 +262,31 @@ void hfft(const ExecutionSpace& exec_space, const InViewType& in,
     auto extents     = KokkosFFT::Impl::extract_extents(in);
     ManageableComplexInViewType cin(
         "cin", KokkosFFT::Impl::create_layout<LayoutType>(extents));
+
     Kokkos::deep_copy(exec_space, cin, in);
+    if constexpr (!KokkosFFT::Impl::is_real_v<in_value_type>) {
+      if (cin.span() >= std::size_t(std::numeric_limits<int>::max())) {
+        KokkosFFT::Impl::md_unary_operation<int64_t>(
+            "KokkosFFT::conjugate", exec_space, cin,
+            KokkosFFT::Impl::Conjugate());
+      } else {
+        KokkosFFT::Impl::md_unary_operation<int>("KokkosFFT::conjugate",
+                                                 exec_space, cin,
+                                                 KokkosFFT::Impl::Conjugate());
+      }
+    }
     irfft(exec_space, cin, out, new_norm, axis, n);
   } else {
-    InViewType in_conj("in_conj", in.layout());
-    Kokkos::deep_copy(exec_space, in_conj, in);
-    if (in_conj.span() >= std::size_t(std::numeric_limits<int>::max())) {
+    // For non-const complex input, we can perform the conjugation in-place and
+    // save memory
+    if (in.span() >= std::size_t(std::numeric_limits<int>::max())) {
       KokkosFFT::Impl::md_unary_operation<int64_t>(
-          "KokkosFFT::conjugate", exec_space, in_conj,
-          KokkosFFT::Impl::Conjugate());
+          "KokkosFFT::conjugate", exec_space, in, KokkosFFT::Impl::Conjugate());
     } else {
-      KokkosFFT::Impl::md_unary_operation<int>("KokkosFFT::conjugate",
-                                               exec_space, in_conj,
-                                               KokkosFFT::Impl::Conjugate());
+      KokkosFFT::Impl::md_unary_operation<int>(
+          "KokkosFFT::conjugate", exec_space, in, KokkosFFT::Impl::Conjugate());
     }
-    irfft(exec_space, in_conj, out, new_norm, axis, n);
+    irfft(exec_space, in, out, new_norm, axis, n);
   }
 }
 

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -453,15 +453,16 @@ void test_fft1_1dhfft_1dview() {
   ConstComplexView1DType x_herm_const = x_herm;
 
   // Check if the input is unchanged
+  T eps = std::numeric_limits<T>::epsilon() * 10;
   KokkosFFT::hfft(exec, x_herm_const, out);
-  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, eps, eps));
   KokkosFFT::hfft(exec, x_herm_const, out_b,
                   KokkosFFT::Normalization::backward);
-  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, eps, eps));
   KokkosFFT::hfft(exec, x_herm_const, out_o, KokkosFFT::Normalization::ortho);
-  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, eps, eps));
   KokkosFFT::hfft(exec, x_herm_const, out_f, KokkosFFT::Normalization::forward);
-  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, eps, eps));
 
   multiply(exec, out_o, Kokkos::sqrt(static_cast<T>(len)));
   multiply(exec, out_f, static_cast<T>(len));

--- a/fft/unit_test/Test_Transform.cpp
+++ b/fft/unit_test/Test_Transform.cpp
@@ -391,6 +391,8 @@ void test_fft1_1dhfft_1dview() {
   using RealView1DType = Kokkos::View<T*, LayoutType, execution_space>;
   using ComplexView1DType =
       Kokkos::View<Kokkos::complex<T>*, LayoutType, execution_space>;
+  using ConstComplexView1DType =
+      Kokkos::View<const Kokkos::complex<T>*, LayoutType, execution_space>;
 
   ComplexView1DType x_herm("x_herm", len_herm),
       x_herm_ref("x_herm_ref", len_herm);
@@ -445,10 +447,32 @@ void test_fft1_1dhfft_1dview() {
   Kokkos::deep_copy(ref_signal, h_ref_signal);
 
   KokkosFFT::fft(exec, x, ref);
-
   Kokkos::deep_copy(x_herm, x_herm_ref);
-  KokkosFFT::hfft(exec, x_herm,
-                  out);  // default: KokkosFFT::Normalization::backward
+
+  // Testing for const Views
+  ConstComplexView1DType x_herm_const = x_herm;
+
+  // Check if the input is unchanged
+  KokkosFFT::hfft(exec, x_herm_const, out);
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  KokkosFFT::hfft(exec, x_herm_const, out_b,
+                  KokkosFFT::Normalization::backward);
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  KokkosFFT::hfft(exec, x_herm_const, out_o, KokkosFFT::Normalization::ortho);
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+  KokkosFFT::hfft(exec, x_herm_const, out_f, KokkosFFT::Normalization::forward);
+  EXPECT_TRUE(allclose(exec, x_herm_const, x_herm_ref, 1.e-5, 1.e-6));
+
+  multiply(exec, out_o, Kokkos::sqrt(static_cast<T>(len)));
+  multiply(exec, out_f, static_cast<T>(len));
+
+  EXPECT_TRUE(allclose(exec, out, ref, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, out_b, out, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, out_o, out, 1.e-5, 1.e-6));
+  EXPECT_TRUE(allclose(exec, out_f, out, 1.e-5, 1.e-6));
+
+  // Testing for non-const Views, input can be overwritten
+  KokkosFFT::hfft(exec, x_herm, out);
 
   Kokkos::deep_copy(x_herm, x_herm_ref);
   KokkosFFT::hfft(exec, x_herm, out_b, KokkosFFT::Normalization::backward);


### PR DESCRIPTION
As an experiment, this PR introduces an API to ensure that input data is unchanged. 

- [x] Update `hfft` function to manipulate const Views. If the input data is const Views, it makes an internal buffer and does not touch the input Views.
- [x] Add an unit-test that `hfft` does not update the const input Views