### PR TITLE
[Docs] Add hfft/ihfft example

### DIFF
--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -9,4 +9,19 @@ KokkosFFT::hfft
 
 .. note::
 
+   The input can be either a real-valued or complex-valued view, and the output must be a real-valued view. The output length along the transform axis is ``(n / 2 + 1) * 2``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
    For the real input, we internally convert it to complex and perform ``hfft`` on it.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/hermitian/docs_hfft.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ 15 -4 0 -1 0 -4

--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::hfft
 
 .. note::
 
-   The input can be either a real-valued or complex-valued view, and the output must be a real-valued view. The output length along the transform axis is ``(n / 2 + 1) * 2``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+   The input can be either a real-valued or complex-valued view, and the output must be a real-valued view. The output length along the transform axis is ``2 * (n - 1)``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
    For the real input, we internally convert it to complex and perform ``hfft`` on it.
 
 Examples

--- a/docs/api/hermitian/hfft.rst
+++ b/docs/api/hermitian/hfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::hfft
 
 .. note::
 
-   The input can be either a real-valued or complex-valued view, and the output must be a real-valued view. The output length along the transform axis is ``2 * (n - 1)``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+   The input can be either a real-valued or complex-valued view, and the output must be a real-valued view. The input length along the transform axis is ``n/2 + 1``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
    For the real input, we internally convert it to complex and perform ``hfft`` on it.
 
 Examples

--- a/docs/api/hermitian/ihfft.rst
+++ b/docs/api/hermitian/ihfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::ihfft
 
 .. note::
 
-   The input must be a real-valued view, and the output must be a complex-valued view. The input length along the transform axis is ``(n / 2 + 1) * 2``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+   The input must be a real-valued view, and the output must be a complex-valued view. The input length along the transform axis is ``2 * (n - 1)``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
 
 Examples
 ========

--- a/docs/api/hermitian/ihfft.rst
+++ b/docs/api/hermitian/ihfft.rst
@@ -6,3 +6,21 @@ KokkosFFT::ihfft
 ----------------
 
 .. doxygenfunction:: KokkosFFT::ihfft(const ExecutionSpace& exec_space, const InViewType& in, const OutViewType& out, KokkosFFT::Normalization, int axis, std::optional<std::size_t> n)
+
+.. note::
+
+   The input must be a real-valued view, and the output must be a complex-valued view. The input length along the transform axis is ``(n / 2 + 1) * 2``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/hermitian/docs_ihfft.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ (1,0) (2,0) (3,0) (4,0)

--- a/docs/api/hermitian/ihfft.rst
+++ b/docs/api/hermitian/ihfft.rst
@@ -9,7 +9,7 @@ KokkosFFT::ihfft
 
 .. note::
 
-   The input must be a real-valued view, and the output must be a complex-valued view. The input length along the transform axis is ``2 * (n - 1)``, where ``n`` is the output length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
+   The input must be a real-valued view, and the output must be a complex-valued view. The output length along the transform axis is ``n/2 + 1``, where ``n`` is the input length along that axis. If this condition is not met, the `std::runtime_error` exception will be thrown.
 
 Examples
 ========

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -39,3 +39,10 @@ target_link_libraries(docs_rfftn PUBLIC KokkosFFT::fft)
 
 add_executable(docs_irfftn real/docs_irfftn.cpp)
 target_link_libraries(docs_irfftn PUBLIC KokkosFFT::fft)
+
+# Hermitian FFT examples
+add_executable(docs_hfft hermitian/docs_hfft.cpp)
+target_link_libraries(docs_hfft PUBLIC KokkosFFT::fft)
+
+add_executable(docs_ihfft hermitian/docs_ihfft.cpp)
+target_link_libraries(docs_ihfft PUBLIC KokkosFFT::fft)

--- a/examples/docs/hermitian/docs_hfft.cpp
+++ b/examples/docs/hermitian/docs_hfft.cpp
@@ -15,11 +15,11 @@ int main(int argc, char* argv[]) {
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using View1D         = Kokkos::View<double*, ExecutionSpace>;
 
-  const int n0 = 4;
+  const int n0 = 6;
 
-  View1D x("x", n0), x_hat("x_hat", 2 * (n0 - 1));
+  View1D x("x", n0 / 2 + 1), x_hat("x_hat", n0);
   auto h_x = Kokkos::create_mirror_view(x);
-  for (int i = 0; i < n0; ++i) {
+  for (int i = 0; i < x.extent_int(0); ++i) {
     h_x(i) = i + 1;
   }
   Kokkos::deep_copy(x, h_x);

--- a/examples/docs/hermitian/docs_hfft.cpp
+++ b/examples/docs/hermitian/docs_hfft.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
 
   const int n0 = 4;
 
-  View1D x("x", n0), x_hat("x_hat", (n0 / 2 + 1) * 2);
+  View1D x("x", n0), x_hat("x_hat", 2 * (n0 - 1));
   auto h_x = Kokkos::create_mirror_view(x);
   for (int i = 0; i < n0; ++i) {
     h_x(i) = i + 1;

--- a/examples/docs/hermitian/docs_hfft.cpp
+++ b/examples/docs/hermitian/docs_hfft.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of hfft usage in documentation
+/// x = [1, 2, 3, 4]
+/// x_hat = [15.0, -4.0, 0.0, -1.0, 0.0, -4.0]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View1D         = Kokkos::View<double*, ExecutionSpace>;
+
+  const int n0 = 4;
+
+  View1D x("x", n0), x_hat("x_hat", (n0 / 2 + 1) * 2);
+  auto h_x = Kokkos::create_mirror_view(x);
+  for (int i = 0; i < n0; ++i) {
+    h_x(i) = i + 1;
+  }
+  Kokkos::deep_copy(x, h_x);
+
+  ExecutionSpace exec;
+  KokkosFFT::hfft(exec, x, x_hat);
+
+  auto h_x_hat =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_hat);
+  for (int i = 0; i < x_hat.extent_int(0); ++i) {
+    std::cout << " " << h_x_hat(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/hermitian/docs_ihfft.cpp
+++ b/examples/docs/hermitian/docs_ihfft.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of ihfft usage in documentation
+/// x_hat = [15.0, -4.0, 0.0, -1.0, 0.0, -4.0]
+/// x = [1.-0.j, 2.-0.j, 3.-0.j, 4.-0.j]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using View1D         = Kokkos::View<double*, ExecutionSpace>;
+  using ComplexView1D  = Kokkos::View<Kokkos::complex<double>*, ExecutionSpace>;
+
+  const int n0 = 4;
+
+  View1D x_hat("x_hat", (n0 / 2 + 1) * 2);
+  ComplexView1D x("x", n0);
+  auto h_x_hat = Kokkos::create_mirror_view(x_hat);
+  h_x_hat(0)   = 15.0;
+  h_x_hat(1)   = -4.0;
+  h_x_hat(2)   = 0.0;
+  h_x_hat(3)   = -1.0;
+  h_x_hat(4)   = 0.0;
+  h_x_hat(5)   = -4.0;
+  Kokkos::deep_copy(x_hat, h_x_hat);
+
+  ExecutionSpace exec;
+  KokkosFFT::ihfft(exec, x_hat, x);
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  for (int i = 0; i < x.extent_int(0); ++i) {
+    std::cout << " " << h_x(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/hermitian/docs_ihfft.cpp
+++ b/examples/docs/hermitian/docs_ihfft.cpp
@@ -16,10 +16,10 @@ int main(int argc, char* argv[]) {
   using View1D         = Kokkos::View<double*, ExecutionSpace>;
   using ComplexView1D  = Kokkos::View<Kokkos::complex<double>*, ExecutionSpace>;
 
-  const int n0 = 4;
+  const int n0 = 6;
 
-  View1D x_hat("x_hat", 2 * (n0 - 1));
-  ComplexView1D x("x", n0);
+  View1D x_hat("x_hat", n0);
+  ComplexView1D x("x", n0 / 2 + 1);
   auto h_x_hat = Kokkos::create_mirror_view(x_hat);
   h_x_hat(0)   = 15.0;
   h_x_hat(1)   = -4.0;

--- a/examples/docs/hermitian/docs_ihfft.cpp
+++ b/examples/docs/hermitian/docs_ihfft.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[]) {
 
   const int n0 = 4;
 
-  View1D x_hat("x_hat", (n0 / 2 + 1) * 2);
+  View1D x_hat("x_hat", 2 * (n0 - 1));
   ComplexView1D x("x", n0);
   auto h_x_hat = Kokkos::create_mirror_view(x_hat);
   h_x_hat(0)   = 15.0;


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_hfft.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_ihfft.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.
