### PR TITLE
Use symboliclink to README and avoid relative include

### DIFF
--- a/python_scripts/README.md
+++ b/python_scripts/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/python_scripts/pyproject.toml
+++ b/python_scripts/pyproject.toml
@@ -9,8 +9,8 @@ build-backend = "hatchling.build"
 [project]
 name = "kokkos-fft-python"
 version = "1.0"
-readme = "../README.md"
-requires-python = ">=3.8"
+readme = "README.md"
+requires-python = ">=3.10"
 dependencies = [
   "pytest>=7.0",
   "numpy",


### PR DESCRIPTION
Due to the recent update, relative include of readme no longer works.
https://github.com/pypa/hatch/issues/2353