### PR TITLE
Install gtest and gmock

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ AMD-MI300A:
   tags: [uo-gpu, odyssey, amd-mi300]
   image: rocm/dev-ubuntu-24.04:6.2.4-complete
   script:
-    - apt-get update && apt-get install -y libgtest-dev cmake git
+    - apt-get update && apt-get install -y libgtest-dev libgmock-dev cmake git
     - export HSA_XNACK=1
     - git clone https://github.com/kokkos/kokkos.git
     - cmake -S kokkos


### PR DESCRIPTION
Install gmock explicitly though apt get

Alternative fix

1. Use bundled GTest

```
  # Equivalent of "actions/checkout with submodules: recursive" in the GitHub
  # workflows: tpls/googletest is needed as the fallback of find_package(GTest)
  variables:
    GIT_SUBMODULE_STRATEGY: recursive
    GIT_SUBMODULE_DEPTH: 1
    GIT_SUBMODULE_FORCE_HTTPS: "true"
``` 

2. Install GTest

```
    - apt-get update && apt-get install -y cmake git          # libgtest-dev removed
    - export HSA_XNACK=1
    # GoogleTest (gtest + gmock) from source: the Ubuntu libgtest-dev package
    # ships gtest without gmock, so find_package(GTest CONFIG) cannot satisfy
    # the GTest::gmock target required by the top level CMakeLists.txt
    - git clone --depth 1 --branch v1.17.0 https://github.com/google/googletest.git
    - cmake -S googletest
            -B googletest_build
            -D CMAKE_BUILD_TYPE=Release
            -D CMAKE_INSTALL_PREFIX=googletest_install
            -D CMAKE_INSTALL_LIBDIR=lib
            -D CMAKE_CXX_COMPILER=hipcc
            -D CMAKE_CXX_STANDARD=17
            -D BUILD_GMOCK=ON
            -D INSTALL_GTEST=ON
    - cmake --build googletest_build --parallel
    - cmake --install googletest_build
```