### PR TITLE
Use testing tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,6 @@ cd build && ctest --output-on-failure
 | `KokkosFFT_ENABLE_ROCFFT` | OFF | Enable rocFFT (AMD GPU, alternative to hipFFT) |
 | `KokkosFFT_ENABLE_ONEMKL` | auto | Enable oneMKL (Intel GPU) |
 | `KokkosFFT_ENABLE_DISTRIBUTED` | OFF | Enable distributed (MPI) FFT support |
-| `KokkosFFT_ENABLE_TESTING_TOOLS` | OFF | Enable testing utility library |
 
 ### Test Executables
 

--- a/.github/workflows/build_nightly.yaml
+++ b/.github/workflows/build_nightly.yaml
@@ -45,7 +45,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
             build_procs: 4
           - name: serial
             image: gcc
@@ -65,7 +65,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
             build_procs: 2
           - name: hip
             image: rocm
@@ -85,7 +85,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
             build_procs: 4
           - name: sycl
             image: intel

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -80,7 +80,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_THREADS=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
               benchmark: ON
             cmake_build_type: Release
           - name: serial
@@ -102,7 +102,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_SERIAL=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
               benchmark: ON
             cmake_build_type: Release
           - name: hip
@@ -124,7 +124,7 @@ jobs:
             cmake_flags:
               cxx_standard: 20
               kokkos: -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON
-              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON -DKokkosFFT_ENABLE_TESTING_TOOLS=ON
+              kokkos_fft: -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DKokkosFFT_ENABLE_ROCFFT=ON
               benchmark: ON
             cmake_build_type: Release
           - name: sycl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ option(KokkosFFT_ENABLE_EXAMPLES "Build KokkosFFT examples" OFF)
 option(KokkosFFT_ENABLE_TESTS "Build KokkosFFT tests" OFF)
 option(KokkosFFT_ENABLE_BENCHMARK "Build benchmarks for KokkosFFT" OFF)
 option(KokkosFFT_ENABLE_DOCS "Build KokkosFFT documentaion/website" OFF)
-option(KokkosFFT_ENABLE_TESTING_TOOLS "Enable unit-testing tools" OFF)
 option(KokkosFFT_ENABLE_DISTRIBUTED "Enable KokkosFFT distributed support" OFF)
 option(KokkosFFT_ENABLE_TESTS_DISTRIBUTED_ONLY "Enable KokkosFFT distributed tests only" OFF)
 
@@ -121,9 +120,7 @@ if(KokkosFFT_ENABLE_TESTS)
   if(NOT GTest_FOUND)
     add_subdirectory(tpls/googletest)
   endif()
-  if(KokkosFFT_ENABLE_TESTING_TOOLS)
-    add_subdirectory(testing)
-  endif()
+  add_subdirectory(testing)
 endif()
 
 # Build documentation with Doxygen and Sphinx

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -19,10 +19,10 @@ add_executable(
   Test_Helpers.cpp
 )
 
-target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common GTest::gtest)
+target_link_libraries(unit-tests-kokkos-fft-common PUBLIC common KokkosFFT::testing GTest::gtest GTest::gmock)
 
 add_executable(unit-tests-kokkos-transpose Test_Main.cpp Test_Transpose.cpp)
-target_link_libraries(unit-tests-kokkos-transpose PUBLIC KokkosFFT::fft GTest::gtest)
+target_link_libraries(unit-tests-kokkos-transpose PUBLIC common KokkosFFT::testing GTest::gtest GTest::gmock)
 
 # Enable GoogleTest
 include(GoogleTest)

--- a/common/unit_test/Test_Normalization.cpp
+++ b/common/unit_test/Test_Normalization.cpp
@@ -3,13 +3,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 
 #include <cmath>
+
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include <Kokkos_Random.hpp>
 
 #include "KokkosFFT_Convert_Types.hpp"
 #include "KokkosFFT_Layout.hpp"
 #include "KokkosFFT_Normalization.hpp"
 #include "KokkosFFT_Traits.hpp"
+#include "KokkosFFT_Testing_Allclose.hpp"
 #include "Test_Utils.hpp"
 
 namespace {
@@ -209,29 +213,29 @@ void test_normalization(KokkosFFT::Normalization norm) {
   // Backward FFT with forward Normalization -> Do nothing
   KokkosFFT::Impl::normalize<T>(exec, x, KokkosFFT::Direction::backward, norm,
                                 extents);
-  EXPECT_TRUE(allclose(exec, x, ref_b, 1.e-5, 1.e-12));
   exec.fence();
+  EXPECT_THAT(x, KokkosFFT::Testing::allclose(ref_b, 1.e-5, 1.e-12));
   Kokkos::deep_copy(x, ref_x);
 
   // Forward FFT with forward Normalization -> 1/N normalization
   KokkosFFT::Impl::normalize<T>(exec, x, KokkosFFT::Direction::forward, norm,
                                 extents);
-  EXPECT_TRUE(allclose(exec, x, ref_f, 1.e-5, 1.e-12));
   exec.fence();
+  EXPECT_THAT(x, KokkosFFT::Testing::allclose(ref_f, 1.e-5, 1.e-12));
   Kokkos::deep_copy(x, ref_x);
 
   auto extents_vec = KokkosFFT::Impl::to_vector(extents);
   KokkosFFT::Impl::normalize<T>(exec, x, KokkosFFT::Direction::backward, norm,
                                 extents_vec);
-  EXPECT_TRUE(allclose(exec, x, ref_b, 1.e-5, 1.e-12));
   exec.fence();
+  EXPECT_THAT(x, KokkosFFT::Testing::allclose(ref_b, 1.e-5, 1.e-12));
   Kokkos::deep_copy(x, ref_x);
 
   // Forward FFT with forward Normalization -> 1/N normalization
   KokkosFFT::Impl::normalize<T>(exec, x, KokkosFFT::Direction::forward, norm,
                                 extents_vec);
-  EXPECT_TRUE(allclose(exec, x, ref_f, 1.e-5, 1.e-12));
   exec.fence();
+  EXPECT_THAT(x, KokkosFFT::Testing::allclose(ref_f, 1.e-5, 1.e-12));
 }
 
 void test_swap_direction(KokkosFFT::Normalization norm) {


### PR DESCRIPTION
Improves #242 

- [x] Make testing tools always available
- [x] Apply testing tools in` Test_Normalization.cpp`
- [x] Remove `KokkosFFT_ENABLE_TESTING_TOOLS` option from CMake