### PR TITLE
fix: warning from vector initialization

### DIFF
--- a/common/src/KokkosFFT_Extents.hpp
+++ b/common/src/KokkosFFT_Extents.hpp
@@ -356,9 +356,9 @@ auto get_extents(const InViewType& in, const OutViewType& out,
 
   const std::size_t fft_offset = rank - DIM;
   auto slice_tail = [fft_offset, DIM](const std::vector<std::size_t>& extents) {
-    std::vector<std::size_t> slice(DIM);
+    std::vector<std::size_t> slice;
     for (std::size_t i = 0; i < DIM; ++i) {
-      slice.at(i) = extents.at(fft_offset + i);
+      slice.push_back(extents.at(fft_offset + i));
     }
     return slice;
   };


### PR DESCRIPTION
This PR suppresses warnings from vector initialization.

```
    inlined from ‘auto KokkosFFT::Impl::get_extents(const InViewType&, const OutViewType&, const std::vector<int>&, const std::vector<int>&, const std::vector<long unsigned int>&, bool) [with InViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda>; OutViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda>]’ at /home/i18048/jh220036a/tests/fft/kokkos-fft/common/src/KokkosFFT_Extents.hpp:376:8:
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/new_allocator.h:137:49: error: argument 1 range [9223372036854775824, 18446744073709551608] exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
  137 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/new: In function ‘auto KokkosFFT::Impl::get_extents(const InViewType&, const OutViewType&, const std::vector<int>&, const std::vector<int>&, const std::vector<long unsigned int>&, bool) [with InViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda>; OutViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda>]’:
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/new:126:25: note: in a call to allocation function ‘void* operator new(std::size_t)’ declared here
  126 | _GLIBCXX_NODISCARD void* operator new(std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                         ^~~~~~~~
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = long unsigned int]’,
    inlined from ‘constexpr _Tp* std::allocator< <template-parameter-1-1> >::allocate(std::size_t) [with _Tp = long unsigned int]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/allocator.h:188:41,
    inlined from ‘static constexpr _Tp* std::allocator_traits<std::allocator<_Up> >::allocate(allocator_type&, size_type) [with _Tp = long unsigned int]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/alloc_traits.h:464:22,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/stl_vector.h:378:36,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/stl_vector.h:395:41,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/stl_vector.h:332:20,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’ at /work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/stl_vector.h:565:67,
    inlined from ‘KokkosFFT::Impl::get_extents<Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>, Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda> >(const Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>&, const Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>&, const std::vector<int>&, const std::vector<int>&, const std::vector<long unsigned int>&, bool)::<lambda(const std::vector<long unsigned int>&)>’ at /home/i18048/jh220036a/tests/fft/kokkos-fft/common/src/KokkosFFT_Extents.hpp:359:23,
    inlined from ‘auto KokkosFFT::Impl::get_extents(const InViewType&, const OutViewType&, const std::vector<int>&, const std::vector<int>&, const std::vector<long unsigned int>&, bool) [with InViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>; OutViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>]’ at /home/i18048/jh220036a/tests/fft/kokkos-fft/common/src/KokkosFFT_Extents.hpp:376:8:
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/bits/new_allocator.h:137:49: error: argument 1 range [9223372036854775824, 18446744073709551608] exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
  137 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/new: In function ‘auto KokkosFFT::Impl::get_extents(const InViewType&, const OutViewType&, const std::vector<int>&, const std::vector<int>&, const std::vector<long unsigned int>&, bool) [with InViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>; OutViewType = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutRight, Kokkos::Cuda>]’:
/work/opt/local/x86_64/cores/gcc/12.2.0/include/c++/12/new:126:25: note: in a call to allocation function ‘void* operator new(std::size_t)’ declared here
  126 | _GLIBCXX_NODISCARD void* operator new(std::size_t) _GLIBCXX_THROW (std::bad_alloc)
```