### PR TITLE
[Distributed] Add topology helpers part 2

### DIFF
--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -5,7 +5,9 @@
 #ifndef KOKKOSFFT_DISTRIBUTED_TOPOLOGIES_HPP
 #define KOKKOSFFT_DISTRIBUTED_TOPOLOGIES_HPP
 
+#include <algorithm>
 #include <array>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -130,7 +130,7 @@ inline auto get_common_topology_type(const FirstTopology& first_topology,
 /// \param[in] out_topology The output topology.
 /// \return A tuple of two size_t representing the axes that are different
 /// \throws std::runtime_error if the input and output topologies do not have
-/// the same size
+/// the same size or if they are identical
 /// \throws std::runtime_error if the input and output topologies are not slab
 /// topologies
 template <typename iType, std::size_t DIM>
@@ -142,45 +142,23 @@ auto slab_in_out_axes(const std::array<iType, DIM>& in_topology,
   KOKKOSFFT_THROW_IF(in_size != out_size,
                      "Input and output topologies must have the same size.");
 
+  KOKKOSFFT_THROW_IF(in_topology == out_topology,
+                     "Input and output topologies must be different.");
+
   bool is_slab =
       are_specified_topologies(TopologyType::Slab, in_topology, out_topology);
   KOKKOSFFT_THROW_IF(!is_slab,
                      "Input and output topologies must be slab topologies.");
 
-  std::size_t in_axis = 0, out_axis = 0, num_differences = 0;
-  bool found_in_axis = false, found_out_axis = false;
+  std::size_t in_axis = 0, out_axis = 0;
   for (std::size_t i = 0; i < DIM; ++i) {
-    const auto in_value  = in_topology.at(i);
-    const auto out_value = out_topology.at(i);
-    if (in_value == out_value) continue;
-    ++num_differences;
-    if (in_value > 1 && out_value == 1) {
-      KOKKOSFFT_THROW_IF(found_out_axis,
-                         "Input and output slab topologies must differ in "
-                         "exactly one non-1 -> 1 axis.");
-      out_axis       = i;
-      found_out_axis = true;
-      continue;
+    if (in_topology.at(i) > 1 && out_topology.at(i) == 1) {
+      out_axis = i;
     }
-    if (in_value == 1 && out_value > 1) {
-      KOKKOSFFT_THROW_IF(found_in_axis,
-                         "Input and output slab topologies must differ in "
-                         "exactly one non-1 -> 1 axis.");
-      in_axis       = i;
-      found_in_axis = true;
-      continue;
+    if (in_topology.at(i) == 1 && out_topology.at(i) > 1) {
+      in_axis = i;
     }
-
-    KOKKOSFFT_THROW_IF(
-        true,
-        "Input and output slab topologies must differ only by 1 <-> non-1 "
-        "changes.");
   }
-
-  KOKKOSFFT_THROW_IF(
-      num_differences != 2 || !found_in_axis || !found_out_axis,
-      "Input and output slab topologies must differ in exactly two indices: "
-      "one 1 -> non-1 axis and one non-1 -> 1 axis.");
 
   return std::make_tuple(in_axis, out_axis);
 }

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -112,6 +112,316 @@ inline auto get_common_topology_type(const FirstTopology& first_topology,
   return has_mismatch ? TopologyType::Invalid : common_topology_type;
 }
 
+/// \brief Get the axes of the input and output slab topologies that are
+/// different
+/// Example
+/// (1, P) -> (P, 1): y-slab to x-slab
+/// (P, 1) -> (1, p): x-slab to y-slab
+/// (1, 1, P) -> (1, P, 1): z-slab to y-slab
+/// (P, 1, 1) -> (1, P, 1): x-slab to y-slab
+///
+/// \tparam iType The type of the index in the topology.
+/// \tparam DIM The number of dimensions of the topology.
+/// \param[in] in_topology The input topology.
+/// \param[in] out_topology The output topology.
+/// \return A tuple of two size_t representing the axes that are different
+/// \throws std::runtime_error if the input and output topologies do not have
+/// the same size
+/// \throws std::runtime_error if the input and output topologies are not slab
+/// topologies
+template <typename iType, std::size_t DIM>
+auto slab_in_out_axes(const std::array<iType, DIM>& in_topology,
+                      const std::array<iType, DIM>& out_topology) {
+  auto in_size  = KokkosFFT::Impl::total_size(in_topology);
+  auto out_size = KokkosFFT::Impl::total_size(out_topology);
+
+  KOKKOSFFT_THROW_IF(in_size != out_size,
+                     "Input and output topologies must have the same size.");
+
+  bool is_slab =
+      are_specified_topologies(TopologyType::Slab, in_topology, out_topology);
+  KOKKOSFFT_THROW_IF(!is_slab,
+                     "Input and output topologies must be slab topologies.");
+
+  std::size_t in_axis = 0, out_axis = 0;
+  for (std::size_t i = 0; i < DIM; ++i) {
+    if (in_topology.at(i) > 1 && out_topology.at(i) == 1) {
+      out_axis = i;
+    }
+    if (in_topology.at(i) == 1 && out_topology.at(i) > 1) {
+      in_axis = i;
+    }
+  }
+
+  return std::make_tuple(in_axis, out_axis);
+}
+
+/// \brief Get the axes of the input and output topologies that are different
+///
+/// Example
+/// (1, Px, Py, 1) -> (Px, 1, Py, 1): 0-pencil to 1-pencil
+/// (1, 1, P) -> (1, P, 1): 1-pencil to 2-pencil
+/// (P, 1, 1) -> (1, P, 1): 1-pencil to 0-pencil
+///
+/// \tparam iType The type of the index in the topology.
+/// \tparam DIM The number of dimensions of the topology.
+///
+/// \param[in] in_topology The input topology.
+/// \param[in] out_topology The output topology.
+/// \return A tuple of two size_t representing the axes that are different
+/// \throws std::runtime_error if the input and output topologies do not have
+/// at least one non-trivial dimension
+/// \throws std::runtime_error if the input and output topologies do not have
+/// the same size
+template <typename iType, std::size_t DIM>
+auto pencil_in_out_axes(const std::array<iType, DIM>& in_topology,
+                        const std::array<iType, DIM>& out_topology) {
+  // Extract topology that is common between in_topology and out_topology
+  auto in_size  = KokkosFFT::Impl::total_size(in_topology);
+  auto out_size = KokkosFFT::Impl::total_size(out_topology);
+
+  KOKKOSFFT_THROW_IF(in_size == 1 || out_size == 1,
+                     "Input and output topologies must have at least one "
+                     "non-trivial dimension.");
+
+  KOKKOSFFT_THROW_IF(in_size != out_size,
+                     "Input and output topologies must have the same size.");
+
+  std::size_t in_axis = 0, out_axis = 0;
+  for (std::size_t i = 0; i < DIM; ++i) {
+    if (in_topology.at(i) != out_topology.at(i)) {
+      if (in_topology.at(i) == 1) in_axis = i;
+      if (out_topology.at(i) == 1) out_axis = i;
+    }
+  }
+
+  return std::make_tuple(in_axis, out_axis);
+}
+
+/// \brief Get an intermediate topology by swapping two non-one elements
+///        between input and output topologies. Used to propose intermediate
+///        topology for slab/pencil decompositions if direct conversion is not
+///        possible.
+///
+/// \tparam iType The index type used for the topology.
+/// \tparam DIM The dimensionality of the topology.
+///
+/// \param[in] in The input topology.
+/// \param[in] out The output topology.
+/// \return An intermediate topology obtained by swapping two non-one elements.
+/// \throws std::runtime_error if the input and output topologies do not differ
+/// exactly three positions
+template <typename iType, std::size_t DIM>
+std::array<iType, DIM> propose_mid_array(const std::array<iType, DIM>& in,
+                                         const std::array<iType, DIM>& out) {
+  auto diff_indices         = extract_different_indices(in, out);
+  auto diff_value_set       = extract_different_value_set(in, out);
+  auto diff_non_one_indices = extract_non_one_indices(in, out);
+
+  KOKKOSFFT_THROW_IF(diff_non_one_indices.size() < 3,
+                     "The total number of non-one elements either in Input and "
+                     "output topologies must be three.");
+  KOKKOSFFT_THROW_IF(
+      diff_indices.size() < 3 && diff_value_set.size() == 3,
+      "Input and output topologies must differ exactly three positions.");
+
+  // Only copy the exchangeable indices from original arrays in and out
+  std::array<iType, DIM> in_trimmed{}, out_trimmed{};
+  for (auto diff_idx : diff_indices) {
+    in_trimmed.at(diff_idx)  = in.at(diff_idx);
+    out_trimmed.at(diff_idx) = out.at(diff_idx);
+  }
+
+  iType idx_one_in  = KokkosFFT::Impl::get_index(in_trimmed, iType(1));
+  iType idx_one_out = KokkosFFT::Impl::get_index(out_trimmed, iType(1));
+
+  // Try all combinations of 2 indices for a single valid swap
+  for (size_t i = 0; i < diff_non_one_indices.size(); ++i) {
+    for (size_t j = i + 1; j < diff_non_one_indices.size(); ++j) {
+      iType idx_in  = diff_non_one_indices.at(i);
+      iType idx_out = diff_non_one_indices.at(j);
+
+      std::array<iType, DIM> mid = swap_elements(in, idx_in, idx_out);
+      iType idx_one_mid          = KokkosFFT::Impl::get_index(mid, iType(1));
+
+      auto mid_in_diff_indices  = extract_different_indices(mid, in);
+      auto mid_out_diff_indices = extract_different_indices(mid, out);
+      if ((mid_in_diff_indices.size() == 2) &&
+          (mid_out_diff_indices.size() == 2) &&
+          !(idx_one_mid == idx_one_in || idx_one_mid == idx_one_out)) {
+        // Do not allow exchange two non-one elements
+        auto mid_in_diff0  = mid.at(mid_in_diff_indices.at(0));
+        auto mid_in_diff1  = mid.at(mid_in_diff_indices.at(1));
+        auto mid_out_diff0 = mid.at(mid_out_diff_indices.at(0));
+        auto mid_out_diff1 = mid.at(mid_out_diff_indices.at(1));
+        if ((mid_in_diff0 == 1 || mid_in_diff1 == 1) &&
+            (mid_out_diff0 == 1 || mid_out_diff1 == 1)) {
+          return mid;
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+/// \brief Decompose the FFT axes into vectors
+///        The first vector includes the axes for FFT without transpose
+///        The second vector includes the axes for FFT after transpose
+///        The third vector includes the axes for remaining FFT
+///
+/// \tparam iType The index type used for the topology.
+/// \tparam DIM The dimensionality of the topology.
+/// \tparam FFT_DIM The dimensionality of the FFT axes.
+///
+/// \param[in] topologies The vector of topologies.
+/// \param[in] axes The axes along which the FFT is performed.
+/// \return A vector of vectors of axes.
+/// \throws std::runtime_error if the total size of decomposed axes does not
+/// match the original axes size
+template <typename iType, std::size_t DIM, std::size_t FFT_DIM>
+std::vector<std::vector<iType>> decompose_axes(
+    const std::vector<std::array<std::size_t, DIM>>& topologies,
+    const std::array<iType, FFT_DIM>& axes) {
+  auto non_negative_axes = KokkosFFT::Impl::convert_base_int_type<std::size_t>(
+      KokkosFFT::Impl::convert_negative_axes(axes, DIM));
+
+  // Reverse the axes e.g. {0, 2, 1} -> {1, 2, 0}
+  std::vector<std::size_t> axes_reversed =
+      KokkosFFT::Impl::reversed(KokkosFFT::Impl::to_vector(non_negative_axes));
+
+  std::vector<std::vector<iType>> all_axes{};
+  for (auto topology : topologies) {
+    std::vector<iType> ready_axes;
+    for (auto axis : axes_reversed) {
+      if (topology.at(axis) > 1) break;
+      ready_axes.push_back(axis);
+    }
+    // We need to reverse the axes again
+    // i.e. {1, 2} -> {2, 1}
+    all_axes.push_back(KokkosFFT::Impl::reversed(ready_axes));
+
+    // Remove already registered axes
+    for (auto axis : ready_axes) {
+      auto it = std::find(axes_reversed.begin(), axes_reversed.end(), axis);
+      if (it != axes_reversed.end()) {
+        axes_reversed.erase(it);
+      }
+    }
+  }
+
+  auto error_msg = [&axes, &all_axes,
+                    &topologies](std::string_view details) -> std::string {
+    std::string msg(details);
+    msg += " Input axes: ";
+    for (auto axis : axes) {
+      msg += std::to_string(axis) + " ";
+    }
+    msg += "\n";
+    msg += "Decomposed axes: \n";
+    for (std::size_t i = 0; i < all_axes.size(); ++i) {
+      auto topology = topologies.at(i);
+      msg += "at topology (";
+      msg += std::to_string(topology.at(0));
+      for (std::size_t j = 1; j < topology.size(); ++j) {
+        msg += ", " + std::to_string(topology.at(j));
+      }
+      msg += "): Ready axes: ";
+      if (all_axes.at(i).empty()) {
+        msg += "None";
+      } else {
+        auto axis = all_axes.at(i);
+        msg += "(";
+        msg += std::to_string(axis.at(0));
+        for (std::size_t j = 1; j < axis.size(); ++j) {
+          msg += ", " + std::to_string(axis.at(j));
+        }
+        msg += ")";
+      }
+      msg += "\n";
+    }
+    return msg;
+  };
+
+  std::size_t total_axes = 0;
+  for (auto ready_axes : all_axes) {
+    total_axes += ready_axes.size();
+  }
+
+  KOKKOSFFT_THROW_IF(total_axes != axes.size(),
+                     error_msg("Axes are not decomposed correctly:"));
+
+  return all_axes;
+}
+
+/// \brief Compute the axis to transpose to convert one topology to another
+/// Example
+/// (1, Px, Py, 1) -> (Px, 1, Py, 1). Transpose axis is Px (0)
+/// (1, Px, Py, 1) -> (1, Px, 1, Py). Transpose axis is Py (1)
+///
+/// \tparam iType The index type
+/// \tparam DIM The dimension
+///
+/// \param[in] in_topology The input topology
+/// \param[in] out_topology The output topology
+/// \param[in] first_non_one The first non-one element in the input or output
+/// \return The axis to transpose (0 or 1)
+/// \throws std::runtime_error if the input and output topologies do not have
+/// exactly two non-one elements
+/// \throws std::runtime_error if the input and output topologies have identical
+/// non-one elements
+/// \throws std::runtime_error if the input and output topologies differ exactly
+/// two positions
+template <typename iType, std::size_t DIM>
+auto compute_trans_axis(const std::array<iType, DIM>& in_topology,
+                        const std::array<iType, DIM>& out_topology,
+                        iType first_non_one) {
+  auto in_non_ones  = extract_non_one_values(in_topology);
+  auto out_non_ones = extract_non_one_values(out_topology);
+
+  auto error_msg = [&in_topology,
+                    &out_topology](std::string_view details) -> std::string {
+    std::string message(details);
+    message += "in_topology (";
+    message += std::to_string(in_topology.at(0));
+    for (std::size_t r = 1; r < in_topology.size(); r++) {
+      message += ",";
+      message += std::to_string(in_topology.at(r));
+    }
+    message += "), ";
+    message += "out_topology (";
+    message += std::to_string(out_topology.at(0));
+    for (std::size_t r = 1; r < out_topology.size(); r++) {
+      message += ",";
+      message += std::to_string(out_topology.at(r));
+    }
+    message += ")";
+    return message;
+  };
+
+  KOKKOSFFT_THROW_IF(in_non_ones.size() != 2 || out_non_ones.size() != 2,
+                     error_msg("Input and output topologies must have exactly "
+                               "two non-one elements."));
+  KOKKOSFFT_THROW_IF(has_identical_non_ones(in_non_ones) ||
+                         has_identical_non_ones(out_non_ones),
+                     error_msg("Input and output topologies must not have "
+                               "identical non-one elements."));
+  auto diff_indices = extract_different_indices(in_topology, out_topology);
+  KOKKOSFFT_THROW_IF(
+      diff_indices.size() != 2,
+      error_msg(
+          "Input and output topologies must differ exactly two positions"));
+  iType exchange_non_one = 0;
+  for (auto diff_idx : diff_indices) {
+    if (in_topology.at(diff_idx) > 1) {
+      exchange_non_one = in_topology.at(diff_idx);
+      break;
+    }
+  }
+  iType trans_axis = !(exchange_non_one == first_non_one);
+  return trans_axis;
+}
+
 }  // namespace Impl
 }  // namespace Distributed
 }  // namespace KokkosFFT

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -5,7 +5,11 @@
 #ifndef KOKKOSFFT_DISTRIBUTED_TOPOLOGIES_HPP
 #define KOKKOSFFT_DISTRIBUTED_TOPOLOGIES_HPP
 
+#include <array>
+#include <tuple>
 #include <type_traits>
+#include <vector>
+#include <KokkosFFT.hpp>
 #include "KokkosFFT_Distributed_Types.hpp"
 #include "KokkosFFT_Distributed_ContainerAnalyses.hpp"
 
@@ -171,8 +175,8 @@ auto slab_in_out_axes(const std::array<iType, DIM>& in_topology,
 /// \return A tuple of two size_t representing the axes that are different
 /// \throws std::runtime_error if the input and output topologies do not have
 /// at least one non-trivial dimension
-/// \throws std::runtime_error if the input and output topologies do not have
-/// the same size
+/// \throws std::runtime_error if the input and output topologies are not pencil
+/// topologies
 template <typename iType, std::size_t DIM>
 auto pencil_in_out_axes(const std::array<iType, DIM>& in_topology,
                         const std::array<iType, DIM>& out_topology) {
@@ -180,12 +184,13 @@ auto pencil_in_out_axes(const std::array<iType, DIM>& in_topology,
   auto in_size  = KokkosFFT::Impl::total_size(in_topology);
   auto out_size = KokkosFFT::Impl::total_size(out_topology);
 
-  KOKKOSFFT_THROW_IF(in_size == 1 || out_size == 1,
-                     "Input and output topologies must have at least one "
-                     "non-trivial dimension.");
-
   KOKKOSFFT_THROW_IF(in_size != out_size,
                      "Input and output topologies must have the same size.");
+
+  bool is_pencil =
+      are_specified_topologies(TopologyType::Pencil, in_topology, out_topology);
+  KOKKOSFFT_THROW_IF(!is_pencil,
+                     "Input and output topologies must be pencil topologies.");
 
   std::size_t in_axis = 0, out_axis = 0;
   for (std::size_t i = 0; i < DIM; ++i) {
@@ -370,8 +375,8 @@ std::vector<std::vector<iType>> decompose_axes(
 /// exactly two non-one elements
 /// \throws std::runtime_error if the input and output topologies have identical
 /// non-one elements
-/// \throws std::runtime_error if the input and output topologies differ exactly
-/// two positions
+/// \throws std::runtime_error if the input and output topologies do not differ
+/// in exactly two positions
 template <typename iType, std::size_t DIM>
 auto compute_trans_axis(const std::array<iType, DIM>& in_topology,
                         const std::array<iType, DIM>& out_topology,

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <type_traits>

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -147,15 +147,40 @@ auto slab_in_out_axes(const std::array<iType, DIM>& in_topology,
   KOKKOSFFT_THROW_IF(!is_slab,
                      "Input and output topologies must be slab topologies.");
 
-  std::size_t in_axis = 0, out_axis = 0;
+  std::size_t in_axis = 0, out_axis = 0, num_differences = 0;
+  bool found_in_axis = false, found_out_axis = false;
   for (std::size_t i = 0; i < DIM; ++i) {
-    if (in_topology.at(i) > 1 && out_topology.at(i) == 1) {
-      out_axis = i;
+    const auto in_value  = in_topology.at(i);
+    const auto out_value = out_topology.at(i);
+    if (in_value == out_value) continue;
+    ++num_differences;
+    if (in_value > 1 && out_value == 1) {
+      KOKKOSFFT_THROW_IF(found_out_axis,
+                         "Input and output slab topologies must differ in "
+                         "exactly one non-1 -> 1 axis.");
+      out_axis       = i;
+      found_out_axis = true;
+      continue;
     }
-    if (in_topology.at(i) == 1 && out_topology.at(i) > 1) {
-      in_axis = i;
+    if (in_value == 1 && out_value > 1) {
+      KOKKOSFFT_THROW_IF(found_in_axis,
+                         "Input and output slab topologies must differ in "
+                         "exactly one non-1 -> 1 axis.");
+      in_axis       = i;
+      found_in_axis = true;
+      continue;
     }
+
+    KOKKOSFFT_THROW_IF(
+        true,
+        "Input and output slab topologies must differ only by 1 <-> non-1 "
+        "changes.");
   }
+
+  KOKKOSFFT_THROW_IF(
+      num_differences != 2 || !found_in_axis || !found_out_axis,
+      "Input and output slab topologies must differ in exactly two indices: "
+      "one 1 -> non-1 axis and one non-1 -> 1 axis.");
 
   return std::make_tuple(in_axis, out_axis);
 }
@@ -175,8 +200,8 @@ auto slab_in_out_axes(const std::array<iType, DIM>& in_topology,
 /// \return A tuple of two size_t representing the axes that are different
 /// \throws std::runtime_error if the input and output topologies do not have
 /// at least one non-trivial dimension
-/// \throws std::runtime_error if the input and output topologies are not pencil
-/// topologies
+/// \throws std::runtime_error if the input and output topologies do not have
+/// the same size
 template <typename iType, std::size_t DIM>
 auto pencil_in_out_axes(const std::array<iType, DIM>& in_topology,
                         const std::array<iType, DIM>& out_topology) {
@@ -184,13 +209,12 @@ auto pencil_in_out_axes(const std::array<iType, DIM>& in_topology,
   auto in_size  = KokkosFFT::Impl::total_size(in_topology);
   auto out_size = KokkosFFT::Impl::total_size(out_topology);
 
+  KOKKOSFFT_THROW_IF(in_size == 1 || out_size == 1,
+                     "Input and output topologies must have at least one "
+                     "non-trivial dimension.");
+
   KOKKOSFFT_THROW_IF(in_size != out_size,
                      "Input and output topologies must have the same size.");
-
-  bool is_pencil =
-      are_specified_topologies(TopologyType::Pencil, in_topology, out_topology);
-  KOKKOSFFT_THROW_IF(!is_pencil,
-                     "Input and output topologies must be pencil topologies.");
 
   std::size_t in_axis = 0, out_axis = 0;
   for (std::size_t i = 0; i < DIM; ++i) {
@@ -241,8 +265,8 @@ std::array<iType, DIM> propose_mid_array(const std::array<iType, DIM>& in,
   iType idx_one_out = KokkosFFT::Impl::get_index(out_trimmed, iType(1));
 
   // Try all combinations of 2 indices for a single valid swap
-  for (size_t i = 0; i < diff_non_one_indices.size(); ++i) {
-    for (size_t j = i + 1; j < diff_non_one_indices.size(); ++j) {
+  for (std::size_t i = 0; i < diff_non_one_indices.size(); ++i) {
+    for (std::size_t j = i + 1; j < diff_non_one_indices.size(); ++j) {
       iType idx_in  = diff_non_one_indices.at(i);
       iType idx_out = diff_non_one_indices.at(j);
 

--- a/distributed/unit_test/Test_Topologies.cpp
+++ b/distributed/unit_test/Test_Topologies.cpp
@@ -149,14 +149,15 @@ std::string error_are_topologies(
 /// \tparam Topology2Type The type of the second topology input.
 /// \param[in] topo1 The first input topology that caused the failure.
 /// \param[in] topo2 The second input topology that caused the failure.
+/// \param[in] actual The actual in/out axes.
 /// \param[in] expected The expected in/out axes.
 /// \return Error message including the input topologies and the expected in/out
 /// axes.
 template <typename Topology1Type, typename Topology2Type>
-std::string error_in_out_axes(const Topology1Type& topo1,
-                              const Topology2Type& topo2,
-                              std::tuple<std::size_t, std::size_t> expected) {
-  auto actual = KokkosFFT::Distributed::Impl::slab_in_out_axes(topo1, topo2);
+std::string error_in_out_axes(
+    const Topology1Type& topo1, const Topology2Type& topo2,
+    const std::tuple<std::size_t, std::size_t>& actual,
+    const std::tuple<std::size_t, std::size_t>& expected) {
   std::string msg = "Input topologies: ";
   msg += topology_to_string("topology1", topo1);
   msg += " and ";
@@ -240,6 +241,20 @@ std::string error_decompose_axes(
     }
     msg += ")";
     if (i != expected.size() - 1) {
+      msg += " and ";
+    }
+  }
+  msg += "), but got: (";
+  for (std::size_t i = 0; i < actual.size(); ++i) {
+    msg += "(";
+    for (std::size_t j = 0; j < actual.at(i).size(); ++j) {
+      msg += std::to_string(actual.at(i).at(j));
+      if (j != actual.at(i).size() - 1) {
+        msg += ", ";
+      }
+    }
+    msg += ")";
+    if (i != actual.size() - 1) {
       msg += " and ";
     }
   }
@@ -1135,7 +1150,8 @@ void test_slab_in_out_axes_2D(std::size_t nprocs) {
     // Failure tests because of size 1 case
     std::vector<topo_and_ref_type> topo_test_cases = {{topo0, topo1, {0, 1}},
                                                       {topo1, topo0, {1, 0}}};
-    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_inout_axes] :
+         topo_test_cases) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto inout_axes =
@@ -1152,14 +1168,14 @@ void test_slab_in_out_axes_2D(std::size_t nprocs) {
       auto inout_axes =
           KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
       EXPECT_EQ(inout_axes, ref_inout_axes)
-          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+          << error_in_out_axes(topo_in, topo_out, inout_axes, ref_inout_axes);
     }
   }
 
   // Failure tests because of shape mismatch (or size 1 case)
   std::vector<topo_and_ref_type> topo_failure_test_cases = {
       {topo0, topo2, {0, 1}}, {topo0, topo3, {0, 1}}};
-  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+  for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_inout_axes] :
        topo_failure_test_cases) {
     EXPECT_THROW(
         {
@@ -1182,7 +1198,8 @@ void test_slab_in_out_axes_3D(std::size_t nprocs) {
     std::vector<topo_and_ref_type> topo_test_cases = {
         {topo0, topo1, {0, 1}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {1, 0}},
         {topo1, topo2, {1, 2}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {2, 1}}};
-    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_inout_axes] :
+         topo_test_cases) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto inout_axes =
@@ -1199,14 +1216,14 @@ void test_slab_in_out_axes_3D(std::size_t nprocs) {
       auto inout_axes =
           KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
       EXPECT_EQ(inout_axes, ref_inout_axes)
-          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+          << error_in_out_axes(topo_in, topo_out, inout_axes, ref_inout_axes);
     }
   }
 
   // Failure tests because of shape mismatch (or size 1 case)
   std::vector<topo_and_ref_type> topo_failure_test_cases = {
       {topo0, topo3, {0, 1}}, {topo0, topo4, {0, 1}}};
-  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+  for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_inout_axes] :
        topo_failure_test_cases) {
     EXPECT_THROW(
         {
@@ -1393,7 +1410,7 @@ void test_compute_trans_axis(std::size_t nprocs) {
         {topo0, topo1, 0}, {topo0, topo2, 1}, {topo1, topo0, 0},
         {topo1, topo2, 1}, {topo2, topo0, 1}, {topo2, topo1, 1}};
 
-    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_trans_axis] :
          topo3D_failure_test_cases) {
       EXPECT_THROW(
           {
@@ -1406,7 +1423,7 @@ void test_compute_trans_axis(std::size_t nprocs) {
 
     std::vector<topo4D_and_ref_type> topo4D_failure_test_cases = {
         {topo3, topo4, 0}, {topo4, topo3, 0}};
-    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_trans_axis] :
          topo4D_failure_test_cases) {
       EXPECT_THROW(
           {
@@ -1433,7 +1450,7 @@ void test_compute_trans_axis(std::size_t nprocs) {
     std::vector<topo3D_and_ref_type> topo3D_failure_test_cases = {
         {topo1, topo2, 0}, {topo2, topo1, 1}};
 
-    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_trans_axis] :
          topo3D_failure_test_cases) {
       EXPECT_THROW(
           {
@@ -1469,7 +1486,8 @@ void test_pencil_in_out_axes_3D(std::size_t nprocs) {
     std::vector<topo_and_ref_type> topo_and_ref_vec = {
         {topo0, topo1, {1, 2}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {2, 1}},
         {topo1, topo2, {0, 1}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {1, 0}}};
-    for (const auto& [topo_in, topo_out, ref_in_out] : topo_and_ref_vec) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_in_out] :
+         topo_and_ref_vec) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto inout_axis =
@@ -1487,14 +1505,14 @@ void test_pencil_in_out_axes_3D(std::size_t nprocs) {
       auto inout_axes =
           KokkosFFT::Distributed::Impl::pencil_in_out_axes(topo_in, topo_out);
       EXPECT_EQ(inout_axes, ref_inout_axes)
-          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+          << error_in_out_axes(topo_in, topo_out, inout_axes, ref_inout_axes);
     }
   }
 
   // Failure tests because of shape mismatch (or size 1 case)
   std::vector<topo_and_ref_type> topo_failure_test_cases = {
       {topo3, topo0, {0, 1}}, {topo3, topo1, {0, 1}}, {topo3, topo2, {0, 2}}};
-  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+  for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_inout_axes] :
        topo_failure_test_cases) {
     EXPECT_THROW(
         {
@@ -1518,7 +1536,8 @@ void test_get_mid_array_pencil_3D(std::size_t nprocs) {
         {topo0, topo1, topo_type{}}, {topo0, topo2, topo_type{}},
         {topo1, topo0, topo_type{}}, {topo1, topo2, topo_type{}},
         {topo2, topo0, topo_type{}}, {topo2, topo1, topo_type{}}};
-    for (const auto& [topo_in, topo_out, ref_mid] : topo_and_ref_vec) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_mid] :
+         topo_and_ref_vec) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto mid =
@@ -1534,7 +1553,8 @@ void test_get_mid_array_pencil_3D(std::size_t nprocs) {
         {topo1, topo0, topo_type{}},
         {topo1, topo2, topo_type{}},
         {topo2, topo1, topo_type{}}};
-    for (const auto& [topo_in, topo_out, ref_mid] : topo_failure_test_cases) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_mid] :
+         topo_failure_test_cases) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto mid =
@@ -1570,7 +1590,8 @@ void test_get_mid_array_pencil_4D(std::size_t nprocs) {
         {topo0, topo1, topo_type{}}, {topo0, topo2, topo_type{}},
         {topo1, topo0, topo_type{}}, {topo1, topo2, topo_type{}},
         {topo2, topo0, topo_type{}}, {topo2, topo1, topo_type{}}};
-    for (const auto& [topo_in, topo_out, ref_mid] : topo_and_ref_vec) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_mid] :
+         topo_and_ref_vec) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto mid =
@@ -1587,7 +1608,8 @@ void test_get_mid_array_pencil_4D(std::size_t nprocs) {
         {topo1, topo4, topo_type{}}, {topo2, topo3, topo_type{}},
         {topo2, topo4, topo_type{}}, {topo3, topo5, topo_type{}},
         {topo4, topo5, topo_type{}}};
-    for (const auto& [topo_in, topo_out, ref_mid] : topo_failure_test_cases) {
+    for ([[maybe_unused]] const auto& [topo_in, topo_out, ref_mid] :
+         topo_failure_test_cases) {
       EXPECT_THROW(
           {
             [[maybe_unused]] auto mid =

--- a/distributed/unit_test/Test_Topologies.cpp
+++ b/distributed/unit_test/Test_Topologies.cpp
@@ -144,6 +144,137 @@ std::string error_are_topologies(
   return msg;
 }
 
+/// \brief Generate error message for in_out_axes test failures.
+/// \tparam Topology1Type The type of the first topology input.
+/// \tparam Topology2Type The type of the second topology input.
+/// \param[in] topo1 The first input topology that caused the failure.
+/// \param[in] topo2 The second input topology that caused the failure.
+/// \param[in] expected The expected in/out axes.
+/// \return Error message including the input topologies and the expected in/out
+/// axes.
+template <typename Topology1Type, typename Topology2Type>
+std::string error_in_out_axes(const Topology1Type& topo1,
+                              const Topology2Type& topo2,
+                              std::tuple<std::size_t, std::size_t> expected) {
+  auto actual = KokkosFFT::Distributed::Impl::slab_in_out_axes(topo1, topo2);
+  std::string msg = "Input topologies: ";
+  msg += topology_to_string("topology1", topo1);
+  msg += " and ";
+  msg += topology_to_string("topology2", topo2);
+  msg += ", should have in/out axes: (";
+  msg += std::to_string(std::get<0>(expected));
+  msg += ", ";
+  msg += std::to_string(std::get<1>(expected));
+  msg += "), but got: (";
+  msg += std::to_string(std::get<0>(actual));
+  msg += ", ";
+  msg += std::to_string(std::get<1>(actual));
+  msg += ").";
+  return msg;
+}
+
+/// \brief Generate error message for mid_topology test failures.
+/// \tparam TopologyType The type of the topology input.
+/// \param[in] topo1 The first input topology that caused the failure.
+/// \param[in] topo2 The second input topology that caused the failure.
+/// \param[in] expected The expected topology
+/// \return Error message including the input topologies and the expected
+/// topology
+template <typename TopologyType>
+std::string error_mid_topology(const TopologyType& topo1,
+                               const TopologyType& topo2,
+                               const TopologyType& expected) {
+  auto actual = KokkosFFT::Distributed::Impl::propose_mid_array(topo1, topo2);
+  std::string msg = "Input topologies: ";
+  msg += topology_to_string("topology1", topo1);
+  msg += " and ";
+  msg += topology_to_string("topology2", topo2);
+  msg += ", should have a mid topology: (";
+  msg += std::to_string(expected.at(0));
+  for (std::size_t i = 1; i < expected.size(); ++i) {
+    msg += ", ";
+    msg += std::to_string(expected.at(i));
+  }
+  msg += "), but got (";
+  msg += std::to_string(actual.at(0));
+  for (std::size_t i = 1; i < actual.size(); ++i) {
+    msg += ", ";
+    msg += std::to_string(actual.at(i));
+  }
+  msg += ").";
+  return msg;
+}
+
+/// \brief Generate error message for decompose_axes test failures.
+/// \tparam iType The index type used for the topology.
+/// \tparam DIM The dimensionality of the topology.
+/// \tparam FFT_DIM The dimensionality of the FFT axes.
+/// \param[in] topologies The input topologies that caused the failure.
+/// \param[in] axes The axes along which the FFT is performed.
+/// \param[in] expected The expected decomposed axes
+/// \return Error message including the input topologies, FFT axes, and the
+/// expected decomposition
+template <typename iType, std::size_t DIM, std::size_t FFT_DIM>
+std::string error_decompose_axes(
+    const std::vector<std::array<std::size_t, DIM>>& topologies,
+    const std::array<iType, FFT_DIM>& axes,
+    const std::vector<std::vector<iType>>& expected) {
+  auto actual = KokkosFFT::Distributed::Impl::decompose_axes(topologies, axes);
+  std::string msg = "Input topologies: ";
+  for (std::size_t i = 0; i < topologies.size(); ++i) {
+    msg += topology_to_string("topology", topologies.at(i));
+    if (i != topologies.size() - 1) {
+      msg += " and ";
+    }
+  }
+  msg += ", with FFT axes: ";
+  msg += topology_to_string("axes", axes);
+  msg += ", should have decomposed axes: (";
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    msg += "(";
+    for (std::size_t j = 0; j < expected.at(i).size(); ++j) {
+      msg += std::to_string(expected.at(i).at(j));
+      if (j != expected.at(i).size() - 1) {
+        msg += ", ";
+      }
+    }
+    msg += ")";
+    if (i != expected.size() - 1) {
+      msg += " and ";
+    }
+  }
+  msg += ").";
+
+  return msg;
+}
+
+/// \brief Generate error message for compute_trans_axis test failures.
+/// \tparam iType The index type
+/// \tparam DIM The dimension
+/// \param[in] in_topology The input topology
+/// \param[in] out_topology The output topology
+/// \param[in] first_non_one The first non-one element in the input or output
+/// \param[in] expected The expected transformation axis (0 or 1)
+/// \return Error message including the input topologies and the expected in/out
+/// axes.
+template <typename iType, std::size_t DIM>
+std::string error_trans_axis(const std::array<iType, DIM>& in_topology,
+                             const std::array<iType, DIM>& out_topology,
+                             iType first_non_one, iType expected) {
+  auto actual = KokkosFFT::Distributed::Impl::compute_trans_axis(
+      in_topology, out_topology, first_non_one);
+  std::string msg = "Input topologies: ";
+  msg += topology_to_string("in_topology", in_topology);
+  msg += " and ";
+  msg += topology_to_string("out_topology", out_topology);
+  msg += ", should have trans_axis: ";
+  msg += std::to_string(expected);
+  msg += ", but got: ";
+  msg += std::to_string(actual);
+  msg += ".";
+  return msg;
+}
+
 template <bool is_std_array>
 void test_to_topology_type(std::size_t nprocs) {
   using KokkosFFT::Distributed::Impl::TopologyType;
@@ -994,6 +1125,489 @@ void test_are_topologies(std::size_t nprocs) {
   }
 }
 
+void test_slab_in_out_axes_2D(std::size_t nprocs) {
+  using topo_type = std::array<std::size_t, 2>;
+  using topo_and_ref_type =
+      std::tuple<topo_type, topo_type, std::tuple<std::size_t, std::size_t>>;
+  topo_type topo0{1, nprocs}, topo1{nprocs, 1}, topo2{nprocs, 7}, topo3{1, 1};
+
+  if (nprocs == 1) {
+    // Failure tests because of size 1 case
+    std::vector<topo_and_ref_type> topo_test_cases = {{topo0, topo1, {0, 1}},
+                                                      {topo1, topo0, {1, 0}}};
+    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto inout_axes =
+                KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in,
+                                                               topo_out);
+          },
+          std::runtime_error);
+    }
+  } else {
+    std::vector<topo_and_ref_type> topo_test_cases = {{topo0, topo1, {0, 1}},
+                                                      {topo1, topo0, {1, 0}}};
+
+    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+      auto inout_axes =
+          KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
+      EXPECT_EQ(inout_axes, ref_inout_axes)
+          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+    }
+  }
+
+  // Failure tests because of shape mismatch (or size 1 case)
+  std::vector<topo_and_ref_type> topo_failure_test_cases = {
+      {topo0, topo2, {0, 1}}, {topo0, topo3, {0, 1}}};
+  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+       topo_failure_test_cases) {
+    EXPECT_THROW(
+        {
+          [[maybe_unused]] auto inout_axes =
+              KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
+        },
+        std::runtime_error);
+  }
+}
+
+void test_slab_in_out_axes_3D(std::size_t nprocs) {
+  using topo_type = std::array<std::size_t, 3>;
+  using topo_and_ref_type =
+      std::tuple<topo_type, topo_type, std::tuple<std::size_t, std::size_t>>;
+  topo_type topo0{1, 1, nprocs}, topo1{1, nprocs, 1}, topo2{nprocs, 1, 1},
+      topo3{1, nprocs, 7}, topo4{1, 1, 1};
+
+  if (nprocs == 1) {
+    // Failure tests because of size 1 case
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {topo0, topo1, {0, 1}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {1, 0}},
+        {topo1, topo2, {1, 2}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {2, 1}}};
+    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto inout_axes =
+                KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in,
+                                                               topo_out);
+          },
+          std::runtime_error);
+    }
+  } else {
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {topo0, topo1, {1, 2}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {2, 1}},
+        {topo1, topo2, {0, 1}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {1, 0}}};
+    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_test_cases) {
+      auto inout_axes =
+          KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
+      EXPECT_EQ(inout_axes, ref_inout_axes)
+          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+    }
+  }
+
+  // Failure tests because of shape mismatch (or size 1 case)
+  std::vector<topo_and_ref_type> topo_failure_test_cases = {
+      {topo0, topo3, {0, 1}}, {topo0, topo4, {0, 1}}};
+  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+       topo_failure_test_cases) {
+    EXPECT_THROW(
+        {
+          [[maybe_unused]] auto inout_axes =
+              KokkosFFT::Distributed::Impl::slab_in_out_axes(topo_in, topo_out);
+        },
+        std::runtime_error);
+  }
+}
+
+void test_decompose_axes_slab(std::size_t nprocs) {
+  using topo3D_type       = std::array<std::size_t, 3>;
+  using topo4D_type       = std::array<std::size_t, 4>;
+  using axes_type         = std::array<std::size_t, 3>;
+  using vec_topo3D_type   = std::vector<topo3D_type>;
+  using vec_topo4D_type   = std::vector<topo4D_type>;
+  using vec_axes_type     = std::vector<std::size_t>;
+  using vec_vec_axes_type = std::vector<vec_axes_type>;
+  using topo3D_and_ref_type =
+      std::tuple<vec_topo3D_type, axes_type, vec_vec_axes_type>;
+  using topo4D_and_ref_type =
+      std::tuple<vec_topo4D_type, axes_type, vec_vec_axes_type>;
+
+  // 3D topologies
+  topo3D_type topo0{1, 1, nprocs}, topo1{1, nprocs, 1}, topo2{nprocs, 1, 1};
+
+  // 4D topologies
+  topo4D_type topo3{1, 1, 1, nprocs}, topo4{1, 1, nprocs, 1};
+
+  axes_type axes012{0, 1, 2}, axes021{0, 2, 1}, axes102{1, 0, 2},
+      axes120{1, 2, 0}, axes201{2, 0, 1}, axes210{2, 1, 0};
+
+  std::vector<axes_type> all_axes{axes012, axes021, axes102,
+                                  axes120, axes201, axes210};
+
+  if (nprocs == 1) {
+    for (const auto& axes : all_axes) {
+      vec_vec_axes_type ref_all_axes2{KokkosFFT::Impl::to_vector(axes), {}},
+          ref_all_axes3{KokkosFFT::Impl::to_vector(axes), {}, {}};
+      // 3D case
+      std::vector<topo3D_and_ref_type> topo3D_test_cases = {
+          {vec_topo3D_type{topo0, topo1}, axes, ref_all_axes2},
+          {vec_topo3D_type{topo0, topo2}, axes, ref_all_axes2},
+          {vec_topo3D_type{topo1, topo2}, axes, ref_all_axes2},
+          {vec_topo3D_type{topo2, topo0, topo2}, axes, ref_all_axes3}};
+      for (const auto& [topos3D, axes3D, ref_axes3D] : topo3D_test_cases) {
+        auto all_axes_3D =
+            KokkosFFT::Distributed::Impl::decompose_axes(topos3D, axes3D);
+        EXPECT_EQ(all_axes_3D, ref_axes3D)
+            << error_decompose_axes(topos3D, axes3D, ref_axes3D);
+      }
+
+      // 4D case
+      std::vector<topo4D_and_ref_type> topo4D_test_cases = {
+          {vec_topo4D_type{topo3, topo4}, axes, ref_all_axes2},
+          {vec_topo4D_type{topo4, topo3}, axes, ref_all_axes2}};
+
+      for (const auto& [topos4D, axes4D, ref_axes4D] : topo4D_test_cases) {
+        auto all_axes_4D =
+            KokkosFFT::Distributed::Impl::decompose_axes(topos4D, axes4D);
+        EXPECT_EQ(all_axes_4D, ref_axes4D)
+            << error_decompose_axes(topos4D, axes4D, ref_axes4D);
+      }
+    }
+  } else {
+    vec_vec_axes_type ref_all_axes_2_0_2{vec_axes_type{2, 1}, vec_axes_type{0},
+                                         vec_axes_type{}},
+        ref_all_axes_3_4{vec_axes_type{0, 1, 2}, vec_axes_type{}},
+        ref_all_axes_4_3_ax210{vec_axes_type{1, 0}, vec_axes_type{2}},
+        ref_all_axes_4_3_ax012{vec_axes_type{}, vec_axes_type{0, 1, 2}};
+    // 3D case
+    std::vector<topo3D_and_ref_type> topo3D_test_cases{
+        {vec_topo3D_type{topo2, topo0, topo2}, axes021, ref_all_axes_2_0_2}};
+    for (const auto& [topos3D, axes3D, ref_axes3D] : topo3D_test_cases) {
+      auto all_axes_3D =
+          KokkosFFT::Distributed::Impl::decompose_axes(topos3D, axes3D);
+      EXPECT_EQ(all_axes_3D, ref_axes3D)
+          << error_decompose_axes(topos3D, axes3D, ref_axes3D);
+    }
+
+    // 4D case
+    std::vector<topo4D_and_ref_type> topo4D_test_cases{
+        {vec_topo4D_type{topo3, topo4}, axes012, ref_all_axes_3_4},
+        {vec_topo4D_type{topo4, topo3}, axes210, ref_all_axes_4_3_ax210},
+        {vec_topo4D_type{topo4, topo3}, axes012, ref_all_axes_4_3_ax012}};
+
+    for (const auto& [topos4D, axes4D, ref_axes4D] : topo4D_test_cases) {
+      auto all_axes_4D =
+          KokkosFFT::Distributed::Impl::decompose_axes(topos4D, axes4D);
+      EXPECT_EQ(all_axes_4D, ref_axes4D)
+          << error_decompose_axes(topos4D, axes4D, ref_axes4D);
+    }
+  }
+}
+
+void test_decompose_axes_pencil(std::size_t nprocs) {
+  using topo_type         = std::array<std::size_t, 3>;
+  using axes_type         = std::array<std::size_t, 3>;
+  using vec_axes_type     = std::vector<std::size_t>;
+  using vec_topo_type     = std::vector<topo_type>;
+  using vec_vec_axes_type = std::vector<vec_axes_type>;
+  using topo_and_ref_type =
+      std::tuple<vec_topo_type, axes_type, vec_vec_axes_type>;
+  std::size_t np0 = 4;
+
+  // 3D topologies
+  topo_type topo0{1, nprocs, np0}, topo1{nprocs, 1, np0}, topo2{np0, nprocs, 1},
+      topo3{nprocs, np0, 1}, topo4{np0, 1, nprocs};
+
+  axes_type axes012{0, 1, 2}, axes021{0, 2, 1}, axes102{1, 0, 2},
+      axes120{1, 2, 0}, axes201{2, 0, 1}, axes210{2, 1, 0};
+  std::vector<axes_type> all_axes = {axes012, axes021, axes102,
+                                     axes120, axes201, axes210};
+  if (nprocs == 1) {
+    // Slab geometry
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {std::vector<topo_type>{topo0, topo2, topo4, topo2, topo0},
+         axes012,
+         {{}, vec_axes_type{1, 2}, {}, {}, vec_axes_type{0}}},
+        {std::vector<topo_type>{topo0, topo1, topo3, topo1, topo0},
+         axes021,
+         {vec_axes_type{1}, {}, vec_axes_type{0, 2}, {}, {}}},
+        {std::vector<topo_type>{topo0, topo2, topo0, topo1, topo0},
+         axes102,
+         {{}, vec_axes_type{2}, vec_axes_type{1, 0}, {}, {}}},
+        {std::vector<topo_type>{topo0, topo1, topo0, topo2, topo0},
+         axes201,
+         {vec_axes_type{0, 1}, {}, {}, vec_axes_type{2}, {}}},
+        {std::vector<topo_type>{topo0, topo2, topo0, topo1},
+         axes102,
+         {{}, vec_axes_type{2}, vec_axes_type{1, 0}, {}}}};
+
+    for (const auto& [topos, axes, ref_axes] : topo_test_cases) {
+      auto all_axes = KokkosFFT::Distributed::Impl::decompose_axes(topos, axes);
+      EXPECT_EQ(all_axes, ref_axes)
+          << error_decompose_axes(topos, axes, ref_axes);
+    }
+  } else {
+    // Pencil geometry
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {std::vector<topo_type>{topo0, topo2, topo4, topo2, topo0},
+         axes012,
+         {{}, vec_axes_type{2}, vec_axes_type{1}, {}, vec_axes_type{0}}},
+        {std::vector<topo_type>{topo0, topo1, topo3, topo1, topo0},
+         axes021,
+         {{}, vec_axes_type{1}, vec_axes_type{2}, {}, vec_axes_type{0}}},
+        {std::vector<topo_type>{topo0, topo2, topo0, topo1, topo0},
+         axes102,
+         {{}, vec_axes_type{2}, vec_axes_type{0}, vec_axes_type{1}, {}}},
+        {std::vector<topo_type>{topo0, topo1, topo0, topo2, topo0},
+         axes201,
+         {{}, vec_axes_type{1}, vec_axes_type{0}, vec_axes_type{2}, {}}},
+        {std::vector<topo_type>{topo0, topo2, topo0, topo1},
+         axes102,
+         {{}, vec_axes_type{2}, vec_axes_type{0}, vec_axes_type{1}}}};
+
+    for (const auto& [topos, axes, ref_axes] : topo_test_cases) {
+      auto all_axes = KokkosFFT::Distributed::Impl::decompose_axes(topos, axes);
+      EXPECT_EQ(all_axes, ref_axes)
+          << error_decompose_axes(topos, axes, ref_axes);
+    }
+  }
+}
+
+void test_compute_trans_axis(std::size_t nprocs) {
+  using topo3D_type         = std::array<std::size_t, 3>;
+  using topo4D_type         = std::array<std::size_t, 4>;
+  using topo3D_and_ref_type = std::tuple<topo3D_type, topo3D_type, std::size_t>;
+  using topo4D_and_ref_type = std::tuple<topo4D_type, topo4D_type, std::size_t>;
+
+  std::size_t np0 = 4;
+
+  // 3D topologies
+  topo3D_type topo0{1, nprocs, np0}, topo1{nprocs, 1, np0},
+      topo2{np0, nprocs, 1};
+
+  // 4D topologies
+  topo4D_type topo3{1, 1, np0, nprocs}, topo4{1, np0, 1, nprocs};
+
+  if (nprocs == 1 || nprocs == np0) {
+    // Failure tests because these are not pencils for nprocs == 1 or they
+    // include identical non-one elements for nprocs == np0
+    std::vector<topo3D_and_ref_type> topo3D_failure_test_cases = {
+        {topo0, topo1, 0}, {topo0, topo2, 1}, {topo1, topo0, 0},
+        {topo1, topo2, 1}, {topo2, topo0, 1}, {topo2, topo1, 1}};
+
+    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+         topo3D_failure_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto trans_axis =
+                KokkosFFT::Distributed::Impl::compute_trans_axis(
+                    topo_in, topo_out, nprocs);
+          },
+          std::runtime_error);
+    }
+
+    std::vector<topo4D_and_ref_type> topo4D_failure_test_cases = {
+        {topo3, topo4, 0}, {topo4, topo3, 0}};
+    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+         topo4D_failure_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto trans_axis =
+                KokkosFFT::Distributed::Impl::compute_trans_axis(
+                    topo_in, topo_out, nprocs);
+          },
+          std::runtime_error);
+    }
+  } else {
+    // 3D case
+    std::vector<topo3D_and_ref_type> topo3D_test_cases = {{topo0, topo1, 0},
+                                                          {topo0, topo2, 1},
+                                                          {topo1, topo0, 0},
+                                                          {topo2, topo0, 1}};
+
+    for (const auto& [topo_in, topo_out, ref_trans_axis] : topo3D_test_cases) {
+      auto trans_axis = KokkosFFT::Distributed::Impl::compute_trans_axis(
+          topo_in, topo_out, nprocs);
+      EXPECT_EQ(trans_axis, ref_trans_axis)
+          << error_trans_axis(topo_in, topo_out, nprocs, ref_trans_axis);
+    }
+
+    std::vector<topo3D_and_ref_type> topo3D_failure_test_cases = {
+        {topo1, topo2, 0}, {topo2, topo1, 1}};
+
+    for (const auto& [topo_in, topo_out, ref_trans_axis] :
+         topo3D_failure_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto trans_axis =
+                KokkosFFT::Distributed::Impl::compute_trans_axis(
+                    topo_in, topo_out, nprocs);
+          },
+          std::runtime_error);
+    }
+
+    // 4D case
+    std::vector<topo4D_and_ref_type> topo4D_test_cases = {{topo3, topo4, 0},
+                                                          {topo4, topo3, 0}};
+
+    for (const auto& [topo_in, topo_out, ref_trans_axis] : topo4D_test_cases) {
+      auto trans_axis = KokkosFFT::Distributed::Impl::compute_trans_axis(
+          topo_in, topo_out, np0);
+      EXPECT_EQ(trans_axis, ref_trans_axis)
+          << error_trans_axis(topo_in, topo_out, np0, ref_trans_axis);
+    }
+  }
+}
+
+void test_pencil_in_out_axes_3D(std::size_t nprocs) {
+  using topo_type = std::array<std::size_t, 3>;
+  using topo_and_ref_type =
+      std::tuple<topo_type, topo_type, std::tuple<std::size_t, std::size_t>>;
+  topo_type topo0{1, 1, nprocs}, topo1{1, nprocs, 1}, topo2{nprocs, 1, 1},
+      topo3{nprocs, 1, 2}, topo4{nprocs, 2, 1};
+
+  if (nprocs == 1) {
+    // Failure tests because of size 1 case
+    std::vector<topo_and_ref_type> topo_and_ref_vec = {
+        {topo0, topo1, {1, 2}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {2, 1}},
+        {topo1, topo2, {0, 1}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {1, 0}}};
+    for (const auto& [topo_in, topo_out, ref_in_out] : topo_and_ref_vec) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto inout_axis =
+                KokkosFFT::Distributed::Impl::pencil_in_out_axes(topo_in,
+                                                                 topo_out);
+          },
+          std::runtime_error);
+    }
+  } else {
+    std::vector<topo_and_ref_type> topo_and_ref_vec = {
+        {topo0, topo1, {1, 2}}, {topo0, topo2, {0, 2}}, {topo1, topo0, {2, 1}},
+        {topo1, topo2, {0, 1}}, {topo2, topo0, {2, 0}}, {topo2, topo1, {1, 0}},
+        {topo3, topo4, {1, 2}}, {topo4, topo3, {2, 1}}};
+    for (const auto& [topo_in, topo_out, ref_inout_axes] : topo_and_ref_vec) {
+      auto inout_axes =
+          KokkosFFT::Distributed::Impl::pencil_in_out_axes(topo_in, topo_out);
+      EXPECT_EQ(inout_axes, ref_inout_axes)
+          << error_in_out_axes(topo_in, topo_out, ref_inout_axes);
+    }
+  }
+
+  // Failure tests because of shape mismatch (or size 1 case)
+  std::vector<topo_and_ref_type> topo_failure_test_cases = {
+      {topo3, topo0, {0, 1}}, {topo3, topo1, {0, 1}}, {topo3, topo2, {0, 2}}};
+  for (const auto& [topo_in, topo_out, ref_inout_axes] :
+       topo_failure_test_cases) {
+    EXPECT_THROW(
+        {
+          [[maybe_unused]] auto inout_axes =
+              KokkosFFT::Distributed::Impl::pencil_in_out_axes(topo_in,
+                                                               topo_out);
+        },
+        std::runtime_error);
+  }
+}
+
+void test_get_mid_array_pencil_3D(std::size_t nprocs) {
+  using topo_type         = std::array<std::size_t, 3>;
+  using topo_and_ref_type = std::tuple<topo_type, topo_type, topo_type>;
+  topo_type topo0{nprocs, 1, 8}, topo1{nprocs, 8, 1}, topo2{8, nprocs, 1},
+      topo3{1, 2, nprocs}, topo4{2, nprocs, 1};
+
+  if (nprocs == 1) {
+    // Failure tests because only two elements differ
+    std::vector<topo_and_ref_type> topo_and_ref_vec = {
+        {topo0, topo1, topo_type{}}, {topo0, topo2, topo_type{}},
+        {topo1, topo0, topo_type{}}, {topo1, topo2, topo_type{}},
+        {topo2, topo0, topo_type{}}, {topo2, topo1, topo_type{}}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_and_ref_vec) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto mid =
+                KokkosFFT::Distributed::Impl::propose_mid_array(topo_in,
+                                                                topo_out);
+          },
+          std::runtime_error);
+    }
+  } else {
+    // Failure tests because only two elements differ
+    std::vector<topo_and_ref_type> topo_failure_test_cases = {
+        {topo0, topo1, topo_type{}},
+        {topo1, topo0, topo_type{}},
+        {topo1, topo2, topo_type{}},
+        {topo2, topo1, topo_type{}}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_failure_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto mid =
+                KokkosFFT::Distributed::Impl::propose_mid_array(topo_in,
+                                                                topo_out);
+          },
+          std::runtime_error);
+    }
+    topo_type ref_mid02{1, nprocs, 8}, ref_mid34{2, 1, nprocs};
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {topo0, topo2, ref_mid02},
+        {topo2, topo0, ref_mid02},
+        {topo3, topo4, ref_mid34},
+        {topo4, topo3, ref_mid34}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_test_cases) {
+      auto mid =
+          KokkosFFT::Distributed::Impl::propose_mid_array(topo_in, topo_out);
+      EXPECT_EQ(mid, ref_mid) << error_mid_topology(topo_in, topo_out, ref_mid);
+    }
+  }
+}
+
+void test_get_mid_array_pencil_4D(std::size_t nprocs) {
+  using topo_type         = std::array<std::size_t, 4>;
+  using topo_and_ref_type = std::tuple<topo_type, topo_type, topo_type>;
+  topo_type topo0{1, 1, nprocs, 8}, topo1{1, nprocs, 1, 8},
+      topo2{1, 8, nprocs, 1}, topo3{1, nprocs, 8, 1}, topo4{1, 8, 1, nprocs},
+      topo5{1, 1, 8, nprocs};
+
+  if (nprocs == 1) {
+    // Failure tests because only two elements differ
+    std::vector<topo_and_ref_type> topo_and_ref_vec = {
+        {topo0, topo1, topo_type{}}, {topo0, topo2, topo_type{}},
+        {topo1, topo0, topo_type{}}, {topo1, topo2, topo_type{}},
+        {topo2, topo0, topo_type{}}, {topo2, topo1, topo_type{}}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_and_ref_vec) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto mid =
+                KokkosFFT::Distributed::Impl::propose_mid_array(topo_in,
+                                                                topo_out);
+          },
+          std::runtime_error);
+    }
+  } else {
+    // Failure tests because only two elements differ
+    std::vector<topo_and_ref_type> topo_failure_test_cases = {
+        {topo0, topo1, topo_type{}}, {topo0, topo2, topo_type{}},
+        {topo0, topo5, topo_type{}}, {topo1, topo3, topo_type{}},
+        {topo1, topo4, topo_type{}}, {topo2, topo3, topo_type{}},
+        {topo2, topo4, topo_type{}}, {topo3, topo5, topo_type{}},
+        {topo4, topo5, topo_type{}}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_failure_test_cases) {
+      EXPECT_THROW(
+          {
+            [[maybe_unused]] auto mid =
+                KokkosFFT::Distributed::Impl::propose_mid_array(topo_in,
+                                                                topo_out);
+          },
+          std::runtime_error);
+    }
+
+    std::vector<topo_and_ref_type> topo_test_cases = {
+        {topo0, topo3, topo1}, {topo0, topo4, topo2}, {topo1, topo2, topo0},
+        {topo1, topo5, topo3}, {topo2, topo5, topo4}, {topo3, topo4, topo5}};
+    for (const auto& [topo_in, topo_out, ref_mid] : topo_test_cases) {
+      auto mid =
+          KokkosFFT::Distributed::Impl::propose_mid_array(topo_in, topo_out);
+      EXPECT_EQ(mid, ref_mid) << error_mid_topology(topo_in, topo_out, ref_mid);
+    }
+  }
+}
+
 }  // namespace
 
 TEST_P(TopologyParamTests, GetTopologyType_std_array) {
@@ -1034,6 +1648,46 @@ TEST_P(TopologyParamTests, are_topologies_std_array) {
 TEST_P(TopologyParamTests, are_topologies_topology) {
   int n0 = GetParam();
   test_are_topologies<false>(n0);
+}
+
+TEST_P(TopologyParamTests, decompose_axes_slab) {
+  int n0 = GetParam();
+  test_decompose_axes_slab(n0);
+}
+
+TEST_P(TopologyParamTests, decompose_axes_pencil) {
+  int n0 = GetParam();
+  test_decompose_axes_pencil(n0);
+}
+
+TEST_P(TopologyParamTests, compute_trans_axis) {
+  int n0 = GetParam();
+  test_compute_trans_axis(n0);
+}
+
+TEST_P(TopologyParamTests, slab_in_out_axes_2D) {
+  int n0 = GetParam();
+  test_slab_in_out_axes_2D(n0);
+}
+
+TEST_P(TopologyParamTests, slab_in_out_axes_3D) {
+  int n0 = GetParam();
+  test_slab_in_out_axes_3D(n0);
+}
+
+TEST_P(TopologyParamTests, pencil_in_out_axes_3D) {
+  int n0 = GetParam();
+  test_pencil_in_out_axes_3D(n0);
+}
+
+TEST_P(TopologyParamTests, get_mid_array_3D) {
+  int n0 = GetParam();
+  test_get_mid_array_pencil_3D(n0);
+}
+
+TEST_P(TopologyParamTests, get_mid_array_4D) {
+  int n0 = GetParam();
+  test_get_mid_array_pencil_4D(n0);
 }
 
 INSTANTIATE_TEST_SUITE_P(TopologyTests, TopologyParamTests,

--- a/distributed/unit_test/Test_Types.cpp
+++ b/distributed/unit_test/Test_Types.cpp
@@ -168,7 +168,7 @@ TYPED_TEST(CompileTestTopologyTypes, internal_types) {
 
 // Test default constructor
 TYPED_TEST(TestTopology, default_constructor) {
-  TypeParam topology;
+  TypeParam topology{};
   EXPECT_EQ(topology.size(), this->m_test_data.size());
   EXPECT_EQ(topology.empty(), this->m_test_data.empty());
 }


### PR DESCRIPTION
This introduces helpers to analyze given topologies. More functions to analyze slab/pencil topologies.

- [x] `slab_in_out_axes`: analyze the input and output axes for slab topology
- [x] `pencil_in_out_axes`: analyze the input and output axes for pencil topology
- [x] `propose_mid_array`: Find an intermediate topology between input topologies
- [x] `decompose_axes`: From the list of topologies, decompose the FFT axes into vectors
- [x] `compute_trans_axis`: Compute the axis to transpose to convert one topology to another