### PR TITLE
fix: Kokkos_DIR

### DIFF
--- a/.github/workflows/nightly-ruche.yaml
+++ b/.github/workflows/nightly-ruche.yaml
@@ -75,7 +75,7 @@ jobs:
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
-              -DKokkos_DIR=kokkos_install/lib/cmake/Kokkos/ \
+              -DKokkos_DIR=kokkos_install/lib64/cmake/Kokkos/ \
               ${{ matrix.backend.kokkosFFT_configure }}
 
       - name: Start, update and configure


### PR DESCRIPTION
As found in the [log](https://github.com/kokkos/kokkos-fft/actions/runs/26378381513/job/77642804247), kokkos is installed under `kokkos_install/lib64`
