### PR TITLE
Move topology_to_string under common

### DIFF
--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -158,7 +158,7 @@ void check_fft_call(FFTStatusType status, const char* command_name,
 /// \param[in] container The container values to stringify.
 /// \return The formatted container string.
 template <typename ContainerType>
-std::string container_to_string(const std::string& name,
+std::string container_to_string(std::string_view name,
                                 const ContainerType& container) {
   using value_type = std::remove_cv_t<std::remove_reference_t<
       decltype(std::declval<const ContainerType&>().at(0))>>;
@@ -166,7 +166,10 @@ std::string container_to_string(const std::string& name,
       std::is_integral_v<value_type>,
       "container_to_string: Input container must hold integral values");
 
-  std::string msg = name + "(";
+  std::string msg;
+  msg.reserve(name.size() + 2);
+  msg += name;
+  msg += "(";
   if (container.empty()) {
     msg += ")";
     return msg;

--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -7,6 +7,7 @@
 
 #include <stdexcept>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -149,7 +150,7 @@ void check_fft_call(FFTStatusType status, const char* command_name,
 /// Example:
 /// \code{.cpp}
 /// std::array<int, 3> arr = {1, 2, 3};
-/// std::string msg = container_to_string("Array", arr);
+/// std::string msg = container_to_string("Array ", arr);
 /// // msg: "Array (1, 2, 3)"
 /// \endcode
 /// \tparam ContainerType The type of the container input.

--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -5,6 +5,7 @@
 #ifndef KOKKOSFFT_ASSERTS_HPP
 #define KOKKOSFFT_ASSERTS_HPP
 
+#include <cstddef>
 #include <stdexcept>
 #include <sstream>
 #include <string>

--- a/common/src/KokkosFFT_Asserts.hpp
+++ b/common/src/KokkosFFT_Asserts.hpp
@@ -8,6 +8,8 @@
 #include <stdexcept>
 #include <sstream>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 
 #define KOKKOSFFT_STATIC_ASSERT_VIEWS_ARE_OPERATABLE(expr, name)             \
   static_assert(                                                             \
@@ -141,6 +143,39 @@ void check_fft_call(FFTStatusType status, const char* command_name,
        << result_to_string(status) << ")\n";
     throw std::runtime_error(ss.str());
   }
+}
+
+/// \brief Convert a container-like object to a formatted string.
+/// Example:
+/// \code{.cpp}
+/// std::array<int, 3> arr = {1, 2, 3};
+/// std::string msg = container_to_string("Array", arr);
+/// // msg: "Array (1, 2, 3)"
+/// \endcode
+/// \tparam ContainerType The type of the container input.
+/// \param[in] name The label to prepend to the formatted container.
+/// \param[in] container The container values to stringify.
+/// \return The formatted container string.
+template <typename ContainerType>
+std::string container_to_string(const std::string& name,
+                                const ContainerType& container) {
+  using value_type = std::remove_cv_t<std::remove_reference_t<
+      decltype(std::declval<const ContainerType&>().at(0))>>;
+  static_assert(
+      std::is_integral_v<value_type>,
+      "container_to_string: Input container must hold integral values");
+
+  std::string msg = name + "(";
+  if (container.empty()) {
+    msg += ")";
+    return msg;
+  }
+  msg += std::to_string(container.at(0));
+  for (std::size_t i = 1; i < container.size(); ++i) {
+    msg += ", " + std::to_string(container.at(i));
+  }
+  msg += ")";
+  return msg;
 }
 
 }  // namespace Impl

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_executable(
   unit-tests-kokkos-fft-common
   Test_Main.cpp
+  Test_Assert.cpp
   Test_CheckConditions.cpp
   Test_Container_Helpers.cpp
   Test_Convert_Types.cpp

--- a/common/unit_test/Test_Assert.cpp
+++ b/common/unit_test/Test_Assert.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <vector>
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosFFT_Asserts.hpp"
+
+namespace {
+// Int like types
+using base_int_types = ::testing::Types<int, std::size_t>;
+
+// Basically the same fixtures, used for labeling tests
+template <typename T>
+struct TestContainerToString : public ::testing::Test {
+  using value_type = T;
+};
+
+template <typename ContainerType, typename EmptyContainerType>
+void test_container_to_string() {
+  ContainerType container{1, 2, 3};
+  std::string expected = "Container: (1, 2, 3)";
+  std::string actual =
+      KokkosFFT::Impl::container_to_string("Container: ", container);
+  EXPECT_EQ(expected, actual)
+      << "Expected: " << expected << ", but got: " << actual;
+
+  EmptyContainerType empty_container{};
+  expected = "Container: ()";
+  actual = KokkosFFT::Impl::container_to_string("Container: ", empty_container);
+  EXPECT_EQ(expected, actual)
+      << "Expected: " << expected << ", but got: " << actual;
+
+  ContainerType unnamed_container{4, 5, 6};
+  expected = "(4, 5, 6)";
+  actual   = KokkosFFT::Impl::container_to_string("", unnamed_container);
+  EXPECT_EQ(expected, actual)
+      << "Expected: " << expected << ", but got: " << actual;
+}
+
+}  // namespace
+
+TYPED_TEST_SUITE(TestContainerToString, base_int_types);
+
+TYPED_TEST(TestContainerToString, array_to_string) {
+  using value_type           = typename TestFixture::value_type;
+  using container_type       = std::array<value_type, 3>;
+  using empty_container_type = std::array<value_type, 0>;
+  test_container_to_string<container_type, empty_container_type>();
+}
+
+TYPED_TEST(TestContainerToString, vector_to_string) {
+  using value_type           = typename TestFixture::value_type;
+  using container_type       = std::vector<value_type>;
+  using empty_container_type = std::vector<value_type>;
+  test_container_to_string<container_type, empty_container_type>();
+}

--- a/common/unit_test/Test_Assert.cpp
+++ b/common/unit_test/Test_Assert.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 #include <array>
+#include <cstddef>
+#include <string>
 #include <vector>
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -323,30 +323,18 @@ std::vector<std::vector<iType>> decompose_axes(
   auto error_msg = [&axes, &all_axes,
                     &topologies](std::string_view details) -> std::string {
     std::string msg(details);
-    msg += " Input axes: ";
-    for (auto axis : axes) {
-      msg += std::to_string(axis) + " ";
-    }
+    msg += KokkosFFT::Impl::container_to_string(" Input axes: ", axes);
     msg += "\n";
     msg += "Decomposed axes: \n";
     for (std::size_t i = 0; i < all_axes.size(); ++i) {
       auto topology = topologies.at(i);
-      msg += "at topology (";
-      msg += std::to_string(topology.at(0));
-      for (std::size_t j = 1; j < topology.size(); ++j) {
-        msg += ", " + std::to_string(topology.at(j));
-      }
-      msg += "): Ready axes: ";
+      msg += "at ";
+      msg += KokkosFFT::Impl::container_to_string("topology: ", topology);
+      msg += ": Ready axes: ";
       if (all_axes.at(i).empty()) {
         msg += "None";
       } else {
-        auto axis = all_axes.at(i);
-        msg += "(";
-        msg += std::to_string(axis.at(0));
-        for (std::size_t j = 1; j < axis.size(); ++j) {
-          msg += ", " + std::to_string(axis.at(j));
-        }
-        msg += ")";
+        msg += KokkosFFT::Impl::container_to_string("", all_axes.at(i));
       }
       msg += "\n";
     }
@@ -392,20 +380,11 @@ auto compute_trans_axis(const std::array<iType, DIM>& in_topology,
   auto error_msg = [&in_topology,
                     &out_topology](std::string_view details) -> std::string {
     std::string message(details);
-    message += "in_topology (";
-    message += std::to_string(in_topology.at(0));
-    for (std::size_t r = 1; r < in_topology.size(); r++) {
-      message += ",";
-      message += std::to_string(in_topology.at(r));
-    }
-    message += "), ";
-    message += "out_topology (";
-    message += std::to_string(out_topology.at(0));
-    for (std::size_t r = 1; r < out_topology.size(); r++) {
-      message += ",";
-      message += std::to_string(out_topology.at(r));
-    }
-    message += ")";
+    message +=
+        KokkosFFT::Impl::container_to_string("in_topology: ", in_topology);
+    message += ", ";
+    message +=
+        KokkosFFT::Impl::container_to_string("out_topology: ", out_topology);
     return message;
   };
 

--- a/distributed/src/KokkosFFT_Distributed_Topologies.hpp
+++ b/distributed/src/KokkosFFT_Distributed_Topologies.hpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <vector>
 #include <KokkosFFT.hpp>
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Distributed_Types.hpp"
 #include "KokkosFFT_Distributed_ContainerAnalyses.hpp"
 

--- a/distributed/unit_test/Test_Topologies.cpp
+++ b/distributed/unit_test/Test_Topologies.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
+#include "KokkosFFT_Asserts.hpp"
 #include "KokkosFFT_Distributed_Topologies.hpp"
 #include "Test_Utils.hpp"
 
@@ -37,23 +38,6 @@ inline std::string topology_type_to_string(
   }
 }
 
-/// \brief Convert a topology-like container to a formatted string.
-/// \tparam TopologyContainerType The type of the topology input.
-/// \param[in] name The label to prepend to the formatted topology.
-/// \param[in] topology The topology values to stringify.
-/// \return The formatted topology string.
-template <typename TopologyContainerType>
-std::string topology_to_string(const std::string& name,
-                               const TopologyContainerType& topology) {
-  std::string msg = name + " (";
-  msg += std::to_string(topology.at(0));
-  for (std::size_t i = 1; i < topology.size(); ++i) {
-    msg += ", " + std::to_string(topology.at(i));
-  }
-  msg += ")";
-  return msg;
-}
-
 /// \brief Generate error message for topology type test failures.
 /// \tparam TopologyContainerType The type of the topology input.
 /// \param[in] topology The input topology that caused the failure.
@@ -64,7 +48,8 @@ template <typename TopologyContainerType>
 std::string error_to_topology_type(
     const TopologyContainerType& topology,
     KokkosFFT::Distributed::Impl::TopologyType ref) {
-  std::string msg = topology_to_string("Input topology:", topology);
+  std::string msg =
+      KokkosFFT::Impl::container_to_string("Input topology: ", topology);
   msg += ", should be: " + topology_type_to_string(ref) + ", but got: " +
          topology_type_to_string(
              KokkosFFT::Distributed::Impl::to_topology_type(topology));
@@ -84,8 +69,10 @@ template <typename Topology1Type, typename Topology2Type>
 std::string error_get_common_topology_type(
     const Topology1Type& topo1, const Topology2Type& topo2,
     KokkosFFT::Distributed::Impl::TopologyType ref) {
-  std::string msg = topology_to_string("Input topologies: ", topo1);
-  msg += " and " + topology_to_string("", topo2);
+  std::string msg =
+      KokkosFFT::Impl::container_to_string("Input topologies: ", topo1);
+  msg += " and " +
+         KokkosFFT::Impl::container_to_string("Input topologies: ", topo2);
   msg +=
       ", should be: " + topology_type_to_string(ref) + ", but got: " +
       topology_type_to_string(
@@ -106,7 +93,8 @@ template <typename TopologyType>
 std::string error_is_topology(
     const TopologyType& topology,
     KokkosFFT::Distributed::Impl::TopologyType specified, bool expected) {
-  std::string msg = topology_to_string("Input topology:", topology);
+  std::string msg =
+      KokkosFFT::Impl::container_to_string("Input topology: ", topology);
   if (expected) {
     msg += ", should be identified as " + topology_type_to_string(specified) +
            ", but it is not.";
@@ -132,8 +120,10 @@ template <typename Topology1Type, typename Topology2Type>
 std::string error_are_topologies(
     const Topology1Type& topo1, const Topology2Type& topo2,
     KokkosFFT::Distributed::Impl::TopologyType specified, bool expected) {
-  std::string msg = topology_to_string("Input topologies: ", topo1);
-  msg += " and " + topology_to_string("", topo2);
+  std::string msg =
+      KokkosFFT::Impl::container_to_string("Input topologies: ", topo1);
+  msg += " and " +
+         KokkosFFT::Impl::container_to_string("Input topologies: ", topo2);
   if (expected) {
     msg += ", should be identified as " + topology_type_to_string(specified) +
            ", but it is not.";
@@ -159,9 +149,9 @@ std::string error_in_out_axes(
     const std::tuple<std::size_t, std::size_t>& actual,
     const std::tuple<std::size_t, std::size_t>& expected) {
   std::string msg = "Input topologies: ";
-  msg += topology_to_string("topology1", topo1);
+  msg += KokkosFFT::Impl::container_to_string("topology1: ", topo1);
   msg += " and ";
-  msg += topology_to_string("topology2", topo2);
+  msg += KokkosFFT::Impl::container_to_string("topology2: ", topo2);
   msg += ", should have in/out axes: (";
   msg += std::to_string(std::get<0>(expected));
   msg += ", ";
@@ -187,9 +177,9 @@ std::string error_mid_topology(const TopologyType& topo1,
                                const TopologyType& expected) {
   auto actual = KokkosFFT::Distributed::Impl::propose_mid_array(topo1, topo2);
   std::string msg = "Input topologies: ";
-  msg += topology_to_string("topology1", topo1);
+  msg += KokkosFFT::Impl::container_to_string("topology1: ", topo1);
   msg += " and ";
-  msg += topology_to_string("topology2", topo2);
+  msg += KokkosFFT::Impl::container_to_string("topology2: ", topo2);
   msg += ", should have a mid topology: (";
   msg += std::to_string(expected.at(0));
   for (std::size_t i = 1; i < expected.size(); ++i) {
@@ -223,37 +213,24 @@ std::string error_decompose_axes(
   auto actual = KokkosFFT::Distributed::Impl::decompose_axes(topologies, axes);
   std::string msg = "Input topologies: ";
   for (std::size_t i = 0; i < topologies.size(); ++i) {
-    msg += topology_to_string("topology", topologies.at(i));
+    msg += KokkosFFT::Impl::container_to_string(
+        "topology" + std::to_string(i) + ": ", topologies.at(i));
     if (i != topologies.size() - 1) {
       msg += " and ";
     }
   }
   msg += ", with FFT axes: ";
-  msg += topology_to_string("axes", axes);
+  msg += KokkosFFT::Impl::container_to_string("axes: ", axes);
   msg += ", should have decomposed axes: (";
   for (std::size_t i = 0; i < expected.size(); ++i) {
-    msg += "(";
-    for (std::size_t j = 0; j < expected.at(i).size(); ++j) {
-      msg += std::to_string(expected.at(i).at(j));
-      if (j != expected.at(i).size() - 1) {
-        msg += ", ";
-      }
-    }
-    msg += ")";
+    msg += KokkosFFT::Impl::container_to_string("", expected.at(i));
     if (i != expected.size() - 1) {
       msg += " and ";
     }
   }
   msg += "), but got: (";
   for (std::size_t i = 0; i < actual.size(); ++i) {
-    msg += "(";
-    for (std::size_t j = 0; j < actual.at(i).size(); ++j) {
-      msg += std::to_string(actual.at(i).at(j));
-      if (j != actual.at(i).size() - 1) {
-        msg += ", ";
-      }
-    }
-    msg += ")";
+    msg += KokkosFFT::Impl::container_to_string("", actual.at(i));
     if (i != actual.size() - 1) {
       msg += " and ";
     }
@@ -279,9 +256,9 @@ std::string error_trans_axis(const std::array<iType, DIM>& in_topology,
   auto actual = KokkosFFT::Distributed::Impl::compute_trans_axis(
       in_topology, out_topology, first_non_one);
   std::string msg = "Input topologies: ";
-  msg += topology_to_string("in_topology", in_topology);
+  msg += KokkosFFT::Impl::container_to_string("in_topology: ", in_topology);
   msg += " and ";
-  msg += topology_to_string("out_topology", out_topology);
+  msg += KokkosFFT::Impl::container_to_string("out_topology: ", out_topology);
   msg += ", should have trans_axis: ";
   msg += std::to_string(expected);
   msg += ", but got: ";

--- a/distributed/unit_test/Test_Topologies.cpp
+++ b/distributed/unit_test/Test_Topologies.cpp
@@ -71,8 +71,7 @@ std::string error_get_common_topology_type(
     KokkosFFT::Distributed::Impl::TopologyType ref) {
   std::string msg =
       KokkosFFT::Impl::container_to_string("Input topologies: ", topo1);
-  msg += " and " +
-         KokkosFFT::Impl::container_to_string("Input topologies: ", topo2);
+  msg += " and " + KokkosFFT::Impl::container_to_string("", topo2);
   msg +=
       ", should be: " + topology_type_to_string(ref) + ", but got: " +
       topology_type_to_string(

--- a/distributed/unit_test/Test_Topologies.cpp
+++ b/distributed/unit_test/Test_Topologies.cpp
@@ -121,8 +121,7 @@ std::string error_are_topologies(
     KokkosFFT::Distributed::Impl::TopologyType specified, bool expected) {
   std::string msg =
       KokkosFFT::Impl::container_to_string("Input topologies: ", topo1);
-  msg += " and " +
-         KokkosFFT::Impl::container_to_string("Input topologies: ", topo2);
+  msg += " and " + KokkosFFT::Impl::container_to_string("", topo2);
   if (expected) {
     msg += ", should be identified as " + topology_type_to_string(specified) +
            ", but it is not.";


### PR DESCRIPTION
- [x] Make `topology_to_string` to `container_to_string` under `common`
- [x] Add an unit-test
- [x] Use `container_to_string` instead of `topology_to_string`