### PR TITLE
[Docs] Add fftfreq/rfftfreq examples

### DIFF
--- a/docs/api/helper/fftfreq.rst
+++ b/docs/api/helper/fftfreq.rst
@@ -6,3 +6,17 @@ KokkosFFT::fftfreq
 ------------------
 
 .. doxygenfunction:: KokkosFFT::fftfreq
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/helper/docs_fftfreq.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ 0 0.1 0.2 0.3 0.4 -0.5 -0.4 -0.3 -0.2 -0.1

--- a/docs/api/helper/rfftfreq.rst
+++ b/docs/api/helper/rfftfreq.rst
@@ -6,3 +6,17 @@ KokkosFFT::rfftfreq
 -------------------
 
 .. doxygenfunction:: KokkosFFT::rfftfreq
+
+Examples
+========
+
+.. literalinclude:: ../../../examples/docs/helper/docs_rfftfreq.cpp
+  :language: c++
+  :linenos:
+  :lines: 5-
+
+Expected output:
+
+.. code::
+
+ 0 0.111111 0.222222 0.333333 0.444444

--- a/examples/docs/CMakeLists.txt
+++ b/examples/docs/CMakeLists.txt
@@ -46,3 +46,10 @@ target_link_libraries(docs_hfft PUBLIC KokkosFFT::fft)
 
 add_executable(docs_ihfft hermitian/docs_ihfft.cpp)
 target_link_libraries(docs_ihfft PUBLIC KokkosFFT::fft)
+
+# Helper routines
+add_executable(docs_fftfreq helper/docs_fftfreq.cpp)
+target_link_libraries(docs_fftfreq PUBLIC KokkosFFT::fft)
+
+add_executable(docs_rfftfreq helper/docs_rfftfreq.cpp)
+target_link_libraries(docs_rfftfreq PUBLIC KokkosFFT::fft)

--- a/examples/docs/helper/docs_fftfreq.cpp
+++ b/examples/docs/helper/docs_fftfreq.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of fftfreq usage in documentation
+/// For n = 10, the output is
+/// freq = [0 0.1 0.2 0.3 0.4 -0.5 -0.4 -0.3 -0.2 -0.1]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+
+  const int n0 = 10;
+  ExecutionSpace exec;
+  auto freq = KokkosFFT::fftfreq<ExecutionSpace, double>(exec, n0);
+
+  auto h_freq = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, freq);
+  for (int i = 0; i < freq.extent_int(0); ++i) {
+    std::cout << " " << h_freq(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/examples/docs/helper/docs_rfftfreq.cpp
+++ b/examples/docs/helper/docs_rfftfreq.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: (C) The Kokkos-FFT development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Complex.hpp>
+#include <KokkosFFT.hpp>
+
+/// \brief Example of rfftfreq usage in documentation
+/// For n = 9, the output is
+/// freq = [0 0.111111 0.222222 0.333333 0.444444]
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+
+  const int n0 = 9;
+  ExecutionSpace exec;
+  auto freq = KokkosFFT::rfftfreq<ExecutionSpace, double>(exec, n0);
+
+  auto h_freq = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, freq);
+  for (int i = 0; i < freq.extent_int(0); ++i) {
+    std::cout << " " << h_freq(i);
+  }
+  std::cout << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
This PR aims at adding a minimum working example in API reference. 

- [x] Add docs_fftfreq.cpp which includes a minimum working example that is compiled in CI.
- [x] Add docs_rfftfreq.cpp which includes a minimum working example that is compiled in CI.
- [x] Embed this in API reference with literal includes.
